### PR TITLE
Case filter

### DIFF
--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -192,12 +192,13 @@ class ExperimentService:
         self._base_uri = uri
         self._http_client = HTTPClient
 
-    def experiment_execute(self, workspace_id, exp_id):
+    def experiment_execute(self, workspace_id, exp_id, case_ids=None):
+        body = {"includeCases": {"ids": case_ids}} if case_ids is not None else None
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{exp_id}/execution"
         ).resolve()
-        self._http_client.post_json_no_response_body(url)
+        self._http_client.post_json_no_response_body(url, body=body)
         return exp_id
 
     def experiment_delete(self, workspace_id, exp_id):

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -1056,6 +1056,42 @@ def experiment():
 
 
 @pytest.fixture
+def batch_experiment_with_case_filter():
+    ws_service = unittest.mock.MagicMock()
+    model_exe_service = unittest.mock.MagicMock()
+    exp_service = unittest.mock.MagicMock()
+    ws_service.experiment_get.return_value = {
+        "run_info": {
+            "status": "done",
+            "failed": 0,
+            "successful": 1,
+            "cancelled": 0,
+            "not_started": 3,
+        }
+    }
+    exp_service.experiment_execute.return_value = "pid_2009"
+    exp_service.execute_status.return_value = {"status": "done"}
+    exp_service.cases_get.return_value = {
+        "data": {
+            "items": [
+                {"id": "case_1"},
+                {"id": "case_2"},
+                {"id": "case_3"},
+                {"id": "case_4"},
+            ]
+        }
+    }
+    exp_service.case_get.return_value = {
+        "id": "case_3",
+        "run_info": {"status": "successful"},
+        "input": {
+            "fmu_id": "modelica_fluid_examples_heatingsystem_20210130_114628_bbd91f1"
+        },
+    }
+    ExperimentWithService = collections.namedtuple('ExperimentWithService', ['experiment', 'exp_service'])
+    return ExperimentWithService(Experiment("Workspace", "Test", ws_service, model_exe_service, exp_service), exp_service)
+
+@pytest.fixture
 def batch_experiment():
     ws_service = unittest.mock.MagicMock()
     exp_service = unittest.mock.MagicMock()

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -276,6 +276,17 @@ class TestExperimentService:
         service.experiment.experiment_execute("WS", "pid_2009")
         assert experiment_execute.adapter.called
 
+    def test_model_execute_with_case_filter(self, experiment_execute):
+        uri = modelon.impact.client.sal.service.URI(experiment_execute.url)
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri, context=experiment_execute.context
+        )
+        service.experiment.experiment_execute("WS", "pid_2009", case_ids=['case_1'])
+        assert experiment_execute.adapter.called
+        assert experiment_execute.adapter.request_history[0].json() == {
+            'includeCases': {'ids': ['case_1']}
+        }
+
     def test_delete_experiment(self, delete_experiment):
         uri = modelon.impact.client.sal.service.URI(delete_experiment.url)
         service = modelon.impact.client.sal.service.Service(


### PR DESCRIPTION
The following workflow should now work ->
```
from modelon.impact.client import Client, Range

client = Client(url="http://127.0.0.1:8080")
workspace = client.create_workspace("filter")

# Choose analysis type
dynamic = workspace.get_custom_function('dynamic')

# Get model class
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")

# Execute experiment
experiment_definition = model.new_experiment_definition(
    dynamic.with_parameters(start_time=0.0, final_time=2.0),
    simulation_options=dynamic.get_simulation_options().with_values(ncp=500),
    solver_options={'atol': 1e-8},
).with_modifiers({'inertia1.J': 2, 'PI.k': Range(102, 103, 5)})
experiment = workspace.create_experiment(experiment_definition)
case_generation = experiment.execute(with_cases=[]).wait()
case_3 = case_generation.get_cases()[2]
result = experiment.execute(with_cases=[case_3]).wait()
```