### PR TITLE
feat: Added support to set labels for experiment

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1428,6 +1428,15 @@ class Experiment:
         """
         self._exp_sal.experiment_delete(self._workspace_id, self._exp_id)
 
+    def set_label(self, label):
+        """Sets a label for an experiment.
+
+        Example::
+
+            experiment.set_label(label)
+        """
+        self._exp_sal.experiment_set_label(self._workspace_id, self._exp_id, label)
+
 
 class _CaseRunInfo:
     def __init__(self, status):

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -207,6 +207,12 @@ class ExperimentService:
         ).resolve()
         self._http_client.delete_json(url)
 
+    def experiment_set_label(self, workspace_id, exp_id, label):
+        url = (
+            self._base_uri / f"api/workspaces/{workspace_id}/experiments/{exp_id}"
+        ).resolve()
+        return self._http_client.put_json(url, body={"label": label})
+
     def execute_status(self, workspace_id, experiment_id):
         url = (
             self._base_uri

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -460,6 +460,14 @@ def experiment_execute(sem_ver_check, mock_server_base):
 
 
 @pytest.fixture
+def set_experiment_label(sem_ver_check, mock_server_base):
+
+    return with_json_route_no_resp(
+        mock_server_base, 'PUT', 'api/workspaces/WS/experiments/pid_2009'
+    )
+
+
+@pytest.fixture
 def delete_experiment(sem_ver_check, mock_server_base):
 
     return with_json_route_no_resp(

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -287,6 +287,17 @@ class TestExperimentService:
             'includeCases': {'ids': ['case_1']}
         }
 
+    def test_set_label_for_experiment(self, set_experiment_label):
+        uri = modelon.impact.client.sal.service.URI(set_experiment_label.url)
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri, context=set_experiment_label.context
+        )
+        service.experiment.experiment_set_label("WS", "pid_2009", "Label")
+        assert set_experiment_label.adapter.called
+        assert set_experiment_label.adapter.request_history[0].json() == {
+            'label': "Label"
+        }
+
     def test_delete_experiment(self, delete_experiment):
         uri = modelon.impact.client.sal.service.URI(delete_experiment.url)
         service = modelon.impact.client.sal.service.Service(

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -470,6 +470,14 @@ class TestCase:
         result = case.execute().wait()
         assert result == Case('case_1', 'AwesomeWorkspace', 'pid_2009')
 
+    def test_set_case_label(self, experiment):
+        exp = experiment.experiment
+        exp_sal = experiment.exp_service
+        exp.set_label('Label')
+        exp_sal.experiment_set_label.assert_has_calls(
+            [mock.call('Workspace', 'Test', 'Label')]
+        )
+
     def test_case_input(self, experiment):
         exp = experiment.experiment
 


### PR DESCRIPTION
Should now be possible to set experiment labels
```
import uuid
from modelon.impact.client import (
    Client,
    SimpleModelicaExperimentDefinition,
)

workspace_id = uuid.uuid4().hex
client = Client(url="http://127.0.0.1:8080/")
workspace = client.create_workspace(workspace_id)
dynamic = workspace.get_custom_function('dynamic')
dyn_model = workspace.get_model('Modelica.Blocks.Examples.PID_Controller')


exp_definition = SimpleModelicaExperimentDefinition(dyn_model, dynamic)

experiment = workspace.create_experiment(exp_definition)
experiment = experiment.execute().wait()
experiment.set_label('Doomed')

```