### PR TITLE
feat: Possibility to add extensions to experiment

### DIFF
--- a/modelon/impact/client/__init__.py
+++ b/modelon/impact/client/__init__.py
@@ -2,4 +2,5 @@ from modelon.impact.client.client import Client
 from modelon.impact.client.experiment_definition import (
     SimpleExperimentDefinition,
     Range,
+    SimpleExperimentExtension,
 )

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -104,14 +104,18 @@ class WorkspaceService:
 
     def experiments_get(self, workspace_id):
         url = (self._base_uri / f"api/workspaces/{workspace_id}/experiments").resolve()
-        return self._http_client.get_json(url)
+        return self._http_client.get_json(
+            url, headers={"Accept": "application/vnd.impact.experiment.v2+json"}
+        )
 
     def experiment_get(self, workspace_id, experiment_id):
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}"
         ).resolve()
-        return self._http_client.get_json(url)
+        return self._http_client.get_json(
+            url, headers={"Accept": "application/vnd.impact.experiment.v2+json"}
+        )
 
     def experiment_create(self, workspace_id, definition):
         url = (self._base_uri / f"api/workspaces/{workspace_id}/experiments").resolve()
@@ -316,8 +320,8 @@ class HTTPClient:
     def __init__(self, context=None):
         self._context = context if context else Context()
 
-    def get_json(self, url):
-        request = RequestJSON(self._context, "GET", url)
+    def get_json(self, url, headers=None):
+        request = RequestJSON(self._context, "GET", url, headers=headers)
         return request.execute().data
 
     def get_text(self, url):
@@ -369,13 +373,16 @@ class URI:
 
 
 class Request:
-    def __init__(self, context, method, url, request_type, body=None, files=None):
+    def __init__(
+        self, context, method, url, request_type, body=None, files=None, headers=None
+    ):
         self.context = context
         self.method = method
         self.url = url
         self.body = body
         self.files = files
         self.request_type = request_type
+        self.headers = headers
 
     def execute(self, check_return=True):
         try:
@@ -385,7 +392,7 @@ class Request:
                     self.url, json=self.body, files=self.files
                 )
             elif self.method == "GET":
-                resp = self.context.session.get(self.url)
+                resp = self.context.session.get(self.url, headers=self.headers)
             elif self.method == "DELETE":
                 resp = self.context.session.delete(self.url, json=self.body)
             else:
@@ -408,23 +415,25 @@ class Request:
 
 
 class RequestJSON(Request):
-    def __init__(self, context, method, url, body=None, files=None):
-        super().__init__(context, method, url, JSONResponse, body, files)
+    def __init__(self, context, method, url, body=None, files=None, headers=None):
+        super().__init__(context, method, url, JSONResponse, body, files, headers)
 
 
 class RequestZip(Request):
-    def __init__(self, context, method, url, body=None, files=None):
-        super().__init__(context, method, url, ZIPResponse, body, files)
+    def __init__(self, context, method, url, body=None, files=None, headers=None):
+        super().__init__(context, method, url, ZIPResponse, body, files, headers)
 
 
 class RequestText(Request):
-    def __init__(self, context, method, url, body=None, files=None):
-        super().__init__(context, method, url, TextResponse, body, files)
+    def __init__(self, context, method, url, body=None, files=None, headers=None):
+        super().__init__(context, method, url, TextResponse, body, files, headers)
 
 
 class RequestOctetStream(Request):
