### PR TITLE
fix: Adding read the docs specifics

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,3 +5,5 @@ sphinx:
 
 python:
   version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ author = 'Modelon'
 # The full version, including alpha/beta/rc tags
 # TODO : Need to ensure version number is set correctly with the release bot.
 release = '1.0.0'
-
+master_doc = 'index'
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
Read the docs configs
@efredriksson-modelon  - Poetry is not supported by sphinx hence the need for requirements.txt.