### PR TITLE
fix: Separating the operations and entities module

### DIFF
--- a/modelon/impact/client/__init__.py
+++ b/modelon/impact/client/__init__.py
@@ -1,10 +1,11 @@
 import logging
 import modelon.impact.client.entities
 import modelon.impact.client.sal.service
-from semantic_version import SimpleSpec, Version  # type: ignore
-from modelon.impact.client import exceptions
 import modelon.impact.client.sal.exceptions
 import modelon.impact.client.credential_manager
+
+from semantic_version import SimpleSpec, Version  # type: ignore
+from modelon.impact.client import exceptions
 
 logger = logging.getLogger(__name__)
 

--- a/modelon/impact/client/exceptions.py
+++ b/modelon/impact/client/exceptions.py
@@ -16,7 +16,3 @@ class OperationFailureError(Error):
 
 class OperationNotCompleteError(Error):
     pass
-
-
-class EmptyLogError(Error):
-    pass

--- a/modelon/impact/client/experiment_definition.py
+++ b/modelon/impact/client/experiment_definition.py
@@ -1,12 +1,11 @@
-from abc import ABC, abstractmethod
-from modelon.impact.client.operations import ModelExecutable
 from modelon.impact.client import entities
+from abc import ABC, abstractmethod
 from modelon.impact.client.options import ExecutionOption
 from modelon.impact.client import exceptions
 
 
 def _assert_valid_args(fmu, custom_function, options):
-    if not isinstance(fmu, ModelExecutable):
+    if not isinstance(fmu, entities.ModelExecutable):
         raise TypeError("Fmu must be an instance of ModelExecutable class")
     if not isinstance(custom_function, entities.CustomFunction):
         raise TypeError("Custom_function must be an instance of CustomFunction class")
@@ -15,12 +14,13 @@ def _assert_valid_args(fmu, custom_function, options):
 
 
 def _assert_settable_parameters(fmu, **variables):
-    for name in variables.keys():
-        if name not in fmu.settable_parameters():
-            raise KeyError(
-                f"{name} is not a valid parameter modifier! "
-                f"Settable parameters are {fmu.settable_parameters()}"
-            )
+    add = set(variables.keys()) - set(fmu.settable_parameters())
+    if add:
+        raise KeyError(
+            f"Paramter(s) '{', '.join(add)}' {'are' if len(add)>1 else 'is'} "
+            "not a valid parameter modifier! Settable parameters"
+            f" are {fmu.settable_parameters()}"
+        )
 
 
 def _assert_successful_compilation(fmu):

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -1,76 +1,53 @@
-import unittest.mock
 import modelon.impact.client.sal.service
 import pytest
 import os
 import tempfile
-import modelon.impact.client.operations
 import modelon.impact.client.options
+import modelon.impact.client.exceptions as exceptions
+
 from tests.files.paths import SINGLE_FILE_LIBRARY_PATH
+from modelon.impact.client.entities import (
+    Workspace,
+    Model,
+    ModelExecutable,
+    Experiment,
+    Case,
+)
+from modelon.impact.client.operations import (
+    ExperimentOperation,
+    ModelExecutableOperation,
+)
 from tests.impact.client.fixtures import *
 
 
 class TestWorkspace:
-    def test_workspace_get_custom_function(self, custom_function_parameter_list):
-        custom_function_service = unittest.mock.MagicMock()
-        custom_function_service.custom_function_get.return_value = {
-            'name': 'dynamic',
-            'parameters': custom_function_parameter_list,
-        }
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', custom_function_service=custom_function_service
-        )
-        custom_function = ws.get_custom_function('dynamic')
+    def test_get_custom_function(self, workspace):
+        custom_function = workspace.get_custom_function('dynamic')
         assert 'dynamic' == custom_function.name
 
