### PR TITLE
fix: Calling the fetch trajectories api only once

### DIFF
--- a/tests/impact/client/test_operations.py
+++ b/tests/impact/client/test_operations.py
@@ -124,6 +124,22 @@ class TestExperiment:
             "case_1", "Workspace", "Test"
         )
 
+    def test_exp_trajectories_single_run(self, experiment):
+        exp = experiment.trajectories(['inertia.I', 'time'])
+        assert exp['case_1']['inertia.I'] == [1, 2, 3, 4]
+        assert exp['case_1']['time'] == [5, 2, 9, 4]
+
+    def test_exp_trajectories_batch_execute(self, batch_experiment):
+        exp = batch_experiment.trajectories(['inertia.I'])
+        assert exp['case_1']['inertia.I'] == [1, 2, 3, 4]
+        assert exp['case_2']['inertia.I'] == [14, 4, 4, 74]
+
+    def test_exp_trajectories_no_keys(self, experiment):
+        pytest.raises(ValueError, experiment.trajectories, [])
+
+    def test_exp_trajectories_invalid_keys(self, experiment):
+        pytest.raises(ValueError, experiment.trajectories, ['s'])
+
 
 class TestCase:
     def test_case(self, experiment):


### PR DESCRIPTION
```
import uuid
from modelon.impact.client import experiment_definition, Client

import matplotlib.pyplot as plt

from tests.files.paths import BOUNCING_BALL_MO_PATH


TEST_URL = "http://localhost:8080"

# Workspace and library setup
workspace_id = uuid.uuid4().hex
client = Client(url=TEST_URL)
workspace = client.create_workspace(workspace_id)
workspace.import_library(BOUNCING_BALL_MO_PATH)

# Compilation
model = workspace.get_model("BouncingBall")
dynamic = workspace.get_custom_function('dynamic')

fmu = model.compile(dynamic.options().with_compiler_options(c_compiler="gcc")).wait(
    timeout=120
)

simulate_def = experiment_definition.SimpleExperimentDefinition(
    fmu,
    dynamic.with_parameters(start_time=0.0, final_time=2.0),
    dynamic.options().with_simulation_options(ncp=500),
).with_modifiers(h0=1, e=experiment_definition.Range(0.1, 0.5, 3))
exp = workspace.execute(simulate_def).wait(timeout=120)

res = exp.trajectories(['h', 'time'])

# # # Plot single case
# case = next(iter([case for case in exp.cases() if case.is_successful()]))
# res = case.trajectories('time', 'h')
plt.plot(res['case_1']['time'], res['case_1']['h'])
plt.show()
for case in exp.cases():
    plt.plot(res[case.id]['time'], res[case.id]['h'])

plt.show()

# # Plot single case
case = next(iter([case for case in exp.cases() if case.is_successful()]))
res = case.trajectories()
plt.plot(res['time'], res['h'])
plt.show()

# # Or plot many cases
for case in exp.cases():
    res = case.trajectories()  # Returns an object representing the
    plt.plot(res['time'], res['h'])

plt.show()
```