### PR TITLE
feat: Added support for initializing from case and experiment

### DIFF
--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -444,7 +444,7 @@ class TestCase:
             experiment_with_failed_case.get_case("case_2").get_result,
         )
 
-    def test_case_update(self, experiment):
+    def test_case_update(self, experiment, batch_experiment):
         exp = experiment.experiment
         exp_sal = experiment.exp_service
 
@@ -454,6 +454,8 @@ class TestCase:
         case.input.analysis.solver_options = {'atol': 1e-8}
         case.input.analysis.simulation_log_level = "DEBUG"
         case.input.analysis.parameters = {"start_time": 1, "final_time": 2e5}
+        case_2 = batch_experiment.get_case('case_2')
+        case.initialize_from_case = case_2
         case.update()
         exp_sal.case_put.assert_has_calls(
             [
@@ -476,7 +478,10 @@ class TestCase:
                             'parametrization': {'PI.k': 120},
                             'structural_parametrization': {},
                             'fmu_base_parametrization': {},
-                            'initialize_from_case': '',
+                            'initialize_from_case': {
+                                'experimentId': 'Test',
+                                'caseId': 'case_2',
+                            },
                         },
                     },
                 )


### PR DESCRIPTION
This PR added support for initializing from Experiment and Case based on https://modelonproducts.atlassian.net/browse/WAMS-7563. 
The input property in class is updated to just use the _info variable as in any workflow of retrieving case objects this info will always be available. Also the _get_info() method is now updated to do the GET call to fetch latest metadata about the case. This is needed since now cases can be updated and re-executed and this information can change. 