### PR TITLE
fix: not_started status not checked for successful experiment

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1292,7 +1292,6 @@ class Experiment:
             self.run_info.status == ExperimentStatus.DONE
             and self.run_info.failed == 0
             and self.run_info.cancelled == 0
-            and self.run_info.not_started == 0
         )
 
     def get_variables(self):


### PR DESCRIPTION
This PR removes checking the "not_started" key in run_info while asserting successful experiment. This would otherwise give a false assertion for experiments run with case filter.