### PR TITLE
Johan feedback fixes - Options split up

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,7 @@ Can be used for workflows entierly done server side
    # Execute experiment
    experiment_def = fmu.new_experiment_specification(
        dynamic.with_parameters(start_time=0.0, final_time=2.0),
-       dynamic_opts.with_simulation_options(ncp=500),
+       simulation_options = dynamic_opts.with_simulation_options(ncp=500),
     ).with_modifiers({'inertia1.J': 2, 'inertia2.J': Range(0.1, 0.5, 3)})
    exp = workspace.execute(experiment_def).wait()
 

--- a/modelon/impact/client/options.py
+++ b/modelon/impact/client/options.py
@@ -1,10 +1,10 @@
 from copy import deepcopy
 
 
-def _set_options(custom_func_name, custom_func_sal, option_cat, options, **modified):
+def _set_options(options, **modified):
     opts = deepcopy(options)
     for name, value in modified.items():
-        opts[option_cat][name] = value
+        opts[name] = value
     return opts
 
 
@@ -13,7 +13,9 @@ class ExecutionOptions:
     An class containing the simulation, compiler, solver and runtime options settings.
     """
 
-    def __init__(self, values, custom_function_name, custom_function_service=None):
+    def __init__(
+        self, values, custom_function_name, custom_function_service=None,
+    ):
         self._values = values
         self._name = custom_function_name
         self._custom_func_sal = custom_function_service
@@ -32,25 +34,7 @@ class ExecutionOptions:
         """
         return self._values
 
-    def with_simulation_options(self, **modified):
-        """ Sets/updates the simulation options.
-
-        Parameters::
-
-            parameters --
-                A keyworded, variable-length argument list of simulation
-                options.
-
-        Example::
-
-            custom_function.with_simulation_options(ncp=1000)
-        """
-        values = _set_options(
-            self._name, self._custom_func_sal, "simulation", self._values, **modified,
-        )
-        return ExecutionOptions(values, self._name, self._custom_func_sal)
-
-    def with_compiler_options(self, **modified):
+    def with_values(self, **modified):
         """ Sets/updates the compiler options.
 
         Parameters::
@@ -61,45 +45,12 @@ class ExecutionOptions:
 
         Example::
 
-            custom_function.with_compiler_options(c_compiler='gcc')
+            cmp_opts = custom_function.get_compiler_options().with_values(
+                c_compiler='gcc')
+            runtime_opts = custom_function.get_runtime_options().with_values(
+                cs_solver=0)
+            sol_opts = custom_function.get_solver_options().with_values(rtol=1e-7)
+            sim_opts = custom_function.get_simulation_options().with_values(ncp=500)
         """
