### PR TITLE
Semantic version checks

### DIFF
--- a/modelon/impact/client/__init__.py
+++ b/modelon/impact/client/__init__.py
@@ -1,9 +1,23 @@
 import logging
 import modelon.impact.client.entities
 import modelon.impact.client.sal.service
-
+from semantic_version import SimpleSpec, Version
+import modelon.impact.client.exceptions as exceptions
+import modelon.impact.client.sal.exceptions
 
 logger = logging.getLogger(__name__)
+
+_SUPPORTED_VERSION_RANGE = '>=1.1.0,<2.0.0'
+
+
+def _sem_ver_check(version, supported_version_range):
+    supported_versions = SimpleSpec(supported_version_range)
+    if Version(version) not in supported_versions:
+        raise exceptions.UnsupportedSemanticVersionError(
+            f"Version '{version}' of the HTTP REST API is not supported, must be in the"
+            f" range '{supported_version_range}'! Updgrade or downgrade this package to"
+            f" a version that supports version '{version}' of the HTTP REST API."
+        )
 
 
 class Client:
@@ -14,7 +28,13 @@ class Client:
 
         uri = modelon.impact.client.sal.service.URI(url)
         self._sal = modelon.impact.client.sal.service.Service(uri, context)
-        # TODO: check that the API is of a version that client can use!
+        try:
+            version = self._sal.api_get_metadata()["version"]
+        except modelon.impact.client.sal.exceptions.CommunicationError as exce:
+            raise modelon.impact.client.sal.exceptions.NoResponseFetchVersionError(
+                f'No response from url {url}, please verify that the URL is correct'
+            ) from exce
+        _sem_ver_check(version, _SUPPORTED_VERSION_RANGE)
 
     def get_workspace(self, workspace_id):
         # TODO: should have an endpoint for getting a single workspace

--- a/modelon/impact/client/exceptions.py
+++ b/modelon/impact/client/exceptions.py
@@ -1,0 +1,6 @@
+class Error(Exception):
+    pass
+
+
+class UnsupportedSemanticVersionError(Error):
+    pass

--- a/modelon/impact/client/sal/exceptions.py
+++ b/modelon/impact/client/sal/exceptions.py
@@ -24,3 +24,7 @@ class ErrorBodyIsNotJSONError(ServiceAccessError):
 
 class ErrorJSONInvalidFormatError(ServiceAccessError):
     pass
+
+
+class NoResponseFetchVersionError(ServiceAccessError):
+    pass

--- a/poetry.lock
+++ b/poetry.lock
@@ -329,6 +329,14 @@ fixture = ["fixtures"]
 test = ["fixtures", "mock", "purl", "pytest", "sphinx", "testrepository (>=0.0.18)", "testtools"]
 
 [[package]]
+category = "main"
+description = "A library implementing the 'SemVer' scheme."
+name = "semantic-version"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.8.5"
+
+[[package]]
 category = "dev"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
@@ -409,7 +417,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "e6faf3d0b76d59606cd970eff55ac9a0417b60fe58b6e46f9207b7e9eb46047d"
+content-hash = "7e0159cb30211224421bcf0a24a35c95a1355729ed3b087dfe2679026cfcc7fc"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -556,6 +564,10 @@ requests = [
 requests-mock = [
     {file = "requests-mock-1.8.0.tar.gz", hash = "sha256:e68f46844e4cee9d447150343c9ae875f99fa8037c6dcf5f15bf1fe9ab43d226"},
     {file = "requests_mock-1.8.0-py2.py3-none-any.whl", hash = "sha256:11215c6f4df72702aa357f205cf1e537cffd7392b3e787b58239bde5fb3db53b"},
+]
+semantic-version = [
+    {file = "semantic_version-2.8.5-py2.py3-none-any.whl", hash = "sha256:45e4b32ee9d6d70ba5f440ec8cc5221074c7f4b0e8918bdab748cc37912440a9"},
+    {file = "semantic_version-2.8.5.tar.gz", hash = "sha256:d2cb2de0558762934679b9a104e82eca7af448c9f4974d1f3eeccff651df8a54"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.6"
 requests = "^2.23"
+semantic_version = "^2.8.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -38,6 +38,17 @@ def single_workspace(mock_server_base):
 
 
 @pytest.fixture
+def api_get_metadata(mock_server_base):
+    json = {"version": "1.1.0"}
+    json_header = {'content-type': 'application/json'}
+    mock_server_base.adapter.register_uri(
+        'GET', f'{mock_server_base.url}/api/', json=json, headers=json_header,
+    )
+
+    return mock_server_base
+
+
+@pytest.fixture
 def create_workspace(mock_server_base):
     json = {'id': 'newWorkspace'}
     json_header = {'content-type': 'application/json'}
@@ -89,6 +100,14 @@ def get_with_error(mock_server_base):
 
 
 class TestService:
+    def test_api_get_meta_data(self, api_get_metadata):
+        uri = modelon.impact.client.sal.service.URI(api_get_metadata.url)
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri, context=api_get_metadata.context
+        )
+        data = service.api_get_metadata()
+        assert data == {'version': '1.1.0'}
+
     def test_get_workspaces(self, single_workspace):
         uri = modelon.impact.client.sal.service.URI(single_workspace.url)
         service = modelon.impact.client.sal.service.Service(


### PR DESCRIPTION
This PR resolves [WAMS-5072](https://modelonproducts.atlassian.net/browse/WAMS-5072).

**How to Test**
1. Try to change the api version in swagger.json to anything beyond or below the range 1.0.0 to 2.0.0.

**Model Implementation specifics**
1. I have added a dummy range of supported versions as of now, however this needs to be changes once we make a non-backward compatible change in our APIs.
