### PR TITLE
feat: Added checks to use cached FMU if available

### DIFF
--- a/modelon/impact/client/experiment_definition.py
+++ b/modelon/impact/client/experiment_definition.py
@@ -203,7 +203,7 @@ class SimpleExperimentDefinition(BaseExperimentDefinition):
             else simulation_options
         )
         self._simulation_log_level = simulation_log_level
-        self.variable_modifiers = {}
+        self.variable_modifiers = fmu.modifiers
         self.extensions = []
 
     def validate(self):

--- a/modelon/impact/client/options.py
+++ b/modelon/impact/client/options.py
@@ -15,10 +15,7 @@ class ExecutionOptions(Mapping):
     """
 
     def __init__(
-        self,
-        values,
-        custom_function_name,
-        custom_function_service=None,
+        self, values, custom_function_name, custom_function_service=None,
     ):
         self._values = values
         self._name = custom_function_name
@@ -54,8 +51,5 @@ class ExecutionOptions(Mapping):
             sol_opts = custom_function.get_solver_options().with_values(rtol=1e-7)
             sim_opts = custom_function.get_simulation_options().with_values(ncp=500)
         """
-        values = _set_options(
-            self._values,
-            **modified,
-        )
+        values = _set_options(self._values, **modified,)
         return ExecutionOptions(values, self._name, self._custom_func_sal)

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -127,25 +127,27 @@ class ModelExecutableService:
         self._base_uri = uri
         self._http_client = HTTPClient
 
-    def _fmu_setup(self, workspace_id, options):
+    def fmu_setup(self, workspace_id, options, get_cached):
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/model-executables"
+            f"?getCached={'true' if get_cached else 'false'}"
         ).resolve()
-        return self._http_client.post_json(url, body=options)["id"]
+        resp = self._http_client.post_json(url, body=options)
+        return resp["id"], resp["parameters"]
 
-    def compile_model(self, workspace_id, options):
-        fmuId = self._fmu_setup(workspace_id, options)
+    def compile_model(self, workspace_id, fmu_id):
         url = (
             self._base_uri
-            / f"api/workspaces/{workspace_id}/model-executables/{fmuId}/compilation"
+            / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}/compilation"
         ).resolve()
         self._http_client.post_json_no_response_body(url)
-        return fmuId
+        return fmu_id
 
-    def compile_log(self, workspace_id, fmuId):
+    def compile_log(self, workspace_id, fmu_id):
         url = (
             self._base_uri
-            / f"api/workspaces/{workspace_id}/model-executables/{fmuId}/compilation/log"
+            / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}/compilation/"
+            "log"
         ).resolve()
         return self._http_client.get_text(url)
 

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -16,6 +16,7 @@ from modelon.impact.client.entities import (
 from modelon.impact.client.operations import (
     ExperimentOperation,
     ModelExecutableOperation,
+    CachedModelExecutableOperation,
 )
 from tests.impact.client.fixtures import *
 
@@ -113,7 +114,7 @@ class TestWorkspace:
 class TestCustomFunction:
     def test_custom_function_with_parameters_ok(self, custom_function):
         new = custom_function.with_parameters(
-            p1=3.4, p2=False, p3='då', p4='new string', p5=4,
+            p1=3.4, p2=False, p3='då', p4='new string', p5=4
         )
         assert new.parameter_values == {
             'p1': 3.4,
@@ -137,7 +138,7 @@ class TestCustomFunction:
         pytest.raises(ValueError, custom_function.with_parameters, p2='not a boolean')
 
     def test_custom_function_with_parameters_cannot_set_enumeration_type(
-        self, custom_function,
+        self, custom_function
     ):
         pytest.raises(ValueError, custom_function.with_parameters, p3=4.6)
 
@@ -147,7 +148,7 @@ class TestCustomFunction:
         pytest.raises(ValueError, custom_function.with_parameters, p4=4.6)
 
     def test_custom_function_with_parameters_cannot_set_enumeration_value(
-        self, custom_function,
+        self, custom_function
     ):
         pytest.raises(ValueError, custom_function.with_parameters, p3='not in values')
 
@@ -173,12 +174,20 @@ class TestCustomFunction:
 
 
 class TestModel:
-    def test_compile(self, model_compiled, compiler_options, runtime_options):
-        fmu = model_compiled.compile(compiler_options, runtime_options)
+    def test_find_cached(self, model_cached, compiler_options, runtime_options):
+        fmu = model_cached.compile(compiler_options, runtime_options)
+        assert fmu == CachedModelExecutableOperation(
+            'AwesomeWorkspace', 'test_pid_fmu_id'
+        )
+
+    def test_force_compile(self, model_compiled, compiler_options, runtime_options):
+        fmu = model_compiled.compile(
+            compiler_options, runtime_options, force_compilation=True
+        )
         assert fmu == ModelExecutableOperation('AwesomeWorkspace', 'test_pid_fmu_id')
 
-    def test_compile_dict_options(self, model_compiled):
-        fmu = model_compiled.compile({'c_compiler': 'gcc'})
+    def test_force_compile_dict_options(self, model_compiled):
+        fmu = model_compiled.compile({'c_compiler': 'gcc'}, force_compilation=True)
         assert fmu == ModelExecutableOperation('AwesomeWorkspace', 'test_pid_fmu_id')
 
     def test_compile_invalid_type_options(self, model_compiled):
@@ -197,19 +206,42 @@ class TestModelExecutable:
                 "iteration_variable_count": 2,
             }
         }
