### PR TITLE
Trajectory fix

### DIFF
--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -822,6 +822,8 @@ def failed_experiment():
         "id": "case_1",
         "run_info": {"status": "failed"},
     }
+    exp_service.result_variables_get.return_value = ["inertia.I", "time"]
+    exp_service.trajectories_get.return_value = [[[1, 2, 3, 4]], [[5, 2, 9, 4]]]
     return Experiment("Workspace", "Test", ws_service, exp_service)
 
 

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -273,14 +273,9 @@ class TestExperiment:
         assert failed_experiment.cases() == [Case("case_1", "Workspace", "Test")]
         assert failed_experiment.case("case_1") == Case("case_1", "Workspace", "Test")
         assert not failed_experiment.is_successful()
-        pytest.raises(
-            exceptions.OperationFailureError, failed_experiment.variables,
-        )
-        pytest.raises(
-            exceptions.OperationFailureError,
-            failed_experiment.trajectories,
-            ['inertia.I'],
-        )
+        assert failed_experiment.trajectories(['inertia.I']) == {
+            'case_1': {'inertia.I': [1, 2, 3, 4]}
+        }
 
     def test_cancelled_execution(self, cancelled_experiment):
         assert cancelled_experiment.info["run_info"]["status"] == "cancelled"
@@ -336,9 +331,7 @@ class TestCase:
         pytest.raises(
             exceptions.OperationFailureError, failed_case.result,
         )
-        pytest.raises(
-            exceptions.OperationFailureError, failed_case.trajectories,
-        )
+        assert failed_case.trajectories()["inertia.I"] == [1, 2, 3, 4]
 
     def test_failed_execution_result(self, failed_experiment):
         pytest.raises(

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -48,7 +48,7 @@ def test_experiment_definition_with_modifier(fmu, custom_function_no_param):
         fmu,
         custom_function=custom_function_no_param,
         options=custom_function_no_param.options(),
-    ).with_modifiers(v=1, h0=Range(0.1, 0.5, 3))
+    ).with_modifiers({'h0': Range(0.1, 0.5, 3)}, v=1)
     config = spec.to_dict()
     assert config["experiment"]["modifiers"]["variables"] == {
         'h0': 'range(0.1,0.5,3)',


### PR DESCRIPTION
Modelica model - 
```
model DynamicFailure
    parameter Real upperLimit = 1;
    parameter Real lowerLimit = 2;
    .Modelica.Blocks.Sources.Ramp ramp(duration = 1,offset = upperLimit,height = 1.5) annotation(Placement(transformation(extent = {{-77.19435396308361,-5.064060803474476},{-57.194353963083614,14.935939196525524}},rotation = 0.0,origin = {0.0,0.0})));
equation
    assert(ramp.y < lowerLimit,"Y should be less than lower limit");
    annotation(Icon(coordinateSystem(preserveAspectRatio = false,extent = {{-100.0,-100.0},{100.0,100.0}}),graphics = {Rectangle(lineColor={0,0,0},fillColor={230,230,230},fillPattern=FillPattern.Solid,extent={{-100.0,-100.0},{100.0,100.0}}),Text(lineColor={0,0,255},extent={{-150,150},{150,110}},textString="%name")}),experiment(StopTime = 2),uses(Modelica(version = "3.2.3")));
end DynamicFailure;
```

**Code to test :-**

```
import uuid
from modelon.impact.client import experiment_definition, Client
import matplotlib.pyplot as plt

TEST_URL = "http://localhost:8080"
# Workspace and library setup
workspace_id = uuid.uuid4().hex
client = Client(url=TEST_URL)
workspace = client.create_workspace(workspace_id)
workspace.import_library(r"C:\Users\AbhilashKNair-India\Downloads\DynamicFailure.mo")
# Compilation
model = workspace.get_model("DynamicFailure")
dynamic = workspace.get_custom_function('dynamic')
fmu = model.compile(dynamic.options().with_compiler_options(c_compiler="gcc")).wait(
    timeout=120
)
simulate_def = experiment_definition.SimpleExperimentDefinition(
    fmu,
    dynamic.with_parameters(start_time=0.0, final_time=2.0),
    dynamic.options().with_simulation_options(ncp=500),
).with_modifiers({'upperLimit': 0.5})
exp = workspace.execute(simulate_def).wait(timeout=120)

res = exp.trajectories(['upperLimit', 'time'])
plt.plot(res['case_1']['time'], res['case_1']['upperLimit'])
plt.show()

case = exp.case('case_1')
res = case.trajectories()
plt.plot(res['time'], res['upperLimit'])
plt.show()
```