-    def test_workspace_get_custom_functions(self, custom_function_parameter_list):
-        custom_function_service = unittest.mock.MagicMock()
-        custom_function_service.custom_functions_get.return_value = {
-            'data': {
-                'items': [
-                    {'name': 'dynamic', 'parameters': custom_function_parameter_list}
-                ]
-            }
-        }
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', custom_function_service=custom_function_service
-        )
+    def test_get_custom_functions(self, workspace):
         custom_function_list = [
-            custom_function.name for custom_function in ws.get_custom_functions()
+            custom_function.name for custom_function in workspace.get_custom_functions()
         ]
         assert ['dynamic'] == custom_function_list
 
-    def test_del_workspace(self, workspace, delete_workspace):
-        workspace.delete()
+    def test_delete(self, workspace_ops, delete_workspace):
+        workspace_ops.delete()
         delete_call = delete_workspace.adapter.request_history[3]
         assert (
             'http://mock-impact.com/api/workspaces/AwesomeWorkspace' == delete_call.url
         )
         assert 'DELETE' == delete_call.method
 
-    def test_import_lib(self):
-        ws_service = unittest.mock.MagicMock()
-        ws_service.library_import.return_value = {
-            "name": "Single",
-            "uses": {"Modelica": {"version": "3.2.2"}},
-        }
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', workspace_service=ws_service
-        )
-        resp = ws.import_library(SINGLE_FILE_LIBRARY_PATH)
+    def test_import_library(self, workspace):
+        resp = workspace.import_library(SINGLE_FILE_LIBRARY_PATH)
         assert resp == {
             "name": "Single",
             "uses": {"Modelica": {"version": "3.2.2"}},
         }
 
-    def test_get_model(self):
-        ws = modelon.impact.client.entities.Workspace('AwesomeWorkspace')
-        model = ws.get_model("Modelica.Blocks.PID")
-        assert model == modelon.impact.client.entities.Model(
-            "Modelica.Blocks.PID", ws.id
-        )
-
-    def test_lock_workspace(self, workspace, lock_workspace):
-        workspace.lock()
+    def test_lock(self, workspace_ops, lock_workspace):
+        workspace_ops.lock()
         lock_call = lock_workspace.adapter.request_history[3]
         assert (
             'http://mock-impact.com/api/workspaces/AwesomeWorkspace/lock'
@@ -78,8 +55,8 @@ class TestWorkspace:
         )
         assert 'POST' == lock_call.method
 
-    def test_unlock_workspace(self, workspace, unlock_workspace):
-        workspace.unlock()
+    def test_unlock(self, workspace_ops, unlock_workspace):
+        workspace_ops.unlock()
         unlock_call = unlock_workspace.adapter.request_history[3]
         assert (
             'http://mock-impact.com/api/workspaces/AwesomeWorkspace/lock'
@@ -87,105 +64,48 @@ class TestWorkspace:
         )
         assert 'DELETE' == unlock_call.method
 
