### PR TITLE
feat: Support for executing a created experiment

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1228,6 +1228,30 @@ class Experiment:
         logger.warning("This attribute is deprectated, use 'run_info' instead")
         return self._get_info()
 
+    def execute(self):
+        """Exceutes an experiment.
+        Returns an modelon.impact.client.operations.ExperimentOperation class object.
+
+        Returns:
+
+            experiment_ops --
+                An modelon.impact.client.operations.ExperimentOperation class object.
+
+        Example::
+            experiment = workspace.create_experiment(experiment_definition)
+            experiment_ops = experiment.execute()
+            experiment_ops.cancel()
+            experiment_ops.status()
+            experiment_ops.wait()
+        """
+        return operations.ExperimentOperation(
+            self._workspace_id,
+            self._exp_sal.experiment_execute(self._workspace_id, self._exp_id),
+            self._workspace_sal,
+            self._model_exe_sal,
+            self._exp_sal,
+        )
+
     def is_successful(self):
         """
         Returns True if the Experiment has executed successfully.

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -688,7 +688,6 @@ def workspace():
     custom_function_service = unittest.mock.MagicMock()
     exp_service = unittest.mock.MagicMock()
     ws_service.experiment_create.return_value = {"experiment_id": "pid_2009"}
-    ws_service.experiment_execute.return_value = 'test_exp'
     ws_service.library_import.return_value = {
         "name": "Single",
         "uses": {"Modelica": {"version": "3.2.2"}},
@@ -729,7 +728,6 @@ def workspace_execute_running():
     ws_service = unittest.mock.MagicMock()
     exp_service = unittest.mock.MagicMock()
     ws_service.experiment_create.return_value = {"experiment_id": "pid_2009"}
-    ws_service.experiment_execute.return_value = 'test_exp'
     exp_service.experiment_execute.return_value = "pid_2009"
     exp_service.execute_status.return_value = {"status": "running"}
     return Workspace('AwesomeWorkspace', ws_service, experiment_service=exp_service)
@@ -740,7 +738,6 @@ def workspace_execute_cancelled():
     ws_service = unittest.mock.MagicMock()
     exp_service = unittest.mock.MagicMock()
     ws_service.experiment_create.return_value = {"experiment_id": "pid_2009"}
-    ws_service.experiment_execute.return_value = 'test_exp'
     exp_service.experiment_execute.return_value = "pid_2009"
     exp_service.execute_status.return_value = {"status": "cancelled"}
     return Workspace('AwesomeWorkspace', ws_service, experiment_service=exp_service)
@@ -1039,6 +1036,7 @@ def experiment():
     ws_service.experiment_get.return_value = {
         "run_info": {"status": "done", "failed": 0, "successful": 1, "cancelled": 0}
     }
+    exp_service.experiment_execute.return_value = "pid_2009"
     exp_service.execute_status.return_value = {"status": "done"}
     exp_service.result_variables_get.return_value = ["inertia.I", "time"]
     exp_service.cases_get.return_value = {"data": {"items": [{"id": "case_1"}]}}

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -278,6 +278,10 @@ class TestModelExecutable:
 
 
 class TestExperiment:
+    def test_execute(self, experiment):
+        exp = experiment.execute()
+        assert exp == ExperimentOperation('AwesomeWorkspace', 'pid_2009')
+
     def test_execute_successful(self, experiment):
         assert experiment.id == "Test"
         assert experiment.is_successful()
@@ -322,11 +326,16 @@ class TestExperiment:
     def test_failed_execution(self, failed_experiment):
         assert failed_experiment.run_info.status == ExperimentStatus.FAILED
         assert failed_experiment.is_successful() == False
-        assert failed_experiment.run_info.errors == ['out of licenses', 'too large experiment']
+        assert failed_experiment.run_info.errors == [
+            'out of licenses',
+            'too large experiment',
+        ]
 
     def test_execution_with_failed_cases(self, experiment_with_failed_case):
         assert experiment_with_failed_case.run_info.status == ExperimentStatus.DONE
-        assert experiment_with_failed_case.get_cases() == [Case("case_1", "Workspace", "Test")]
+        assert experiment_with_failed_case.get_cases() == [
+            Case("case_1", "Workspace", "Test")
+        ]
         assert experiment_with_failed_case.get_case("case_1") == Case(
             "case_1", "Workspace", "Test"
         )


### PR DESCRIPTION
Should be possible to execute the following workflow now :-
```
from modelon.impact.client import Client, Range

client = Client(url="http://127.0.0.1:8080")
workspace = client.create_workspace("Case174")

# Choose analysis type
dynamic = workspace.get_custom_function('dynamic')

# Get model class
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")

# Execute experiment
experiment_definition = model.new_experiment_definition(
    dynamic.with_parameters(start_time=0.0, final_time=2.0),
    simulation_options=dynamic.get_simulation_options().with_values(ncp=500),
    solver_options={'atol': 1e-8},
).with_modifiers({'inertia1.J': 2, 'PI.k': Range(10, 100, 5)})
experiment = workspace.create_experiment(experiment_definition)
result = experiment.execute().wait()
```