### PR TITLE
chore: adding an entity for custom functions

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -7,3 +7,67 @@ class Workspace:
 
     def __eq__(self, obj):
         return isinstance(obj, Workspace) and obj._workspace_id == self._workspace_id
+
+
+class _Parameter:
+    _JSON_2_PY_TYPE = {
+        "Number": float,
+        "String": str,
+        "Boolean": bool,
+        "Enumeration": str,
+    }
+
+    def __init__(self, name, value, value_type, valid_values):
+        self.name = name
+        self._value = value
+        self._value_type = value_type
+        self._valid_values = valid_values
+
+    @property
+    def value(self):
+        return self._value
+
+    @value.setter
+    def value(self, value):
+        if not isinstance(value, self._JSON_2_PY_TYPE[self._value_type]):
+            raise ValueError(
+                f"Cannot set {self.name} to {value}, its type is {self._value_type}"
+            )
+
+        if self._value_type == "Enumeration" and value not in self._valid_values:
+            raise ValueError(
+                f"Cannot set enumeration '{self.name}' to '{value}', "
+                f"must be one of {self._valid_values}"
+            )
+
+        self._value = value
+
+
+class CustomFunction:
+    def __init__(self, name, parameter_data):
+        self.name = name
+        self._parameter_data = parameter_data
+        self._param_by_name = {
+            p["name"]: _Parameter(
+                p["name"], p["defaultValue"], p["type"], p.get("values", []),
+            )
+            for p in parameter_data
+        }
+
+    def with_parameters(self, **modified):
+        new = CustomFunction(self.name, self._parameter_data)
+        for name, value in modified.items():
+            if name not in new._param_by_name:
+                raise ValueError(
+                    f"The custom function '{self.name}' "
+                    f"does not have a parameter '{name}'"
+                )
+
+            parameter = new._param_by_name[name]
+            parameter.value = value
+
+        return new
+
+    @property
+    def parameter_values(self):
+        return {p.name: p.value for p in self._param_by_name.values()}

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -1,0 +1,55 @@
+import pytest
+
+from modelon.impact.client.entities import CustomFunction
+
+
+@pytest.fixture
+def custom_function():
+    return CustomFunction(
+        'test',
+        [
+            {'name': 'p1', 'defaultValue': 1.0, 'type': 'Number'},
+            {'name': 'p2', 'defaultValue': True, 'type': 'Boolean'},
+            {
+                'name': 'p3',
+                'defaultValue': 'hej',
+                'type': 'Enumeration',
+                'values': ['hej', 'då'],
+            },
+            {'name': 'p4', 'defaultValue': 'a string', 'type': 'String'},
+        ],
+    )
+
+
+def test_custom_function_with_parameters_ok(custom_function):
+    new = custom_function.with_parameters(p1=3.4, p2=False, p3='då', p4='new string')
+    assert new.parameter_values == {
+        'p1': 3.4,
+        'p2': False,
+        'p3': 'då',
+        'p4': 'new string',
+    }
+
+
+def test_custom_function_with_parameters_no_such_parameter(custom_function):
+    pytest.raises(ValueError, custom_function.with_parameters, does_not_exist=3.4)
+
+
+def test_custom_function_with_parameters_cannot_set_number_type(custom_function):
+    pytest.raises(ValueError, custom_function.with_parameters, p1='not a number')
+
+
+def test_custom_function_with_parameters_cannot_set_boolean_type(custom_function):
+    pytest.raises(ValueError, custom_function.with_parameters, p2='not a boolean')
+
+
+def test_custom_function_with_parameters_cannot_set_enumeration_type(custom_function):
+    pytest.raises(ValueError, custom_function.with_parameters, p3=4.6)
+
+
+def test_custom_function_with_parameters_cannot_set_string_type(custom_function):
+    pytest.raises(ValueError, custom_function.with_parameters, p4=4.6)
+
+
+def test_custom_function_with_parameters_cannot_set_enumeration_value(custom_function):
+    pytest.raises(ValueError, custom_function.with_parameters, p3='not in values')


### PR DESCRIPTION
A new entity for better handling of custom functions. You create it using the `name` and `parameters` returned from the REST end-point. You can then get an updated CustomFunction with new parameter values before sending it in to the experiment:
```
experiment = SimpleExperiment(
    custom_function=workspace.get_custom_function('dynamic').with_parameters(final_time=12),
    ...
)
```