### PR TITLE
fix: Striping quotes from suggested filename

### DIFF
--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -248,7 +248,7 @@ class ExperimentService:
         ).resolve()
         result, headers = self._http_client.get_octet_stream(url)
         d = headers["content-disposition"]
-        file_name = re.findall("filename=(.+)", d)[0]
+        file_name = re.findall("filename=(.+)", d)[0].strip('"')
         return result, file_name
 
     def case_trajectories_get(self, workspace_id, experiment_id, case_id, variables):

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -37,9 +37,7 @@ def with_exception(mock_server_base, method, url, exce):
 
 def with_json_route_no_resp(mock_server_base, method, url, status_code=200):
     mock_server_base.adapter.register_uri(
-        method,
-        f'{mock_server_base.url}/{url}',
-        status_code=status_code,
+        method, f'{mock_server_base.url}/{url}', status_code=status_code,
     )
     return mock_server_base
 
@@ -71,18 +69,22 @@ def with_text_route(mock_server_base, method, url, text_response, status_code=20
 
 
 def with_octet_stream_route(
-    mock_server_base, method, url, octet_response, status_code=200
+    mock_server_base, method, url, octet_response, status_code=200, content_header=None
 ):
     content = octet_response
-    content_header = {
-        'content-type': 'application/octet-stream',
-        'content-disposition': 'attachment; '
-        'filename="BouncingBall_2020-09-01_14-33_case_1.mat"',
-        'connection': 'close',
-        'date': 'Tue, 01 Sep 2020 14:33:56 GMT',
-        'server': '127.0.0.1',
-        'Transfer-Encoding': 'chunked',
-    }
+    content_header = (
+        {
+            'content-type': 'application/octet-stream',
+            'content-disposition': 'attachment; '
+            'filename="BouncingBall_2020-09-01_14-33_case_1.mat"',
+            'connection': 'close',
+            'date': 'Tue, 01 Sep 2020 14:33:56 GMT',
+            'server': '127.0.0.1',
+            'Transfer-Encoding': 'chunked',
+        }
+        if content_header is None
+        else content_header
+    )
     mock_server_base.adapter.register_uri(
         method,
         f'{mock_server_base.url}/{url}',
@@ -510,6 +512,17 @@ def get_case_results(sem_ver_check, mock_server_base):
         'GET',
         'api/workspaces/WS/experiments/pid_2009/cases/case_1/result',
         binary,
+        content_header={
+            'X-Powered-By': 'Express',
+            'content-type': 'application/octet-stream',
+            'content-disposition': 'attachment; filename="Modelica.Blocks.Examples.PID_Controller_2020-10-22_06-03.csv"',
+            'connection': 'close',
+            'date': 'Thu, 22 Oct 2020 06:03:46 GMT',
+            'server': '127.0.0.1',
+            'Content-Length': '540',
+            'ETag': 'W/"21c-YYNaLhSng67+inxuWx+DHndUdno"',
+            'Vary': 'Accept-Encoding',
+        },
     )
 
 
@@ -650,11 +663,7 @@ def workspace_execute_running():
     ws_service.experiment_execute.return_value = 'test_exp'
     exp_service.experiment_execute.return_value = "pid_2009"
     exp_service.execute_status.return_value = {"status": "running"}
-    return Workspace(
-        'AwesomeWorkspace',
-        ws_service,
-        experiment_service=exp_service,
-    )
+    return Workspace('AwesomeWorkspace', ws_service, experiment_service=exp_service,)
 
 
 @pytest.fixture
@@ -665,11 +674,7 @@ def workspace_execute_cancelled():
     ws_service.experiment_execute.return_value = 'test_exp'
     exp_service.experiment_execute.return_value = "pid_2009"
     exp_service.execute_status.return_value = {"status": "cancelled"}
-    return Workspace(
-        'AwesomeWorkspace',
-        ws_service,
-        experiment_service=exp_service,
-    )
+    return Workspace('AwesomeWorkspace', ws_service, experiment_service=exp_service,)
 
 
 @pytest.fixture

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -238,9 +238,7 @@ class TestExperimentService:
             "finished_executions": 1,
             "total_executions": 2,
             "status": "running",
-            "progress": [
-                {"message": "Simulating at 1.0", "percentage": 1},
-            ],
+            "progress": [{"message": "Simulating at 1.0", "percentage": 1},],
         }
 
     def test_cancel_execute(self, cancel_execute):
@@ -300,6 +298,7 @@ class TestExperimentService:
         )
         data, name = service.experiment.case_result_get("WS", "pid_2009", "case_1")
         assert data == b'\x00\x00\x00\x00'
+        assert name == 'Modelica.Blocks.Examples.PID_Controller_2020-10-22_06-03.csv'
 
     def test_case_get_trajectories(self, get_case_trajectories):
         uri = modelon.impact.client.sal.service.URI(get_case_trajectories.url)


### PR DESCRIPTION
This PR fixes a bug where an additional set of quotes were added to the result file_name returned by the **get_result()** function.

**How to test**

```
from modelon.impact.client import Client
import uuid

client = Client(url="http://localhost:8080/")
workspace = client.create_workspace(uuid.uuid4().hex)

# Choose analysis type
linearize = workspace.get_custom_function('dynamic')

# Compile model
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")
fmu = model.compile(compiler_options=linearize.get_compiler_options()).wait()

# Execute experiment
experiment_definition = fmu.new_experiment_definition(linearize)

# Execute experiment
exp = workspace.execute(experiment_definition).wait()
case = exp.get_case('case_1')

result, file_name = case.get_result()

with open(file_name, "wb") as f:
    f.write(result)

```
@jacobtaxen 