-        assert fmu.info == {'run_info': {'status': 'successful'}}
+        assert fmu.info == {
+            'id': 'workspace_pid_controller_20210113_131626_77c5174',
+            'input': {
+                'class_name': 'Workspace.PID_Controller',
+                'compiler_options': {'c_compiler': 'gcc'},
+                'runtime_options': {},
+                'compiler_log_level': 'w',
+                'fmi_target': 'me',
+                'fmi_version': '2.0',
+                'platform': 'auto',
+                'model_snapshot': '1610523986117',
+                'toolchain_version': '0.0.1',
+                'compiled_on_sys': 'win32',
+            },
+            'run_info': {
+                'status': 'successful',
+                'datetime_started': 1610523986193,
+                'errors': [],
+                'datetime_finished': 1610523990763,
+            },
+            'meta': {
+                'created_epoch': 1610523986,
+                'input_hash': 'f47e0d051a804eee3cde3e3d98da5f39',
+                'fmu_file': 'model.fmu',
+            },
+        }
 
     def test_compilation_running(self, fmu_compile_running):
         assert fmu_compile_running.info["run_info"]["status"] == "not_started"
-        pytest.raises(
-            exceptions.OperationNotCompleteError, fmu_compile_running.get_log,
-        )
+        pytest.raises(exceptions.OperationNotCompleteError, fmu_compile_running.get_log)
         pytest.raises(
             exceptions.OperationNotCompleteError,
             fmu_compile_running.get_settable_parameters,
         )
         pytest.raises(
-            exceptions.OperationNotCompleteError, fmu_compile_running.is_successful,
+            exceptions.OperationNotCompleteError, fmu_compile_running.is_successful
         )
 
     def test_compilation_failed(self, fmu_compile_failed):
@@ -224,11 +256,9 @@ class TestModelExecutable:
     def test_compilation_cancelled(self, fmu_compile_cancelled):
         assert fmu_compile_cancelled.info["run_info"]["status"] == "cancelled"
         pytest.raises(
-            exceptions.OperationFailureError, fmu_compile_cancelled.is_successful,
+            exceptions.OperationFailureError, fmu_compile_cancelled.is_successful
         )
