### PR TITLE
fix: changed imports to be python 3.6 compatible

### DIFF
--- a/modelon/impact/client/__init__.py
+++ b/modelon/impact/client/__init__.py
@@ -2,7 +2,7 @@ import logging
 import modelon.impact.client.entities
 import modelon.impact.client.sal.service
 from semantic_version import SimpleSpec, Version  # type: ignore
-import modelon.impact.client.exceptions as exceptions
+from modelon.impact.client import exceptions
 import modelon.impact.client.sal.exceptions
 import modelon.impact.client.credential_manager
 

--- a/modelon/impact/client/experiment_definition.py
+++ b/modelon/impact/client/experiment_definition.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from modelon.impact.client.operations import ModelExecutable
-import modelon.impact.client.entities as entities
+from modelon.impact.client import entities
 from modelon.impact.client.options import ExecutionOption
-import modelon.impact.client.exceptions as exceptions
+from modelon.impact.client import exceptions
 
 
 def _assert_valid_args(fmu, custom_function, options):

--- a/modelon/impact/client/operations.py
+++ b/modelon/impact/client/operations.py
@@ -3,7 +3,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from enum import Enum
-import modelon.impact.client.exceptions as exceptions
+from modelon.impact.client import exceptions
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -2,7 +2,7 @@ import sys
 import logging
 import requests
 import urllib.parse
-import modelon.impact.client.sal.exceptions as exceptions
+from modelon.impact.client.sal import exceptions
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This PR ensures that the library works with Python 3.6. These imports did not work in 3.6 due to https://bugs.python.org/issue30024 not being fixed until 3.7.