### PR TITLE
feat: Added API support for deleting fmus and experiments

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1027,6 +1027,15 @@ class ModelExecutable:
         _assert_is_complete(self.run_info.status, "Compilation")
         return Log(self._model_exe_sal.compile_log(self._workspace_id, self._fmu_id))
 
+    def delete(self):
+        """Deletes an FMU.
+
+        Example::
+
+            fmu.delete()
+        """
+        self._model_exe_sal.fmu_delete(self._workspace_id, self._fmu_id)
+
     def get_settable_parameters(self):
         """
         Returns a list of settable parameters for the FMU.
@@ -1360,6 +1369,15 @@ class Experiment:
             }
             for j in case_nbrs
         }
+
+    def delete(self):
+        """Deletes an experiment.
+
+        Example::
+
+            experiment.delete()
+        """
+        self._exp_sal.experiment_delete(self._workspace_id, self._exp_id)
 
 
 class _CaseRunInfo:

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -151,6 +151,12 @@ class ModelExecutableService:
         ).resolve()
         return self._http_client.get_text(url)
 
+    def fmu_delete(self, workspace_id, fmu_id):
+        url = (
+            self._base_uri / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}"
+        ).resolve()
+        self._http_client.delete_json(url)
+
     def compile_status(self, workspace_id, fmu_id):
         url = (
             self._base_uri
@@ -193,6 +199,12 @@ class ExperimentService:
         ).resolve()
         self._http_client.post_json_no_response_body(url)
         return exp_id
+
+    def experiment_delete(self, workspace_id, exp_id):
+        url = (
+            self._base_uri / f"api/workspaces/{workspace_id}/experiments/{exp_id}"
+        ).resolve()
+        self._http_client.delete_json(url)
 
     def execute_status(self, workspace_id, experiment_id):
         url = (

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -444,10 +444,26 @@ def get_ss_fmu_metadata(sem_ver_check, mock_server_base):
 
 
 @pytest.fixture
+def delete_fmu(sem_ver_check, mock_server_base):
+
+    return with_json_route_no_resp(
+        mock_server_base, 'DELETE', 'api/workspaces/WS/model-executables/fmu_id'
+    )
+
+
+@pytest.fixture
 def experiment_execute(sem_ver_check, mock_server_base):
 
     return with_json_route_no_resp(
         mock_server_base, 'POST', 'api/workspaces/WS/experiments/pid_2009/execution'
+    )
+
+
+@pytest.fixture
+def delete_experiment(sem_ver_check, mock_server_base):
+
+    return with_json_route_no_resp(
+        mock_server_base, 'DELETE', 'api/workspaces/WS/experiments/pid_2009'
     )
 
 
@@ -1101,7 +1117,13 @@ def failed_experiment():
     ws_service = unittest.mock.MagicMock()
     exp_service = unittest.mock.MagicMock()
     ws_service.experiment_get.return_value = {
-        "run_info": {"status": "failed", "failed": 0, "successful": 0, "cancelled": 0, 'errors': ['out of licenses', 'too large experiment']}
+        "run_info": {
+            "status": "failed",
+            "failed": 0,
+            "successful": 0,
+            "cancelled": 0,
+            'errors': ['out of licenses', 'too large experiment'],
+        }
     }
     exp_service.execute_status.return_value = {"status": "done"}
     exp_service.cases_get.return_value = {"data": {"items": []}}
@@ -1125,4 +1147,3 @@ def cancelled_experiment():
     exp_service.case_get.return_value = {"id": "case_1"}
     exp_service.execute_status.return_value = {"status": "cancelled"}
     return Experiment("Workspace", "Test", ws_service, exp_service=exp_service)
-

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -258,6 +258,14 @@ class TestModelExecutbleService:
             }
         }
 
+    def test_delete_fmu(self, delete_fmu):
+        uri = modelon.impact.client.sal.service.URI(delete_fmu.url)
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri, context=delete_fmu.context
+        )
+        service.model_executable.fmu_delete('WS', "fmu_id")
+        assert delete_fmu.adapter.called
+
 
 class TestExperimentService:
     def test_model_execute(self, experiment_execute):
@@ -267,6 +275,14 @@ class TestExperimentService:
         )
         service.experiment.experiment_execute("WS", "pid_2009")
         assert experiment_execute.adapter.called
+
+    def test_delete_experiment(self, delete_experiment):
+        uri = modelon.impact.client.sal.service.URI(delete_experiment.url)
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri, context=delete_experiment.context
+        )
+        service.experiment.experiment_delete("WS", "pid_2009")
+        assert delete_experiment.adapter.called
 
     def test_get_experiment_status(self, experiment_status):
         uri = modelon.impact.client.sal.service.URI(experiment_status.url)
@@ -278,7 +294,7 @@ class TestExperimentService:
             "finished_executions": 1,
             "total_executions": 2,
             "status": "running",
-            "progress": [{"message": "Simulating at 1.0", "percentage": 1},],
+            "progress": [{"message": "Simulating at 1.0", "percentage": 1}],
         }
 
     def test_cancel_execute(self, cancel_execute):


### PR DESCRIPTION
WAMS: https://modelonproducts.atlassian.net/browse/WAMS-8272

**Key changes**
1. Add delete methods to the Experiment and ModelExecutable enteties. 
2. Add unit tests validating that the correct http call will be done when delete method is called.

**How to test**
```
from modelon.impact.client import Client
import time

client = Client(url="http://127.0.0.1:8080")
workspace = client.create_workspace("Test123")

# Choose analysis type
dynamic = workspace.get_custom_function('dynamic')

# Compile model
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")
fmu = model.compile(compiler_options=dynamic.get_compiler_options()).wait()
time.sleep(1)
#fmu.delete()

# Execute experiment
experiment_definition = fmu.new_experiment_definition(dynamic)
exp = workspace.execute(experiment_definition).wait()
time.sleep(1)
exp.delete()
```