-    def test_clone_workspace(self):
-        ws_service = unittest.mock.MagicMock()
-        ws_service.workspace_clone.return_value = {"workspace_id": "MyClonedWorkspace"}
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', workspace_service=ws_service
-        )
-        resp = ws.clone()
-        assert resp == modelon.impact.client.entities.Workspace(
-            'MyClonedWorkspace', workspace_service=ws_service
-        )
-
-    def test_get_fmus(self):
-        ws_service = unittest.mock.MagicMock()
-        ws_service.fmus_get.return_value = {
-            'data': {'items': [{'id': 'as9f-3df5'}, {'id': 'as9D-4df5'}]}
-        }
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', workspace_service=ws_service
-        )
-        resp = ws.get_fmus()
-        assert resp == [
-            modelon.impact.client.entities.ModelExecutable(
-                'AwesomeWorkspace', 'as9f-3df5'
-            ),
-            modelon.impact.client.entities.ModelExecutable(
-                'AwesomeWorkspace', 'as9D-4df5'
-            ),
-        ]
-
-    def test_get_fmu(self):
-        ws_service = unittest.mock.MagicMock()
-        ws_service.fmu_get.return_value = {'id': 'pid_20090615_134'}
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', workspace_service=ws_service
-        )
-        resp = ws.get_fmu('pid_20090615_134')
-        assert resp == modelon.impact.client.entities.ModelExecutable(
-            'AwesomeWorkspace', 'pid_20090615_134'
-        )
-
-    def test_get_experiment(self):
-        ws_service = unittest.mock.MagicMock()
-        ws_service.experiment_get.return_value = {'id': 'pid_20090615_134'}
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', workspace_service=ws_service
-        )
-        resp = ws.get_experiment('pid_20090615_134')
-        assert resp == modelon.impact.client.entities.Experiment(
-            'AwesomeWorkspace', 'pid_20090615_134'
-        )
-
-    def test_get_experiments(self):
-        ws_service = unittest.mock.MagicMock()
-        ws_service.experiments_get.return_value = {
-            'data': {'items': [{'id': 'as9f-3df5'}, {'id': 'dd9f-3df5'}]}
-        }
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', workspace_service=ws_service
-        )
-        resp = ws.get_experiments()
-        assert resp == [
-            modelon.impact.client.entities.Experiment('AwesomeWorkspace', 'as9f-3df5'),
-            modelon.impact.client.entities.Experiment('AwesomeWorkspace', 'dd9f-3df5'),
-        ]
-
-    def test_create_experiment(self):
-        ws_service = unittest.mock.MagicMock()
-        ws_service.experiment_create.return_value = {"experiment_id": "pid_2009"}
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', workspace_service=ws_service
-        )
-        resp = ws.create_experiment({})
-        assert resp == modelon.impact.client.entities.Experiment(
-            'AwesomeWorkspace', 'pid_2009'
-        )
-
-    def test_download_workspace(self):
-        ws_service = unittest.mock.MagicMock()
-        ws_service.workspace_download.return_value = '\x00\x00\x00\x00'
-        ws = modelon.impact.client.entities.Workspace(
-            'AwesomeWorkspace', workspace_service=ws_service
-        )
+    def test_download_workspace(self, workspace):
         t = os.path.join(tempfile.gettempdir(), os.urandom(24).hex())
-        resp = ws.download({}, t)
+        resp = workspace.download({}, t)
         assert resp == t
 
+    def test_clone(self, workspace):
+        clone = workspace.clone()
+        assert clone == Workspace('MyClonedWorkspace')
 
-class TestModel:
-    def test_model_compile(self, options):
-        model_exe_service = unittest.mock.MagicMock()
-        model_exe_service.compile_model.return_value = 'test_pid_fmu_id'
-        model = modelon.impact.client.entities.Model(
-            'Test.PID', 'AwesomeWorkspace', model_exe_service=model_exe_service,
-        )
-        fmu = model.compile(options)
-        assert fmu == modelon.impact.client.operations.ModelExecutable(
-            'AwesomeWorkspace', fmu.id
-        )
-        assert fmu.id == 'test_pid_fmu_id'
+    def test_get_model(self, workspace):
+        model = workspace.get_model("Modelica.Blocks.PID")
+        assert model == Model("Modelica.Blocks.PID", workspace.id)
+
+    def test_get_fmus(self, workspace):
+        fmus = workspace.get_fmus()
+        assert fmus == [
+            ModelExecutable('AwesomeWorkspace', 'as9f-3df5'),
+            ModelExecutable('AwesomeWorkspace', 'as9D-4df5'),
+        ]
+
+    def test_get_fmu(self, workspace):
+        fmu = workspace.get_fmu('pid_20090615_134')
+        assert fmu == ModelExecutable('AwesomeWorkspace', 'pid_20090615_134')
+
+    def test_get_experiment(self, workspace):
+        exp = workspace.get_experiment('pid_20090615_134')
+        assert exp == Experiment('AwesomeWorkspace', 'pid_20090615_134')
+
+    def test_get_experiments(self, workspace):
+        exps = workspace.get_experiments()
+        assert exps == [
+            Experiment('AwesomeWorkspace', 'as9f-3df5'),
+            Experiment('AwesomeWorkspace', 'dd9f-3df5'),
+        ]
+
+    def test_create_experiment(self, workspace):
+        exp = workspace.create_experiment({})
+        assert exp == Experiment('AwesomeWorkspace', 'pid_2009')
+
+    def test_execute_options_dict(self, workspace):
+        exp = workspace.execute({})
+        assert exp == ExperimentOperation('AwesomeWorkspace', 'pid_2009')
 
 
 class TestCustomFunction:
@@ -229,10 +149,180 @@ class TestCustomFunction:
         pytest.raises(ValueError, custom_function.with_parameters, p3='not in values')
 
     def test_options(self, custom_function):
-        options = {"compiler": {"c_compiler": "gcc"}}
-        custom_function._custom_func_sal.custom_function_options_get.return_value = (
-            options
-        )
         new = custom_function.options()
-        assert new.to_dict() == {"compiler": {"c_compiler": "gcc"}}
+        assert new.to_dict() == {
+            "compiler": {"c_compiler": "gcc"},
+            "runtime": {},
+            "simulation": {"ncp": 500},
+            "solver": {},
+        }
         assert isinstance(new, modelon.impact.client.options.ExecutionOption)
+
+
+class TestModel:
+    def test_compile(self, model_compiled, options):
+        fmu = model_compiled.compile(options)
+        assert fmu == ModelExecutableOperation('AwesomeWorkspace', 'test_pid_fmu_id')
+
+
+class TestModelExecutable:
+    def test_compile_successful(self, fmu):
+        assert fmu.id == 'Test'
+        assert fmu.is_successful()
+        assert fmu.settable_parameters() == ['h0', 'v']
+        assert fmu.log() == "Successful Log"
+        assert fmu.metadata == {
+            "steady_state": {
+                "residual_variable_count": 1,
+                "iteration_variable_count": 2,
+            }
+        }
+        assert fmu.info == {'run_info': {'status': 'successful'}}
+
+    def test_compilation_running(self, fmu_compile_running):
+        assert fmu_compile_running.info["run_info"]["status"] == "not_started"
+        pytest.raises(
+            exceptions.OperationNotCompleteError, fmu_compile_running.log,
+        )
+        pytest.raises(
+            exceptions.OperationNotCompleteError,
+            fmu_compile_running.settable_parameters,
+        )
+        pytest.raises(
+            exceptions.OperationNotCompleteError, fmu_compile_running.is_successful,
+        )
+
+    def test_compilation_failed(self, fmu_compile_failed):
+        assert fmu_compile_failed.info["run_info"]["status"] == "failed"
+        assert not fmu_compile_failed.is_successful()
+        assert fmu_compile_failed.log() == "Failed Log"
+        pytest.raises(
+            exceptions.OperationFailureError, fmu_compile_failed.settable_parameters,
+        )
+
+    def test_compilation_cancelled(self, fmu_compile_cancelled):
+        assert fmu_compile_cancelled.info["run_info"]["status"] == "cancelled"
+        pytest.raises(
+            exceptions.OperationFailureError, fmu_compile_cancelled.is_successful,
+        )
+        pytest.raises(
+            exceptions.OperationFailureError, fmu_compile_cancelled.log,
+        )
+        pytest.raises(
+            exceptions.OperationFailureError, fmu_compile_cancelled.settable_parameters,
+        )
+
+
+class TestExperiment:
+    def test_execute_successful(self, experiment):
+        assert experiment.id == "Test"
+        assert experiment.is_successful()
+        assert experiment.info == {
+            "run_info": {"status": "done", "failed": 0, "successful": 1, "cancelled": 0}
+        }
+        assert experiment.variables() == ["inertia.I", "time"]
+        assert experiment.cases() == [Case("case_1", "Workspace", "Test")]
+        assert experiment.case("case_1") == Case("case_1", "Workspace", "Test")
+        exp = experiment.trajectories(['inertia.I', 'time'])
+        assert exp['case_1']['inertia.I'] == [1, 2, 3, 4]
+        assert exp['case_1']['time'] == [5, 2, 9, 4]
+
+    def test_successful_batch_execute(self, batch_experiment):
+        assert batch_experiment.is_successful()
+        assert batch_experiment.info == {
+            "run_info": {"status": "done", "failed": 0, "successful": 2, "cancelled": 0}
+        }
+        assert batch_experiment.variables() == ["inertia.I", "time"]
+        assert batch_experiment.cases() == [
+            Case("case_1", "Workspace", "Test"),
+            Case("case_2", "Workspace", "Test"),
+        ]
+        exp = batch_experiment.trajectories(['inertia.I'])
+        assert exp['case_1']['inertia.I'] == [1, 2, 3, 4]
+        assert exp['case_2']['inertia.I'] == [14, 4, 4, 74]
+
+    def test_running_execution(self, running_experiment):
+        assert running_experiment.info["run_info"]["status"] == "not_started"
+        pytest.raises(
+            exceptions.OperationNotCompleteError, running_experiment.variables,
+        )
+        pytest.raises(
+            exceptions.OperationNotCompleteError,
+            running_experiment.trajectories,
+            ['inertia.I'],
+        )
+
+    def test_failed_execution(self, failed_experiment):
+        assert failed_experiment.info["run_info"]["status"] == "done"
+        assert failed_experiment.cases() == [Case("case_1", "Workspace", "Test")]
+        assert failed_experiment.case("case_1") == Case("case_1", "Workspace", "Test")
+        assert not failed_experiment.is_successful()
+        pytest.raises(
+            exceptions.OperationFailureError, failed_experiment.variables,
+        )
+        pytest.raises(
+            exceptions.OperationFailureError,
+            failed_experiment.trajectories,
+            ['inertia.I'],
+        )
+
+    def test_cancelled_execution(self, cancelled_experiment):
+        assert cancelled_experiment.info["run_info"]["status"] == "cancelled"
+        assert cancelled_experiment.cases() == [Case("case_1", "Workspace", "Test")]
+        assert cancelled_experiment.case("case_1") == Case(
+            "case_1", "Workspace", "Test"
+        )
+        pytest.raises(
+            exceptions.OperationFailureError, cancelled_experiment.is_successful,
+        )
+        pytest.raises(
+            exceptions.OperationFailureError, cancelled_experiment.variables,
+        )
+        pytest.raises(
+            exceptions.OperationFailureError,
+            cancelled_experiment.trajectories,
+            ['inertia.I'],
+        )
+
+    def test_exp_trajectories_non_list_entry(self, experiment):
+        pytest.raises(TypeError, experiment.trajectories, 'hh')
+
+    def test_exp_trajectories_invalid_keys(self, experiment):
+        pytest.raises(ValueError, experiment.trajectories, ['s'])
+
+
+class TestCase:
+    def test_case(self, experiment):
+        case = experiment.case("case_1")
+        assert case.id == "case_1"
+        assert case.info["run_info"]["status"] == "successful"
+        assert case.log() == "Successful Log"
+        assert case.result() == b'\x00\x00\x00\x00'
+        assert case.is_successful()
+        assert case.trajectories()['inertia.I'] == [1, 2, 3, 4]
+
+    def test_multiple_cases(self, batch_experiment):
+        case = batch_experiment.case("case_2")
+        assert case.id == "case_2"
+        assert case.info["run_info"]["status"] == "successful"
+        assert case.log() == "Successful Log"
+        assert case.result() == b'\x00\x00\x00\x00'
+        assert case.is_successful()
+        assert case.trajectories()['inertia.I'] == [14, 4, 4, 74]
+
+    def test_failed_case(self, failed_experiment):
+        failed_case = failed_experiment.case("case_2")
+        assert failed_case.id == "case_1"
+        assert failed_case.info["run_info"]["status"] == "failed"
+        assert not failed_case.is_successful()
+        pytest.raises(
+            exceptions.OperationFailureError, failed_case.result,
+        )
+        pytest.raises(
+            exceptions.OperationFailureError, failed_case.trajectories,
+        )
+
+    def test_failed_execution_result(self, failed_experiment):
+        pytest.raises(
+            exceptions.OperationFailureError, failed_experiment.case("case_2").result,
+        )

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -1,6 +1,7 @@
 import modelon.impact.client.experiment_definition as experiment_definition
 import pytest
 import modelon.impact.client.exceptions as exceptions