-    def __init__(self, context, method, url, body=None, files=None):
-        super().__init__(context, method, url, OctetStreamResponse, body, files)
+    def __init__(self, context, method, url, body=None, files=None, headers=None):
+        super().__init__(
+            context, method, url, OctetStreamResponse, body, files, headers
+        )
 
 
 class Context:

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -113,11 +113,7 @@ class TestWorkspace:
 class TestCustomFunction:
     def test_custom_function_with_parameters_ok(self, custom_function):
         new = custom_function.with_parameters(
-            p1=3.4,
-            p2=False,
-            p3='då',
-            p4='new string',
-            p5=4,
+            p1=3.4, p2=False, p3='då', p4='new string', p5=4,
         )
         assert new.parameter_values == {
             'p1': 3.4,
@@ -141,8 +137,7 @@ class TestCustomFunction:
         pytest.raises(ValueError, custom_function.with_parameters, p2='not a boolean')
 
     def test_custom_function_with_parameters_cannot_set_enumeration_type(
-        self,
-        custom_function,
+        self, custom_function,
     ):
         pytest.raises(ValueError, custom_function.with_parameters, p3=4.6)
 
@@ -152,8 +147,7 @@ class TestCustomFunction:
         pytest.raises(ValueError, custom_function.with_parameters, p4=4.6)
 
     def test_custom_function_with_parameters_cannot_set_enumeration_value(
-        self,
-        custom_function,
+        self, custom_function,
     ):
         pytest.raises(ValueError, custom_function.with_parameters, p3='not in values')
 
@@ -208,16 +202,14 @@ class TestModelExecutable:
     def test_compilation_running(self, fmu_compile_running):
         assert fmu_compile_running.info["run_info"]["status"] == "not_started"
         pytest.raises(
-            exceptions.OperationNotCompleteError,
-            fmu_compile_running.get_log,
+            exceptions.OperationNotCompleteError, fmu_compile_running.get_log,
         )
         pytest.raises(
             exceptions.OperationNotCompleteError,
             fmu_compile_running.get_settable_parameters,
         )
         pytest.raises(
-            exceptions.OperationNotCompleteError,
-            fmu_compile_running.is_successful,
+            exceptions.OperationNotCompleteError, fmu_compile_running.is_successful,
         )
 
     def test_compilation_failed(self, fmu_compile_failed):
@@ -232,12 +224,10 @@ class TestModelExecutable:
     def test_compilation_cancelled(self, fmu_compile_cancelled):
         assert fmu_compile_cancelled.info["run_info"]["status"] == "cancelled"
         pytest.raises(
-            exceptions.OperationFailureError,
-            fmu_compile_cancelled.is_successful,
+            exceptions.OperationFailureError, fmu_compile_cancelled.is_successful,
         )
         pytest.raises(
-            exceptions.OperationFailureError,
-            fmu_compile_cancelled.get_log,
+            exceptions.OperationFailureError, fmu_compile_cancelled.get_log,
         )
         pytest.raises(
             exceptions.OperationFailureError,
@@ -252,8 +242,8 @@ class TestModelExecutable:
             ),
         )
         config = experiment_definition.to_dict()