-        pytest.raises(
-            exceptions.OperationFailureError, fmu_compile_cancelled.get_log,
-        )
+        pytest.raises(exceptions.OperationFailureError, fmu_compile_cancelled.get_log)
         pytest.raises(
             exceptions.OperationFailureError,
             fmu_compile_cancelled.get_settable_parameters,
@@ -290,7 +320,7 @@ class TestExperiment:
     def test_running_execution(self, running_experiment):
         assert running_experiment.info["run_info"]["status"] == "not_started"
         pytest.raises(
-            exceptions.OperationNotCompleteError, running_experiment.get_variables,
+            exceptions.OperationNotCompleteError, running_experiment.get_variables
         )
         pytest.raises(
             exceptions.OperationNotCompleteError,
@@ -316,10 +346,10 @@ class TestExperiment:
             "case_1", "Workspace", "Test"
         )
         pytest.raises(
-            exceptions.OperationFailureError, cancelled_experiment.is_successful,
+            exceptions.OperationFailureError, cancelled_experiment.is_successful
         )
         pytest.raises(
-            exceptions.OperationFailureError, cancelled_experiment.get_variables,
+            exceptions.OperationFailureError, cancelled_experiment.get_variables
         )
         pytest.raises(
             exceptions.OperationFailureError,
@@ -364,9 +394,7 @@ class TestCase:
         assert failed_case.id == "case_1"
         assert failed_case.info["run_info"]["status"] == "failed"
         assert not failed_case.is_successful()
-        pytest.raises(
-            exceptions.OperationFailureError, failed_case.get_result,
-        )
+        pytest.raises(exceptions.OperationFailureError, failed_case.get_result)
         assert failed_case.get_trajectories()["inertia.I"] == [1, 2, 3, 4]
 
     def test_failed_execution_result(self, failed_experiment):

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -62,6 +62,16 @@ def test_experiment_definition_with_modifier(fmu, custom_function_no_param):
     }
 
 
+def test_experiment_definition_with_fmu_modifiers(
+    fmu_with_modifiers, custom_function_no_param
+):
+    definition = SimpleExperimentDefinition(
+        fmu_with_modifiers, custom_function=custom_function_no_param,
+    )
+    config = definition.to_dict()
+    assert config["experiment"]["base"]["modifiers"]["variables"] == {'PI.K': 20}
+
+
 def test_experiment_definition_with_extensions(fmu, custom_function_no_param):
     ext1 = SimpleExperimentExtension().with_modifiers(p=2)
     ext2 = SimpleExperimentExtension({'final_time': 10}).with_modifiers(p=3)

--- a/tests/impact/client/test_operations.py
+++ b/tests/impact/client/test_operations.py
@@ -2,20 +2,26 @@ import pytest
 from modelon.impact.client import exceptions
 
 from modelon.impact.client.entities import ModelExecutable, Experiment
-from modelon.impact.client.operations import Status
+from modelon.impact.client.operations import (
+    Status,
+    CachedModelExecutableOperation,
+    ModelExecutableOperation,
+)
 from tests.impact.client.fixtures import *
 
 
 class TestModelExecutableOperation:
     def test_compile_wait_done(self, model_compiled, compiler_options):
-        fmu = model_compiled.compile(compiler_options)
+        fmu = model_compiled.compile(compiler_options, force_compilation=True)
+        assert fmu == ModelExecutableOperation('AwesomeWorkspace', 'test_pid_fmu_id')
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.DONE
         assert fmu.is_complete()
         assert fmu.wait() == ModelExecutable('AwesomeWorkspace', 'test_pid_fmu_id')
 
     def test_compile_wait_cancel_timeout(self, model_compiled, compiler_options):
-        fmu = model_compiled.compile(compiler_options)
+        fmu = model_compiled.compile(compiler_options, force_compilation=True)
+        assert fmu == ModelExecutableOperation('AwesomeWorkspace', 'test_pid_fmu_id')
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.DONE
         assert fmu.is_complete()
@@ -24,7 +30,8 @@ class TestModelExecutableOperation:
         )
 
     def test_compile_wait_running(self, model_compiling, compiler_options):