+
 from tests.impact.client.fixtures import *
 
 

--- a/tests/impact/client/test_operations.py
+++ b/tests/impact/client/test_operations.py
@@ -1,175 +1,102 @@
 import pytest
 import modelon.impact.client.exceptions as exceptions
+
+from modelon.impact.client.entities import ModelExecutable, Experiment
+from modelon.impact.client.operations import Status
 from tests.impact.client.fixtures import *
-from modelon.impact.client.operations import Status, Case
 
 
-class TestModelExecutable:
-    def test_successful_compile(self, fmu):
-        assert fmu.id == 'Test'
+class TestModelExecutableOperation:
+    def test_compile_wait_done(self, model_compiled, options):
+        fmu = model_compiled.compile(options)
+        assert fmu.id == "test_pid_fmu_id"
+        assert fmu.status() == Status.DONE
         assert fmu.is_complete()
-        assert fmu.is_successful()
-        assert fmu.settable_parameters() == ['h0', 'v']
-        assert fmu.log() == "Successful Log"
-        assert fmu.metadata == {
-            "steady_state": {
-                "residual_variable_count": 1,
-                "iteration_variable_count": 2,
-            }
-        }
+        assert fmu.wait() == ModelExecutable('AwesomeWorkspace', 'test_pid_fmu_id')
 