-        assert config['experiment']['fmu_id'] == fmu.id
-        assert config['experiment']['analysis']['simulation_options'] == {
+        assert config['experiment']['base']['model']['fmu']['id'] == fmu.id
+        assert config['experiment']['base']['analysis']['simulationOptions'] == {
             'ncp': 2000,
             'rtol': 0.1,
         }
@@ -300,8 +290,7 @@ class TestExperiment:
     def test_running_execution(self, running_experiment):
         assert running_experiment.info["run_info"]["status"] == "not_started"
         pytest.raises(
-            exceptions.OperationNotCompleteError,
-            running_experiment.get_variables,
+            exceptions.OperationNotCompleteError, running_experiment.get_variables,
         )
         pytest.raises(
             exceptions.OperationNotCompleteError,
@@ -327,12 +316,10 @@ class TestExperiment:
             "case_1", "Workspace", "Test"
         )
         pytest.raises(
-            exceptions.OperationFailureError,
-            cancelled_experiment.is_successful,
+            exceptions.OperationFailureError, cancelled_experiment.is_successful,
         )
         pytest.raises(
-            exceptions.OperationFailureError,
-            cancelled_experiment.get_variables,
+            exceptions.OperationFailureError, cancelled_experiment.get_variables,
         )
         pytest.raises(
             exceptions.OperationFailureError,
@@ -374,8 +361,7 @@ class TestCase:
         assert failed_case.info["run_info"]["status"] == "failed"
         assert not failed_case.is_successful()
         pytest.raises(
-            exceptions.OperationFailureError,
-            failed_case.get_result,
+            exceptions.OperationFailureError, failed_case.get_result,
         )
         assert failed_case.get_trajectories()["inertia.I"] == [1, 2, 3, 4]
 

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -1,28 +1,12 @@
-from modelon.impact.client import SimpleExperimentDefinition, Range
+from modelon.impact.client import (
+    SimpleExperimentDefinition,
+    Range,
+    SimpleExperimentExtension,
+)
 import pytest
 from modelon.impact.client import exceptions
 
 from tests.impact.client.fixtures import *
-
-
-def test_experiment_definition(fmu, custom_function_no_param):
-    definition = SimpleExperimentDefinition(
-        fmu, custom_function=custom_function_no_param
-    )
-    config = definition.to_dict()
-    assert config == {
-        "experiment": {
-            "analysis": {
-                "analysis_function": "dynamic",
-                "parameters": {},
-                "simulation_options": {"ncp": 500},
-                "solver_options": {},
-                "simulation_log_level": "WARNING",
-            },
-            "fmu_id": "Test",
-            "modifiers": {'variables': {}},
-        }
-    }
 
 
 def test_experiment_definition_default_options(fmu, custom_function_no_param):
@@ -32,15 +16,19 @@ def test_experiment_definition_default_options(fmu, custom_function_no_param):
     config = definition.to_dict()
     assert config == {
         "experiment": {
-            "analysis": {
-                "analysis_function": "dynamic",
-                "parameters": {},
-                "simulation_options": {"ncp": 500},
-                "solver_options": {},
-                "simulation_log_level": "WARNING",
+            "version": 2,
+            "base": {
+                "model": {"fmu": {"id": "Test"}},
+                "modifiers": {'variables': {}},
+                "analysis": {
+                    "type": "dynamic",
+                    "parameters": {},
+                    "simulationOptions": {"ncp": 500},
+                    "solverOptions": {},
+                    "simulationLogLevel": "WARNING",
+                },
             },
-            "fmu_id": "Test",
-            "modifiers": {'variables': {}},
+            "extensions": [],
         }
     }
 
@@ -55,23 +43,49 @@ def test_experiment_definition_with_options(fmu, custom_function_no_param):
         solver_options={'a': 1},
     )
     config = definition.to_dict()
-    assert config["experiment"]["analysis"]["simulation_options"] == {
+    assert config["experiment"]["base"]["analysis"]["simulationOptions"] == {
         "ncp": 2000,
         "rtol": 0.0001,
     }
-    assert config["experiment"]["analysis"]["solver_options"] == {"a": 1}
+    assert config["experiment"]["base"]["analysis"]["solverOptions"] == {"a": 1}
 
 
 def test_experiment_definition_with_modifier(fmu, custom_function_no_param):
     definition = SimpleExperimentDefinition(
-        fmu,
-        custom_function=custom_function_no_param,
+        fmu, custom_function=custom_function_no_param,
     ).with_modifiers({'h0': Range(0.1, 0.5, 3)}, v=1)
     config = definition.to_dict()
-    assert config["experiment"]["modifiers"]["variables"] == {
+    assert config["experiment"]["base"]["modifiers"]["variables"] == {
         'h0': 'range(0.1,0.5,3)',
         'v': 1,
     }
+
+
+def test_experiment_definition_with_extensions(fmu, custom_function_no_param):
+    ext1 = SimpleExperimentExtension().with_modifiers(p=2)
+    ext2 = SimpleExperimentExtension({'final_time': 10}).with_modifiers(p=3)
+    definition = SimpleExperimentDefinition(
+        fmu, custom_function=custom_function_no_param,
+    ).with_extensions([ext1, ext2])
+    config = definition.to_dict()
+    assert config["experiment"]["extensions"] == [
+        {"modifiers": {"variables": {"p": 2}}},
+        {
+            "modifiers": {"variables": {"p": 3}},
+            "analysis": {"parameters": {'final_time': 10},},
+        },
+    ]
+
+
+def test_experiment_definition_with_cases(fmu, custom_function_no_param):
+    definition = SimpleExperimentDefinition(
+        fmu, custom_function=custom_function_no_param,
+    ).with_cases([{'p': 2}, {'p': 3}])
+    config = definition.to_dict()
+    assert config["experiment"]["extensions"] == [
+        {"modifiers": {"variables": {"p": 2}}},
+        {"modifiers": {"variables": {"p": 3}}},
+    ]
 
 
 def test_failed_compile_exp_def(
@@ -114,3 +128,68 @@ def test_invalid_fmu_input(fmu, custom_function_no_param):
     pytest.raises(
         TypeError, SimpleExperimentDefinition, fmu, custom_function_no_param, "", ""
     )
+
+
+def test_experiment_extension_default_options():
+    ext = SimpleExperimentExtension()
+    config = ext.to_dict()
+    assert config == {}
+
+
+def test_experiment_extension_with_options(custom_function_no_param):
+    ext = SimpleExperimentExtension(
+        {'stop_time': 5},
+        {'a': 1},
+        custom_function_no_param.get_simulation_options().with_values(
+            ncp=2000, rtol=0.0001
+        ),
+    )
+    config = ext.to_dict()
+    assert config == {
+        "analysis": {
+            "parameters": {'stop_time': 5},
+            "simulationOptions": {'ncp': 2000, 'rtol': 0.0001},
+            "solverOptions": {'a': 1},
+        },
+    }
+
+
+def test_experiment_extension_with_modifiers():
+    ext = SimpleExperimentExtension().with_modifiers({'PI.k': 10}, P=5, d=15)
+    config = ext.to_dict()
+    assert config == {
+        "modifiers": {"variables": {'PI.k': 10, 'P': 5, 'd': 15}},
+    }
+
+
+def test_experiment_extension_with_range_modifier():
+    ext = SimpleExperimentExtension()
+    pytest.raises(ValueError, ext.with_modifiers, {'h0': Range(0.1, 0.5, 3)})
+
+
+def test_invalid_with_extensions_input(fmu, custom_function_no_param):
+    definition = SimpleExperimentDefinition(
+        fmu, custom_function=custom_function_no_param,
+    )
+    pytest.raises(TypeError, definition.with_extensions, {})
+
+
+def test_invalid_with_extensions_list_input(fmu, custom_function_no_param):
+    definition = SimpleExperimentDefinition(
+        fmu, custom_function=custom_function_no_param,
+    )
+    pytest.raises(TypeError, definition.with_extensions, [{}])
+
+
+def test_invalid_with_cases_input(fmu, custom_function_no_param):
+    definition = SimpleExperimentDefinition(
+        fmu, custom_function=custom_function_no_param,
+    )
+    pytest.raises(TypeError, definition.with_cases, {})
+
+
+def test_invalid_with_cases_list_input(fmu, custom_function_no_param):
+    definition = SimpleExperimentDefinition(
+        fmu, custom_function=custom_function_no_param,
+    )
+    pytest.raises(TypeError, definition.with_cases, [[]])


### PR DESCRIPTION
**Left To Do**
1. Update readTheDocs. Will be done in a separate PR if changes are approved.

**How to test**

Try to simulate the test below:-

```
from modelon.impact.client import Client
from modelon.impact.client.experiment_definition import SimpleExperimentExtension
import uuid

client = Client(url="http://localhost:8080/")
workspace = client.create_workspace(uuid.uuid4().hex)

# Choose analysis type
dynamic = workspace.get_custom_function('dynamic')

# Compile model
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")
fmu = model.compile(
    compiler_options=dynamic.get_compiler_options().with_values(
        generate_html_diagnostics=False
    )
).wait()

# Execute experiment
experiment_definition = fmu.new_experiment_definition(
    dynamic.with_parameters(start_time=0.0, final_time=2.0),
    simulation_options=dynamic.get_simulation_options().with_values(ncp=500),
    solver_options={'atol': 1e-8},
).with_modifiers({'inertia1.J': 2})

simulate_ext1 = SimpleExperimentExtension(
    {'final_time': 5}, {'atol': 1e-7}
).with_modifiers({'PI.k': 40})
simulate_ext2 = SimpleExperimentExtension().with_modifiers({'PI.k': 50})

experiment_definition = experiment_definition.with_extensions(
    [simulate_ext1, simulate_ext2]
)

# experiment_definition = experiment_definition.with_cases([{'PI.k': 20}, {'PI.k': 30}])

# Execute experiment
exp = workspace.execute(experiment_definition).wait()

 
```
@jacobtaxen , @modelon-magnus , @jpersson-modelon 