### PR TITLE
Handle experiments that fail and some minor fixes

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -85,6 +85,7 @@ class ExperimentStatus(Enum):
     NOTSTARTED = "not_started"
     CANCELLED = "cancelled"
     DONE = "done"
+    FAILED = "failed"
 
 
 class CaseStatus(Enum):
@@ -1118,8 +1119,9 @@ class ModelExecutable:
 
 
 class _ExperimentRunInfo:
-    def __init__(self, status, failed, successful, cancelled):
+    def __init__(self, status, errors, failed, successful, cancelled):
         self._status = status
+        self._errors = errors
         self._failed = failed
         self._successful = successful
         self._cancelled = cancelled
@@ -1128,6 +1130,11 @@ class _ExperimentRunInfo:
     def status(self):
         """Status info for an Experiment"""
         return self._status
+
+    @property
+    def errors(self):
+        """A list of errors. Is empty unless 'status' attribute is 'FAILED'"""
+        return self._errors
 
     @property
     def successful(self):
@@ -1191,10 +1198,11 @@ class Experiment:
         run_info = self._get_info()["run_info"]
 
         status = ExperimentStatus(run_info["status"])
+        errors = run_info.get("errors", [])
         failed = run_info.get("failed", 0)
         successful = run_info.get("successful", 0)
         cancelled = run_info.get("cancelled", 0)
-        return _ExperimentRunInfo(status, failed, successful, cancelled)
+        return _ExperimentRunInfo(status, errors, failed, successful, cancelled)
 
     @property
     def info(self):

--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -676,7 +676,7 @@ class Model:
         self._model_exe_sal = model_exe_service
 
     def __repr__(self):
-        return f"Class name '{self.class_name}'"
+        return f"Class name '{self._class_name}'"
 
     def __eq__(self, obj):
         return isinstance(obj, Model) and obj._class_name == self._class_name

--- a/modelon/impact/client/operations.py
+++ b/modelon/impact/client/operations.py
@@ -107,16 +107,18 @@ class Operation(ABC):
         start_t = time.time()
         while True:
             logger.info(f"{self.name} in progress! Status : {self.status().name}")
-            time.sleep(0.5)
             if self.status() == status:
                 logger.info(f"{self.name} completed! Status : {self.status().name}")
                 return self.data()
+
             current_t = time.time()
             if timeout and current_t - start_t > timeout:
                 raise exceptions.OperationTimeOutError(
                     f"Time exceeded the set timeout - {timeout}s! "
                     f"Present status of operation is {self.status().name}!"
                 )
+
+            time.sleep(0.5)
 
 
 class ModelExecutableOperation(Operation):

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -1078,7 +1078,7 @@ def running_experiment():
 
 
 @pytest.fixture
-def failed_experiment():
+def experiment_with_failed_case():
     ws_service = unittest.mock.MagicMock()
     exp_service = unittest.mock.MagicMock()
     ws_service.experiment_get.return_value = {

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -1097,6 +1097,19 @@ def experiment_with_failed_case():
 
 
 @pytest.fixture
+def failed_experiment():
+    ws_service = unittest.mock.MagicMock()
+    exp_service = unittest.mock.MagicMock()
+    ws_service.experiment_get.return_value = {
+        "run_info": {"status": "failed", "failed": 0, "successful": 0, "cancelled": 0, 'errors': ['out of licenses', 'too large experiment']}
+    }
+    exp_service.execute_status.return_value = {"status": "done"}
+    exp_service.cases_get.return_value = {"data": {"items": []}}
+    exp_service.case_get.return_value = {}
+    return Experiment("Workspace", "Test", ws_service, exp_service)
+
+
+@pytest.fixture
 def cancelled_experiment():
     ws_service = unittest.mock.MagicMock()
     exp_service = unittest.mock.MagicMock()

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -273,6 +273,7 @@ class TestExperiment:
         assert experiment.id == "Test"
         assert experiment.is_successful()
         assert experiment.run_info.status == ExperimentStatus.DONE
+        assert experiment.run_info.errors == []
         assert experiment.run_info.failed == 0
         assert experiment.run_info.successful == 1
         assert experiment.run_info.cancelled == 0
@@ -308,6 +309,11 @@ class TestExperiment:
             running_experiment.get_trajectories,
             ['inertia.I'],
         )
+
+    def test_failed_execution(self, failed_experiment):
+        assert failed_experiment.run_info.status == ExperimentStatus.FAILED
+        assert failed_experiment.is_successful() == False
+        assert failed_experiment.run_info.errors == ['out of licenses', 'too large experiment']
 
     def test_execution_with_failed_cases(self, experiment_with_failed_case):
         assert experiment_with_failed_case.run_info.status == ExperimentStatus.DONE

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -80,6 +80,10 @@ class TestWorkspace:
         model = workspace.get_model("Modelica.Blocks.PID")
         assert model == Model("Modelica.Blocks.PID", workspace.id)
 
+    def test_model_repr(self, workspace):
+        model = Model("Modelica.Blocks.PID", workspace.id)
+        assert "Class name 'Modelica.Blocks.PID'" == model.__repr__()
+
     def test_get_fmus(self, workspace):
         fmus = workspace.get_fmus()
         assert fmus == [


### PR DESCRIPTION
This PR was for fixing 2 issues. The first was that the `__repr__` method for Model was broken. The second was that the new Experiment Status that the API can return was not taken care of. While doing this, I felt the need to refactor how the 'info' and 'is_successful' methods work to make sure that the user gets a good experience.

### How to test:
For the first it is enough to run something like:
`workspace.get_model('asdfasdf')`
in a Python shell.

For the second I recommend sending a too large experiment and see that is_successful returns False and that run_info.errors show something reasonable.