-    def test_running_compilation(self, fmu_compile_running):
-        assert fmu_compile_running.id == 'Test'
-        assert not fmu_compile_running.is_complete()
-        assert fmu_compile_running.status() == Status.RUNNING
-
-    def test_running_compilation_log(self, fmu_compile_running):
+    def test_compile_wait_cancel_timeout(self, model_compiled, options):
+        fmu = model_compiled.compile(options)
+        assert fmu.id == "test_pid_fmu_id"
+        assert fmu.status() == Status.DONE
+        assert fmu.is_complete()
         pytest.raises(
-            exceptions.OperationNotCompleteError, fmu_compile_running.log,
+            exceptions.OperationTimeOutError, fmu.wait, 1e-10, Status.CANCELLED
         )
 
-    def test_failed_compilation(self, fmu_compile_failed):
-        assert fmu_compile_failed.id == 'Test'
-        assert fmu_compile_failed.is_complete()
-        assert fmu_compile_failed.info["run_info"]["status"] == "failed"
-        assert not fmu_compile_failed.is_successful()
-        assert fmu_compile_failed.log() == "Failed Log"
+    def test_compile_wait_running(self, model_compiling, options):
+        fmu = model_compiling.compile(options)
+        assert fmu.id == "test_pid_fmu_id"
+        assert fmu.status() == Status.RUNNING
+        assert not fmu.is_complete()
+        assert fmu.wait(status=Status.RUNNING) == ModelExecutable(
+            'AwesomeWorkspace', 'test_pid_fmu_id'
+        )
 
-    def test_cancel_compile_wait_timeout(self, fmu_compile_failed):
+    def test_compile_wait_cancelled(self, model_compile_cancelled, options):
+        fmu = model_compile_cancelled.compile(options)
+        assert fmu.id == "test_pid_fmu_id"
+        assert fmu.status() == Status.CANCELLED
         pytest.raises(
-            exceptions.OperationTimeOutError,
-            fmu_compile_failed.wait,
-            timeout=1e-6,
-            status=Status.CANCELLED,
+            exceptions.OperationFailureError, fmu.is_complete,
+        )
+        assert fmu.wait(status=Status.CANCELLED) == ModelExecutable(
+            'AwesomeWorkspace', 'test_pid_fmu_id'
         )
 
