### PR TITLE
fix: exmple creating set of all FMUs does now works

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -951,6 +951,9 @@ class ModelExecutable:
     def __eq__(self, obj):
         return isinstance(obj, ModelExecutable) and obj._fmu_id == self._fmu_id
 
+    def __hash__(self) -> int:
+        return self._fmu_id.__hash__()
+
     @property
     def id(self):
         """FMU id"""

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -272,6 +272,10 @@ class TestModelExecutable:
         resp = fmu.download()
         assert resp == t
 
+    def test_can_be_put_uniquely_in_set(self, fmu):
+        fmu_set = set([fmu, fmu])
+        assert len(fmu_set) == 1
+
 
 class TestExperiment:
     def test_execute_successful(self, experiment):


### PR DESCRIPTION
The code example in the documentation:
```
# Getting a set of simulated FMU objects from the cases
fmus = set(case.get_fmu() for case in exp.get_cases())
```
did not work because the fmu entity was not hashable.