### PR TITLE
feat: Added support for fetching fmus executed for a case

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1488,7 +1488,7 @@ class Case:
             fmu = case.get_fmu(fmu_id)
             fmus = set(case.get_fmu() for case in exp.get_cases())
         """
-        fmu_id = self.info['input']['fmu_id']
+        fmu_id = self.info["input"]["fmu_id"]
 
         return ModelExecutable(
             self._workspace_id, fmu_id, self._workspace_sal, self._model_exe_sal

--- a/modelon/impact/client/experiment_definition.py
+++ b/modelon/impact/client/experiment_definition.py
@@ -525,7 +525,7 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
 
     def validate(self):
         raise NotImplementedError(
-            'Validation is not supported for SimpleModelicaExperimentDefinition class'
+            "Validation is not supported for SimpleModelicaExperimentDefinition class"
         )
 
     def with_modifiers(self, modifiers=None):

--- a/modelon/impact/client/operations.py
+++ b/modelon/impact/client/operations.py
@@ -321,12 +321,18 @@ class ExperimentOperation(Operation):
     """
 
     def __init__(
-        self, workspace_id, exp_id, workspace_service=None, exp_service=None,
+        self,
+        workspace_id,
+        exp_id,
+        workspace_service=None,
+        model_exe_service=None,
+        exp_service=None,
     ):
         super().__init__()
         self._workspace_id = workspace_id
         self._exp_id = exp_id
         self._workspace_sal = workspace_service
+        self._model_exe_sal = model_exe_service
         self._exp_sal = exp_service
 
     def __repr__(self):
@@ -355,7 +361,11 @@ class ExperimentOperation(Operation):
                 An experiment class instance.
         """
         return entities.Experiment(
-            self._workspace_id, self._exp_id, self._workspace_sal, self._exp_sal
+            self._workspace_id,
+            self._exp_id,
+            self._workspace_sal,
+            self._model_exe_sal,
+            self._exp_sal,
         )
 
     def status(self):

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -1018,6 +1018,7 @@ def fmu_compile_cancelled():
 @pytest.fixture
 def experiment():
     ws_service = unittest.mock.MagicMock()
+    model_exe_service = unittest.mock.MagicMock()
     exp_service = unittest.mock.MagicMock()
     ws_service.experiment_get.return_value = {
         "run_info": {"status": "done", "failed": 0, "successful": 1, "cancelled": 0}
@@ -1028,13 +1029,16 @@ def experiment():
     exp_service.case_get.return_value = {
         "id": "case_1",
         "run_info": {"status": "successful"},
+        "input": {
+            "fmu_id": "modelica_fluid_examples_heatingsystem_20210130_114628_bbd91f1"
+        },
     }
     exp_service.case_get_log.return_value = "Successful Log"
     exp_service.case_result_get.return_value = (bytes(4), 'result.mat')
     exp_service.case_artifact_get.return_value = (bytes(4), 'result.mat')
     exp_service.trajectories_get.return_value = [[[1, 2, 3, 4]], [[5, 2, 9, 4]]]
     exp_service.case_trajectories_get.return_value = [[1, 2, 3, 4], [5, 2, 9, 4]]
-    return Experiment("Workspace", "Test", ws_service, exp_service)
+    return Experiment("Workspace", "Test", ws_service, model_exe_service, exp_service)
 
 
 @pytest.fixture
@@ -1061,7 +1065,7 @@ def batch_experiment():
         [[5, 2, 9, 4], [11, 22, 32, 44]],
     ]
     exp_service.case_trajectories_get.return_value = [[14, 4, 4, 74], [11, 22, 32, 44]]
-    return Experiment("Workspace", "Test", ws_service, exp_service)
+    return Experiment("Workspace", "Test", ws_service, exp_service=exp_service)
 
 
 @pytest.fixture
@@ -1070,7 +1074,7 @@ def running_experiment():
     exp_service = unittest.mock.MagicMock()
     ws_service.experiment_get.return_value = {"run_info": {"status": "not_started"}}
     exp_service.execute_status.return_value = {"status": "running"}
-    return Experiment("Workspace", "Test", ws_service, exp_service)
+    return Experiment("Workspace", "Test", ws_service, exp_service=exp_service)
 
 
 @pytest.fixture
@@ -1089,7 +1093,7 @@ def failed_experiment():
     exp_service.result_variables_get.return_value = ["inertia.I", "time"]
     exp_service.trajectories_get.return_value = [[[1, 2, 3, 4]], [[5, 2, 9, 4]]]
     exp_service.case_trajectories_get.return_value = [[1, 2, 3, 4], [5, 2, 9, 4]]
-    return Experiment("Workspace", "Test", ws_service, exp_service)
+    return Experiment("Workspace", "Test", ws_service, exp_service=exp_service)
 
 
 @pytest.fixture
@@ -1107,4 +1111,5 @@ def cancelled_experiment():
     exp_service.cases_get.return_value = {"data": {"items": [{"id": "case_1"}]}}
     exp_service.case_get.return_value = {"id": "case_1"}
     exp_service.execute_status.return_value = {"status": "cancelled"}
-    return Experiment("Workspace", "Test", ws_service, exp_service)
+    return Experiment("Workspace", "Test", ws_service, exp_service=exp_service)
+

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -376,6 +376,8 @@ class TestCase:
         assert (artifact, name) == (b'\x00\x00\x00\x00', 'result.mat')
         assert case.is_successful()
         assert case.get_trajectories()['inertia.I'] == [1, 2, 3, 4]
+        fmu = case.get_fmu()
+        assert fmu.id == "modelica_fluid_examples_heatingsystem_20210130_114628_bbd91f1"
 
     def test_multiple_cases(self, batch_experiment):
         case = batch_experiment.get_case("case_2")


### PR DESCRIPTION
This PR adds support to fetch FMU's executed in each case
```
from modelon.impact.client import Client, Choices, Range

client = Client()
workspace = client.create_workspace("Hye12")

# Choose analysis type
dynamic = workspace.get_custom_function("dynamic")

# Compile model
model = workspace.get_model("Modelica.Fluid.Examples.HeatingSystem")

# Execute experiment
experiment_definition = model.new_experiment_definition(dynamic).with_modifiers(
    {'pipe.nNodes': Choices(2, 3)}
)
print(experiment_definition.to_dict())
exp = workspace.execute(experiment_definition).wait()
print(exp.is_successful())
case = exp.get_case('case_1')
fmu = case.get_fmu()
print(fmu.id)
case = exp.get_case('case_2')
fmu = case.get_fmu()
print(fmu.id)
```