-    def test_failed_compile_wait_done(self, fmu_compile_failed):
-        fmu_compile_failed.wait(status=Status.DONE)
-        assert fmu_compile_failed.is_complete()
-        assert fmu_compile_failed.info["run_info"]["status"] == "failed"
-        assert not fmu_compile_failed.is_successful()
-
-    def test_failed_compile_empty_log(self, fmu_compile_failed_empty_log):
-        pytest.raises(exceptions.EmptyLogError, fmu_compile_failed_empty_log.log)
-
-    def test_cancelled_compilation(self, fmu_compile_cancelled):
-        assert fmu_compile_cancelled.info["run_info"]["status"] == "cancelled"
+    def test_compile_wait_timeout(self, model_compile_cancelled, options):
+        fmu = model_compile_cancelled.compile(options)
+        assert fmu.id == "test_pid_fmu_id"
+        assert fmu.status() == Status.CANCELLED
         pytest.raises(
-            exceptions.OperationFailureError, fmu_compile_cancelled.is_successful,
+            exceptions.OperationFailureError, fmu.is_complete,
         )
+        pytest.raises(exceptions.OperationTimeOutError, fmu.wait, 1e-10, Status.DONE)
+
+
+class TestExperimentOperation:
+    def test_execute_wait_done(
+        self, workspace,
+    ):
+        exp = workspace.execute({})
+        assert exp.id == "pid_2009"
+        assert exp.status() == Status.DONE
+        assert exp.is_complete()
+        assert exp.wait() == Experiment('AwesomeWorkspace', 'pid_2009')
+
+    def test_execute_wait_cancel_timeout(self, workspace):
+        exp = workspace.execute({})
+        assert exp.id == "pid_2009"
+        assert exp.status() == Status.DONE
+        assert exp.is_complete()
         pytest.raises(
-            exceptions.OperationFailureError, fmu_compile_cancelled.is_complete,
+            exceptions.OperationTimeOutError, exp.wait, 1e-10, Status.CANCELLED
         )
 
+    def test_execute_wait_running(self, workspace_execute_running):
+        exp = workspace_execute_running.execute({})
+        assert exp.id == "pid_2009"
+        assert exp.status() == Status.RUNNING
+        assert not exp.is_complete()
+        assert exp.wait(status=Status.RUNNING) == Experiment(
+            'AwesomeWorkspace', 'pid_2009'
+        )
 
-class TestExperiment:
-    def test_successful_execute(self, experiment):
-        assert experiment.id == "Test"
-        assert experiment.is_complete()
-        assert experiment.is_successful()
-        assert experiment.info["run_info"]["status"] == "done"
-        assert experiment.variables() == ["inertia.I", "time"]
-        assert experiment.cases() == [Case("case_1", "Workspace", "Test")]
-        assert experiment.case("case_1") == Case("case_1", "Workspace", "Test")
-
-    def test_successful_batch_execute(self, batch_experiment):
-        assert batch_experiment.is_successful()
-        assert batch_experiment.variables() == ["inertia.I", "time"]
-        assert batch_experiment.cases() == [
-            Case("case_1", "Workspace", "Test"),
-            Case("case_2", "Workspace", "Test"),
-        ]
-
-    def test_running_execution(self, running_experiment):
-        assert not running_experiment.is_complete()
-        assert running_experiment.status() == Status.RUNNING
-
-    def test_failed_execution(self, failed_experiment):
-        assert failed_experiment.id == 'Test'
-        assert failed_experiment.is_complete()
-        assert failed_experiment.info["run_info"]["status"] == "done"
-        assert not failed_experiment.is_successful()
-
-    def test_cancel_execution_wait_timeout(self, failed_experiment):
+    def test_execute_wait_cancelled(self, workspace_execute_cancelled):
+        exp = workspace_execute_cancelled.execute({})
+        assert exp.id == "pid_2009"
+        assert exp.status() == Status.CANCELLED
         pytest.raises(
-            exceptions.OperationTimeOutError,
-            failed_experiment.wait,
-            timeout=1e-6,
-            status=Status.CANCELLED,
+            exceptions.OperationFailureError, exp.is_complete,
+        )
+        assert exp.wait(status=Status.CANCELLED) == Experiment(
+            'AwesomeWorkspace', 'pid_2009'
         )
 