-        values = _set_options(
-            self._name, self._custom_func_sal, "compiler", self._values, **modified,
-        )
-        return ExecutionOptions(values, self._name, self._custom_func_sal)
-
-    def with_solver_options(self, **modified):
-        """ Sets/updates the solver options.
-
-        Parameters::
-
-            parameters --
-                A keyworded, variable-length argument list of solver
-                options.
-
-        Example::
-
-            custom_function.with_solver_options(rtol=1e-7)
-        """
-        values = _set_options(
-            self._name, self._custom_func_sal, "solver", self._values, **modified,
-        )
-        return ExecutionOptions(values, self._name, self._custom_func_sal)
-
-    def with_runtime_options(self, **modified):
-        """ Sets/updates the runtime options.
-
-        Parameters::
-
-            parameters --
-                A keyworded, variable-length argument list of runtime
-                options.
-
-        Example::
-
-            custom_function.with_runtime_options(rtol=1e-7)
-        """
-        values = _set_options(
-            self._name, self._custom_func_sal, "runtime", self._values, **modified,
-        )
+        values = _set_options(self._values, **modified,)
         return ExecutionOptions(values, self._name, self._custom_func_sal)

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -667,9 +667,9 @@ def custom_function():
     }
     custom_function_service.custom_function_options_get.return_value = {
         "compiler": {"c_compiler": "gcc"},
-        "runtime": {},
+        "runtime": {"cs_solver": 0},
         "simulation": {"ncp": 500},
-        "solver": {},
+        "solver": {'atol': 1e-7, 'rtol': 1e-9},
     }
     return CustomFunction(
         'test_ws', 'dynamic', _custom_function_parameter_list(), custom_function_service
@@ -717,7 +717,7 @@ def model_compile_cancelled():
 
 
 @pytest.fixture
-def options():
+def compiler_options():
     custom_function_service = unittest.mock.MagicMock()
     opts = {
         "compiler": {"c_compiler": "gcc"},
@@ -734,7 +734,73 @@ def options():
     custom_function_service.custom_function_options_get.return_value = opts
     custom_function_service.custom_function_default_options_get.return_value = def_opts
     return modelon.impact.client.options.ExecutionOptions(
-        opts, "dynamic", custom_function_service
+        opts["compiler"], "dynamic", custom_function_service
+    )
+
+
+@pytest.fixture
+def runtime_options():
+    custom_function_service = unittest.mock.MagicMock()
+    opts = {
+        "compiler": {"c_compiler": "gcc"},
+        "runtime": {"log_level": 3},
+        "simulation": {"ncp": 2000},
+        "solver": {"rtol": 0.0001},
+    }
+    def_opts = {
+        "compiler": {"c_compiler": "msvs"},
+        "runtime": {"log_level": 2},
+        "simulation": {"ncp": 500},
+        "solver": {"rtol": 1e-5},
+    }
+    custom_function_service.custom_function_options_get.return_value = opts
+    custom_function_service.custom_function_default_options_get.return_value = def_opts
+    return modelon.impact.client.options.ExecutionOptions(
+        opts["runtime"], "dynamic", custom_function_service
+    )
+
+
+@pytest.fixture
+def simulation_options():
+    custom_function_service = unittest.mock.MagicMock()
+    opts = {
+        "compiler": {"c_compiler": "gcc"},
+        "runtime": {"log_level": 3},
+        "simulation": {"ncp": 2000},
+        "solver": {"rtol": 0.0001},
+    }
+    def_opts = {
+        "compiler": {"c_compiler": "msvs"},
+        "runtime": {"log_level": 2},
+        "simulation": {"ncp": 500},
+        "solver": {"rtol": 1e-5},
+    }
+    custom_function_service.custom_function_options_get.return_value = opts
+    custom_function_service.custom_function_default_options_get.return_value = def_opts
+    return modelon.impact.client.options.ExecutionOptions(
+        opts["simulation"], "dynamic", custom_function_service
+    )
+
+
+@pytest.fixture
+def solver_options():
+    custom_function_service = unittest.mock.MagicMock()
+    opts = {
+        "compiler": {"c_compiler": "gcc"},
+        "runtime": {"log_level": 3},
+        "simulation": {"ncp": 2000},
+        "solver": {"rtol": 0.0001},
+    }
+    def_opts = {
+        "compiler": {"c_compiler": "msvs"},
+        "runtime": {"log_level": 2},
+        "simulation": {"ncp": 500},
+        "solver": {"rtol": 1e-5},
+    }
+    custom_function_service.custom_function_options_get.return_value = opts
+    custom_function_service.custom_function_default_options_get.return_value = def_opts
+    return modelon.impact.client.options.ExecutionOptions(
+        opts["solver"], "dynamic", custom_function_service
     )
 
 

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -6,11 +6,7 @@ from tests.impact.client.fixtures import *
 
 
 def test_experiment_specification(fmu, custom_function_no_param):
-    spec = SimpleExperimentSpecification(
-        fmu,
-        custom_function=custom_function_no_param,
-        options=custom_function_no_param.get_options(),
-    )
+    spec = SimpleExperimentSpecification(fmu, custom_function=custom_function_no_param)
     config = spec.to_dict()
     assert config == {
         "experiment": {
@@ -49,9 +45,10 @@ def test_experiment_specification_with_options(fmu, custom_function_no_param):
     spec = SimpleExperimentSpecification(
         fmu,
         custom_function=custom_function_no_param,
-        options=custom_function_no_param.get_options()
-        .with_simulation_options(ncp=2000, rtol=0.0001)
-        .with_solver_options(a=1),
+        simulation_options=custom_function_no_param.get_simulation_options().with_values(
+            ncp=2000, rtol=0.0001
+        ),
+        solver_options={'a': 1},
     )
     config = spec.to_dict()
     assert config["experiment"]["analysis"]["simulation_options"] == {
@@ -63,9 +60,7 @@ def test_experiment_specification_with_options(fmu, custom_function_no_param):
 
 def test_experiment_specification_with_modifier(fmu, custom_function_no_param):
     spec = SimpleExperimentSpecification(
-        fmu,
-        custom_function=custom_function_no_param,
-        options=custom_function_no_param.get_options(),
+        fmu, custom_function=custom_function_no_param,
     ).with_modifiers({'h0': Range(0.1, 0.5, 3)}, v=1)
     config = spec.to_dict()
     assert config["experiment"]["modifiers"]["variables"] == {
@@ -74,25 +69,29 @@ def test_experiment_specification_with_modifier(fmu, custom_function_no_param):
     }
 
 
-def test_failed_compile_exp_def(fmu_compile_failed, custom_function_no_param, options):
+def test_failed_compile_exp_def(
+    fmu_compile_failed, custom_function_no_param, solver_options, simulation_options
+):
     pytest.raises(
         exceptions.OperationFailureError,
         SimpleExperimentSpecification,
         fmu_compile_failed,
         custom_function_no_param,
-        options,
+        solver_options,
+        simulation_options,
     )
 
 
 def test_cancelled_compile_exp_def(
-    fmu_compile_cancelled, custom_function_no_param, options
+    fmu_compile_cancelled, custom_function_no_param, solver_options, simulation_options
 ):
     pytest.raises(
         exceptions.OperationFailureError,
         SimpleExperimentSpecification,
         fmu_compile_cancelled,
         custom_function_no_param,
-        options,
+        solver_options,
+        simulation_options,
     )
 
 
@@ -108,5 +107,5 @@ def test_invalid_option_input(custom_function, custom_function_no_param):
 
 def test_invalid_fmu_input(fmu, custom_function_no_param):
     pytest.raises(
-        TypeError, SimpleExperimentSpecification, fmu, custom_function_no_param, {},
+        TypeError, SimpleExperimentSpecification, fmu, custom_function_no_param, "", ""
     )

--- a/tests/impact/client/test_operations.py
+++ b/tests/impact/client/test_operations.py
@@ -7,15 +7,15 @@ from tests.impact.client.fixtures import *
 
 
 class TestModelExecutableOperation:
-    def test_compile_wait_done(self, model_compiled, options):
-        fmu = model_compiled.compile(options)
+    def test_compile_wait_done(self, model_compiled, compiler_options):
+        fmu = model_compiled.compile(compiler_options)
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.DONE
         assert fmu.is_complete()
         assert fmu.wait() == ModelExecutable('AwesomeWorkspace', 'test_pid_fmu_id')
 
-    def test_compile_wait_cancel_timeout(self, model_compiled, options):
-        fmu = model_compiled.compile(options)
+    def test_compile_wait_cancel_timeout(self, model_compiled, compiler_options):
+        fmu = model_compiled.compile(compiler_options)
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.DONE
         assert fmu.is_complete()
@@ -23,8 +23,8 @@ class TestModelExecutableOperation:
             exceptions.OperationTimeOutError, fmu.wait, 1e-10, Status.CANCELLED
         )
 
-    def test_compile_wait_running(self, model_compiling, options):
-        fmu = model_compiling.compile(options)
+    def test_compile_wait_running(self, model_compiling, compiler_options):
+        fmu = model_compiling.compile(compiler_options)
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.RUNNING
         assert not fmu.is_complete()
@@ -32,16 +32,16 @@ class TestModelExecutableOperation:
             'AwesomeWorkspace', 'test_pid_fmu_id'
         )
 
-    def test_compile_wait_cancelled(self, model_compile_cancelled, options):
-        fmu = model_compile_cancelled.compile(options)
+    def test_compile_wait_cancelled(self, model_compile_cancelled, compiler_options):
+        fmu = model_compile_cancelled.compile(compiler_options)
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.CANCELLED
         assert fmu.wait(status=Status.CANCELLED) == ModelExecutable(
             'AwesomeWorkspace', 'test_pid_fmu_id'
         )
 
-    def test_compile_wait_timeout(self, model_compile_cancelled, options):
-        fmu = model_compile_cancelled.compile(options)
+    def test_compile_wait_timeout(self, model_compile_cancelled, compiler_options):
+        fmu = model_compile_cancelled.compile(compiler_options)
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.CANCELLED
         pytest.raises(exceptions.OperationTimeOutError, fmu.wait, 1e-10, Status.DONE)

--- a/tests/impact/client/test_options.py
+++ b/tests/impact/client/test_options.py
@@ -1,43 +1,31 @@
 from tests.impact.client.fixtures import *
 
 
-def test_modify_options(options):
-    assert options.to_dict() == {
-        'compiler': {'c_compiler': 'gcc'},
-        'runtime': {'log_level': 3},
-        'simulation': {'ncp': 2000},
-        'solver': {'rtol': 0.0001},
-    }
-    new_opts = (
-        options.with_simulation_options(ncp=10)
-        .with_runtime_options(log_level=1)
-        .with_solver_options(rtol=50)
-        .with_compiler_options(c_compiler=4)
-    )
-    assert new_opts.to_dict() == {
-        'compiler': {'c_compiler': 4},
-        'runtime': {'log_level': 1},
-        'simulation': {'ncp': 10},
-        'solver': {'rtol': 50},
-    }
+def test_modify_options(
+    compiler_options, runtime_options, solver_options, simulation_options
+):
+
+    simulation_opts = simulation_options.with_values(ncp=10)
+    runtime_opts = runtime_options.with_values(log_level=1)
+    solver_opts = solver_options.with_values(rtol=50)
+    compiler_opts = compiler_options.with_values(c_compiler=4)
+
+    assert compiler_opts.to_dict() == {'c_compiler': 4}
+    assert runtime_opts.to_dict() == {'log_level': 1}
+    assert simulation_opts.to_dict() == {'ncp': 10}
+    assert solver_opts.to_dict() == {'rtol': 50}
 
 
-def test_append_options(options):
-    assert options.to_dict() == {
-        'compiler': {'c_compiler': 'gcc'},
-        'runtime': {'log_level': 3},
-        'simulation': {'ncp': 2000},
-        'solver': {'rtol': 0.0001},
-    }
-    new_opts = (
-        options.with_simulation_options(a=10)
-        .with_runtime_options(b="hello")
-        .with_solver_options(c=5.0)
-        .with_compiler_options(d=True)
-    )
-    assert new_opts.to_dict() == {
-        'compiler': {'c_compiler': 'gcc', 'd': True},
-        'runtime': {'log_level': 3, 'b': 'hello'},
-        'simulation': {'ncp': 2000, 'a': 10},
-        'solver': {'rtol': 0.0001, 'c': 5.0},
-    }
+def test_append_options(
+    compiler_options, runtime_options, solver_options, simulation_options
+):
+
+    simulation_opts = simulation_options.with_values(a=10)
+    runtime_opts = runtime_options.with_values(b="hello")
+    solver_opts = solver_options.with_values(c=5.0)
+    compiler_opts = compiler_options.with_values(d=True)
+
+    assert compiler_opts.to_dict() == {'c_compiler': 'gcc', 'd': True}
+    assert runtime_opts.to_dict() == {'log_level': 3, 'b': 'hello'}
+    assert simulation_opts.to_dict() == {'ncp': 2000, 'a': 10}
+    assert solver_opts.to_dict() == {'rtol': 0.0001, 'c': 5.0}


### PR DESCRIPTION
@jacobtaxen , @modelon-magnus , @jpersson-modelon 

Fixes ID 4

Code to test
```
import uuid
from modelon.impact.client import experiment_specification, Client

TEST_URL = "http://localhost:8080"
# Workspace and library setup
workspace_id = uuid.uuid4().hex
client = Client(url=TEST_URL)
workspace = client.create_workspace(workspace_id)
# Compilation
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")
dynamic = workspace.get_custom_function('dynamic')
dynamic_opts = dynamic.get_options()
compile_opts = dynamic_opts.with_compiler_options(c_compiler="gcc")
fmu = model.compile(
    compiler_options=compile_opts, runtime_options={'cs_solver': 0}
).wait(timeout=120)
simulation_options = dynamic_opts.with_simulation_options(ncp=500)
simulate_def = experiment_specification.SimpleExperimentSpecification(
    fmu,
    dynamic.with_parameters(start_time=0, final_time=2),
    solver_options={'atol': 1e-8},
    simulation_options=simulation_options,
)
exp = workspace.execute(simulate_def).wait(timeout=120)
case = exp.get_case('case_1')
result = case.get_trajectories()
print(result.keys())
height = result['PI.k']
time = result['time']
```