### PR TITLE
fix: correct docs on model.new_experiment_definition

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -219,8 +219,11 @@ They can be set in a way similar to the compiler_options::
 
    simulation_options = dynamic.get_simulation_options().with_values(ncp=500)
    solver_options = {'atol':1e-8}
-   experiment_definition = model.new_experiment_definition(dynamic.with_parameters(start_time=0.0, final_time=2.0),
-   solver_options, simulation_options)
+   experiment_definition = model.new_experiment_definition(
+       dynamic.with_parameters(start_time=0.0, final_time=2.0),
+       solver_options=solver_options,
+       simulation_options=simulation_options
+   )
 
 
 Setting up a series of simulations

--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -813,6 +813,7 @@ class Model:
     def new_experiment_definition(
         self,
         custom_function,
+        *,
         compiler_options=None,
         fmi_target="me",
         fmi_version="2.0",
@@ -886,8 +887,10 @@ class Model:
             simulation_options = dynamic.get_simulation_options().
             with_values(ncp=500)
             experiment_definition = model.new_experiment_definition(
-                dynamic, solver_options=solver_options,
-                simulation_options=simulation_options)
+                dynamic,
+                solver_options=solver_options,
+                simulation_options=simulation_options
+            )
             experiment = workspace.execute(experiment_definition).wait()
         """
         return SimpleModelicaExperimentDefinition(

--- a/modelon/impact/client/experiment_definition.py
+++ b/modelon/impact/client/experiment_definition.py
@@ -486,6 +486,7 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
         self,
         model,
         custom_function,
+        *,
         compiler_options=None,
         fmi_target="me",
         fmi_version="2.0",

--- a/modelon/impact/client/experiment_definition.py
+++ b/modelon/impact/client/experiment_definition.py
@@ -474,8 +474,11 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
         simulation_options = custom_function.get_simulation_options()
         .with_values(ncp=500)
         solver_options = {'atol':1e-8}
-        simulate_def = model.new_experiment_definition(custom_function,
-        solver_options, simulation_options)
+        simulate_def = model.new_experiment_definition(
+            custom_function,
+            solver_options=solver_options,
+            simulation_options=simulation_options
+        )
         simulate_def.to_dict()
     """
 
@@ -661,8 +664,11 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
             simulation_options = custom_function.get_simulation_options()
                 .with_values(ncp=500)
             solver_options = {'atol':1e-8}
-            simulate_def = model.new_experiment_definition(custom_function,
-            solver_options, simulation_options)
+            simulate_def = model.new_experiment_definition(
+                custom_function,
+                solver_options=solver_options,
+                simulation_options=simulation_options
+            )
             simulate_def.to_dict()
         """
 
@@ -735,8 +741,11 @@ class SimpleExperimentExtension(BaseExperimentExtension):
         simulation_options = custom_function.get_simulation_options()
         .with_values(ncp=500)
         solver_options = {'atol':1e-8}
-        simulate_def = fmu.new_experiment_definition(custom_function,
-        solver_options, simulation_options).with_modifiers({'inertia1.J': 2})
+        simulate_def = fmu.new_experiment_definition(
+            custom_function,
+            solver_options=solver_options,
+            simulation_options=simulation_options
+        ).with_modifiers({'inertia1.J': 2})
         simulate_ext = SimpleExperimentExtension(
         {'start_time': 0.0, 'final_time': 4.0},
         solver_options,


### PR DESCRIPTION
Following the previous documentation would give you a very hard to decipher error message. 

I have also added a ,*, in the model.new_experiment_definition signature to enforce the keywords, so that you have to set the arguments as keyword args. 

(Also a lot of trailing whitespaces have been removed)