### PR TITLE
fix: do not give NoResponseFetchVersionError for SSL error

### DIFF
--- a/modelon/impact/client/sal/exceptions.py
+++ b/modelon/impact/client/sal/exceptions.py
@@ -6,6 +6,10 @@ class CommunicationError(ServiceAccessError):
     pass
 
 
+class SSLError(ServiceAccessError):
+    pass
+
+
 class InvalidContentTypeError(ServiceAccessError):
     pass
 

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -374,6 +374,11 @@ class Request:
                 resp = self.context.session.delete(self.url, json=self.body)
             else:
                 raise NotImplementedError()
+        except requests.exceptions.SSLError as exce:
+            raise exceptions.SSLError(
+                "SSL error, could not verify connection. Please check that "
+                "certificates are setup correctly for the Modelon Impact server"
+            ) from exce
         except requests.exceptions.RequestException as exce:
             raise exceptions.CommunicationError(
                 "Communication when doing a request failed"

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -28,6 +28,13 @@ def with_json_route(mock_server_base, method, url, json_response, status_code=20
     return mock_server_base
 
 
+def with_exception(mock_server_base, method, url, exce):
+    mock_server_base.adapter.register_uri(
+        method, f'{mock_server_base.url}/{url}', exc=exce
+    )
+    return mock_server_base
+
+
 def with_json_route_no_resp(mock_server_base, method, url, status_code=200):
     mock_server_base.adapter.register_uri(
         method, f'{mock_server_base.url}/{url}', status_code=status_code,
@@ -185,6 +192,11 @@ def get_with_error(sem_ver_check, mock_server_base):
     json = {'error': {'message': 'no authroization', 'code': 123}}
 
     return with_json_route(mock_server_base, 'GET', '', json, 401)
+
+
+@pytest.fixture
+def get_with_ssl_exception(sem_ver_check, mock_server_base):
+    return with_exception(mock_server_base, 'GET', '', requests.exceptions.SSLError)
 
 
 @pytest.fixture

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -365,3 +365,13 @@ class TestHTTPClient:
         )
         data = client.get_json(get_ok_empty_json.url)
         assert data == {}
+
+    def test_ssl_error_mapping(self, get_with_ssl_exception):
+        client = modelon.impact.client.sal.service.HTTPClient(
+            context=get_with_ssl_exception.context
+        )
+        pytest.raises(
+            modelon.impact.client.sal.exceptions.SSLError,
+            client.get_json,
+            get_with_ssl_exception.url,
+        )


### PR DESCRIPTION
Make sure we get the correct error message when certificates are not setup correctly for server.