### PR TITLE
feat: Added support to update and execute cases

### DIFF
--- a/modelon/impact/client/operations.py
+++ b/modelon/impact/client/operations.py
@@ -398,3 +398,89 @@ class ExperimentOperation(Operation):
             workspace.execute(definition).cancel()
         """
         self._exp_sal.execute_cancel(self._workspace_id, self._exp_id)
+
+
+class CaseOperation(Operation):
+    """
+    An operation class for the modelon.impact.client.entities.Case class.
+    """
+
+    def __init__(
+        self,
+        workspace_id,
+        exp_id,
+        case_id,
+        workspace_service=None,
+        model_exe_service=None,
+        exp_service=None,
+    ):
+        super().__init__()
+        self._workspace_id = workspace_id
+        self._exp_id = exp_id
+        self._case_id = case_id
+        self._workspace_sal = workspace_service
+        self._model_exe_sal = model_exe_service
+        self._exp_sal = exp_service
+
+    def __repr__(self):
+        return f"Case operation for id '{self._case_id}'"
+
+    def __eq__(self, obj):
+        return isinstance(obj, CaseOperation) and obj._case_id == self._case_id
+
+    @property
+    def id(self):
+        """Case id"""
+        return self._case_id
+
+    @property
+    def name(self):
+        """Return the name of operation"""
+        return "Execution"
+
+    def data(self):
+        """
+        Returns a new Case class instance.
+
+        Returns:
+
+            experiment --
+                An Case class instance.
+        """
+        return entities.Case(
+            self._case_id,
+            self._workspace_id,
+            self._exp_id,
+            self._workspace_sal,
+            self._model_exe_sal,
+            self._exp_sal,
+        )
+
+    def status(self):
+        """
+        Returns the execution status as an enumeration.
+
+        Returns:
+
+            status --
+                The execution status enum. The status can have the enum values
+                Status.PENDING, Status.RUNNING, Status.STOPPING, Status.CANCELLED
+                or Status.DONE
+
+        Example::
+
+            case.execute().status()
+        """
+        return Status(
+            self._exp_sal.execute_status(self._workspace_id, self._exp_id)["status"]
+        )
+
+    def cancel(self):
+        """
+        Terminates the execution process.
+
+        Example::
+
+            case.execute().cancel()
+        """
+        self._exp_sal.execute_cancel(self._workspace_id, self._exp_id)

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -251,6 +251,14 @@ class ExperimentService:
         ).resolve()
         return self._http_client.get_json(url)
 
+    def case_put(self, workspace_id, experiment_id, case_id, case_data):
+        url = (
+            self._base_uri
+            / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"
+            f"{case_id}"
+        ).resolve()
+        return self._http_client.put_json(url, body=case_data)
+
     def case_get_log(self, workspace_id, experiment_id, case_id):
         url = (
             self._base_uri
@@ -368,6 +376,9 @@ class HTTPClient:
     def delete_json(self, url, body=None):
         RequestJSON(self._context, "DELETE", url, body).execute()
 
+    def put_json(self, url, body=None):
+        RequestJSON(self._context, "PUT", url, body).execute()
+
 
 class URI:
     def __init__(self, content):
@@ -414,6 +425,10 @@ class Request:
                 )
             elif self.method == "GET":
                 resp = self.context.session.get(self.url, headers=self.headers)
+            elif self.method == "PUT":
+                resp = self.context.session.put(
+                    self.url, json=self.body, headers=self.headers
+                )
             elif self.method == "DELETE":
                 resp = self.context.session.delete(self.url, json=self.body)
             else:

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -350,6 +350,14 @@ class TestExperimentService:
         data = service.experiment.case_get("WS", "pid_2009", "case_1")
         assert data == {"id": "case_1"}
 
+    def test_put_case(self, put_case):
+        uri = modelon.impact.client.sal.service.URI(put_case.url)
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri, context=put_case.context
+        )
+        service.experiment.case_put("WS", "pid_2009", "case_1", {})
+        assert put_case.adapter.called
+
     def test_get_case_log(self, get_case_log):
         uri = modelon.impact.client.sal.service.URI(get_case_log.url)
         service = modelon.impact.client.sal.service.Service(


### PR DESCRIPTION
Should be possible to execute the following workflow - 
```
import uuid
from modelon.impact.client import (
    Client,
    SimpleModelicaExperimentDefinition,
)

workspace_id = uuid.uuid4().hex
client = Client(url="http://127.0.0.1:8080/")
workspace = client.create_workspace(workspace_id)
dynamic = workspace.get_custom_function('dynamic')
dyn_model = workspace.get_model('Modelica.Blocks.Examples.PID_Controller')


exp_definition = SimpleModelicaExperimentDefinition(dyn_model, dynamic)

experiment = workspace.create_experiment(exp_definition)
experiment = experiment.execute().wait(timeout=120)
case = experiment.get_case('case_1')

# Check first simulation result
res = case.get_trajectories()
assert len(res['PI.y']) == 502
assert res['PI.y'][-1] == -7.00030035862339

# Update case and re-execute
case.input.analysis.parameters = {"start_time": 0, "final_time": 90}
case.input.analysis.simulation_options = {'ncp': 600}
case.input.analysis.solver_options = {'atol': 1e-8}
case.input.parametrization = {'PI.k': 120}
case.update()
case.execute().wait(timeout=120)

# Check result for second simulation
res = case.get_trajectories()
assert len(res['PI.y']) == 612
assert res['PI.y'][-1] == -9.999999860142198

```