### PR TITLE
fix: Resolves missing docs for client module

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx_copybutton
+semantic-version


### PR DESCRIPTION
ReadTheDocs failed to generate docs for https://modelon-impact-client.readthedocs.io/en/beta/modelon.impact.client.html#modelon-impact-client-client-module due to an import failure for semanticversion package. Unfortunately we can't use the toml file to generate specify dependencies while generating docs.