-    def test_failed_execution_wait_done(self, failed_experiment):
-        failed_experiment.wait(status=Status.DONE)
-        assert failed_experiment.is_complete()
-        assert failed_experiment.status() == Status.DONE
-        assert failed_experiment.info["run_info"]["failed"] == 1
-        assert not failed_experiment.is_successful()
-
-    def test_failed_execution_cases(self, failed_experiment):
-        assert failed_experiment.cases() == [Case("case_1", "Workspace", "Test")]
-        assert failed_experiment.case("case_1") == Case("case_1", "Workspace", "Test")
-
-    def test_cancelled_execution(self, cancelled_experiment):
-        assert cancelled_experiment.info["run_info"]["status"] == "done"
+    def test_execute_wait_timeout(self, workspace_execute_cancelled):
+        exp = workspace_execute_cancelled.execute({})
+        assert exp.id == "pid_2009"
+        assert exp.status() == Status.CANCELLED
         pytest.raises(
-            exceptions.OperationFailureError, cancelled_experiment.is_successful,
+            exceptions.OperationFailureError, exp.is_complete,
         )
-        pytest.raises(
-            exceptions.OperationFailureError, cancelled_experiment.is_complete,
-        )
-
-    def test_cancelled_execution_cases(self, cancelled_experiment):
-        assert cancelled_experiment.cases() == [Case("case_1", "Workspace", "Test")]
-        assert cancelled_experiment.case("case_1") == Case(
-            "case_1", "Workspace", "Test"
-        )
-
-    def test_exp_trajectories_single_run(self, experiment):
-        exp = experiment.trajectories(['inertia.I', 'time'])
-        assert exp['case_1']['inertia.I'] == [1, 2, 3, 4]
-        assert exp['case_1']['time'] == [5, 2, 9, 4]
-
-    def test_exp_trajectories_batch_execute(self, batch_experiment):
-        exp = batch_experiment.trajectories(['inertia.I'])
-        assert exp['case_1']['inertia.I'] == [1, 2, 3, 4]
-        assert exp['case_2']['inertia.I'] == [14, 4, 4, 74]
-
-    def test_exp_trajectories_no_keys(self, experiment):
-        pytest.raises(ValueError, experiment.trajectories, [])
-
-    def test_exp_trajectories_invalid_keys(self, experiment):
-        pytest.raises(ValueError, experiment.trajectories, ['s'])
-
-
-class TestCase:
-    def test_case(self, experiment):
-        case = experiment.case("case_1")
-        assert case.id == "case_1"
-        assert case.info["run_info"]["status"] == "successful"
-        assert case.log() == "Successful Log"
-        assert case.result() == b'\x00\x00\x00\x00'
-        assert case.is_successful()
-        assert case.trajectories()['inertia.I'] == [1, 2, 3, 4]
-
-    def test_multiple_cases(self, batch_experiment):
-        case = batch_experiment.case("case_2")
-        assert case.id == "case_2"
-        assert case.info["run_info"]["status"] == "successful"
-        assert case.log() == "Successful Log"
-        assert case.result() == b'\x00\x00\x00\x00'
-        assert case.is_successful()
-        assert case.trajectories()['inertia.I'] == [14, 4, 4, 74]
-
-    def test_failed_case(self, failed_experiment):
-        failed_case = failed_experiment.case("case_2")
-        assert failed_case.id == "case_1"
-        assert failed_case.info["run_info"]["status"] == "failed"
-        assert not failed_case.is_successful()
-        pytest.raises(
-            exceptions.OperationFailureError, failed_case.result,
-        )
-
-    def test_failed_execution_result(self, failed_experiment):
-        pytest.raises(
-            exceptions.OperationFailureError, failed_experiment.case("case_2").result,
-        )
+        pytest.raises(exceptions.OperationTimeOutError, exp.wait, 1e-10, Status.DONE)


### PR DESCRIPTION
**Key changes**
1. Separating the operations and entities module
2. Status retrieved in from run_info.
3. Separate status forExperiment, ModelExecutable and Case