-        fmu = model_compiling.compile(compiler_options)
+        fmu = model_compiling.compile(compiler_options, force_compilation=True)
+        assert fmu == ModelExecutableOperation('AwesomeWorkspace', 'test_pid_fmu_id')
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.RUNNING
         assert not fmu.is_complete()
@@ -33,7 +40,8 @@ class TestModelExecutableOperation:
         )
 
     def test_compile_wait_cancelled(self, model_compile_cancelled, compiler_options):
-        fmu = model_compile_cancelled.compile(compiler_options)
+        fmu = model_compile_cancelled.compile(compiler_options, force_compilation=True)
+        assert fmu == ModelExecutableOperation('AwesomeWorkspace', 'test_pid_fmu_id')
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.CANCELLED
         assert fmu.wait(status=Status.CANCELLED) == ModelExecutable(
@@ -41,16 +49,40 @@ class TestModelExecutableOperation:
         )
 
     def test_compile_wait_timeout(self, model_compile_cancelled, compiler_options):
-        fmu = model_compile_cancelled.compile(compiler_options)
+        fmu = model_compile_cancelled.compile(compiler_options, force_compilation=True)
+        assert fmu == ModelExecutableOperation('AwesomeWorkspace', 'test_pid_fmu_id')
         assert fmu.id == "test_pid_fmu_id"
         assert fmu.status() == Status.CANCELLED
         pytest.raises(exceptions.OperationTimeOutError, fmu.wait, 1e-10, Status.DONE)
 
 
+class TestCachedModelExecutableOperation:
+    def test_cached_fmu_wait_done(self, model_cached, compiler_options):
+        fmu = model_cached.compile(compiler_options, force_compilation=False)
+        assert fmu == CachedModelExecutableOperation(
+            'AwesomeWorkspace', 'test_pid_fmu_id'
+        )
+        assert fmu.id == "test_pid_fmu_id"
+        assert fmu.name == "Looking for cached FMU"
+        assert fmu.status() == Status.DONE
+        assert fmu.is_complete()
+        assert fmu.wait() == ModelExecutable('AwesomeWorkspace', 'test_pid_fmu_id')
+
+    def test_cached_fmu_wait_cancelled(self, model_cached, compiler_options):
+        fmu = model_cached.compile(compiler_options, force_compilation=False)
+        assert fmu == CachedModelExecutableOperation(
+            'AwesomeWorkspace', 'test_pid_fmu_id'
+        )
+        assert fmu.id == "test_pid_fmu_id"
+        assert fmu.status() == Status.DONE
+        pytest.raises(
+            exceptions.OperationTimeOutError, fmu.wait, status=Status.CANCELLED
+        )
+
+
 class TestExperimentOperation:
     def test_execute_wait_done(
-        self,
-        workspace,
+        self, workspace,
     ):
         exp = workspace.execute({})
         assert exp.id == "pid_2009"


### PR DESCRIPTION
**How to test-**
**Basic Tests**
1. Execute the below code once to create an FMU. 
2. Execute the code again. This time model should not be recompiled(see logs)
3. Change the option generate_html_diagnostics to true. Execute the code again, the Model should recompile now.
 
**Coupling with UI test.**
1.  Compile a model in UI.
2. Change any param in modeling mode
3. Simulate the model using client. Check if parameter modifiers have been correctly applied

```
from modelon.impact.client import Client

client = Client(url="http://localhost:8080")
workspace = client.create_workspace("Hello6")

# Choose analysis type
dynamic = workspace.get_custom_function('dynamic')

# Compile model
model = workspace.get_model("Workspace.PID_Controller")
fmu = model.compile(
    compiler_options=dynamic.get_compiler_options(), compiler_log_level="w",
).wait()
print(fmu.modifiers)

# # Execute experiment
experiment_definition = fmu.new_experiment_definition(dynamic).with_modifiers(
    {'PI.k': 120}
)
exp = workspace.execute(experiment_definition).wait()
case = exp.get_case('case_1')
res = case.get_trajectories()
k = res['PI.k']
```

@jacobtaxen 