### PR TITLE
Import external result

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -209,6 +209,33 @@ class Workspace:
         """
         self._workspace_sal.library_import(self._workspace_id, path_to_lib)
 
+    def upload_result(self, path_to_result, label=None, description=None):
+        """Uploads a '.mat' result file to the workspace.
+
+        Parameters:
+
+            path_to_result --
+                The path for the result file to be imported.
+
+            label --
+                The label of the result file. Default: None.
+
+            description --
+                The description of the result file. Default: None.
+
+        Example::
+
+            workspace.upload_result('C:/A.mat')
+            workspace.upload_result('C:/B.mat', label = "result_for_PID.mat",
+            description = "This is a result file for PID controller")
+        """
+        resp = self._workspace_sal.result_upload(
+            self._workspace_id, path_to_result, label=label, description=description
+        )
+        return operations.ExternalResultUploadOperation(
+            resp["data"]["id"], self._workspace_sal
+        )
+
     def upload_fmu(
         self,
         fmu_path,
@@ -593,10 +620,7 @@ class Workspace:
 
 class _Parameter:
     _JSON_2_PY_TYPE = {
-        "Number": (
-            float,
-            int,
-        ),
+        "Number": (float, int,),
         "String": (str,),
         "Boolean": (bool,),
         "Enumeration": (str,),
@@ -639,10 +663,7 @@ class CustomFunction:
         self._parameter_data = parameter_data
         self._param_by_name = {
             p["name"]: _Parameter(
-                p["name"],
-                p["defaultValue"],
-                p["type"],
-                p.get("values", []),
+                p["name"], p["defaultValue"], p["type"], p.get("values", []),
             )
             for p in parameter_data
         }
@@ -1545,6 +1566,7 @@ class _CaseRunInfo:
     """
     Class containing Case run info.
     """
+
     def __init__(self, status):
         self._status = status
 
@@ -1554,10 +1576,43 @@ class _CaseRunInfo:
         return self._status
 
 
+class _ExternalResultMetaData:
+    """
+    Class containing external result metadata.
+    """
+
+    def __init__(self, id, name, description, workspace_id):
+        self._id = id
+        self._name = name
+        self._description = description
+        self._workspace_id = workspace_id
+
+    @property
+    def id(self):
+        """Result id"""
+        return self._id
+
+    @property
+    def name(self):
+        """Label for result"""
+        return self._name
+
+    @property
+    def description(self):
+        """Description of the result"""
+        return self._description
+
+    @property
+    def workspace_id(self):
+        """Name of workspace"""
+        return self._workspace_id
+
+
 class _CaseAnalysis:
     """
     Class containing Case analysis configuration.
     """
+
     def __init__(self, analysis):
         self._analysis = analysis
 
@@ -1653,6 +1708,7 @@ class _CaseInput:
         caching to reuse the FMU.
         """
         return self._data['input']['fmu_base_parametrization']
+
 
 class Case:
     """
@@ -1953,12 +2009,7 @@ class Result(Mapping):
     """
 
     def __init__(
-        self,
-        case_id,
-        workspace_id,
-        exp_id,
-        workspace_service=None,
-        exp_service=None,
+        self, case_id, workspace_id, exp_id, workspace_service=None, exp_service=None,
     ):
         self._case_id = case_id
         self._workspace_id = workspace_id
@@ -1994,6 +2045,42 @@ class Result(Mapping):
 
     def keys(self):
         return self._variables
+
+
+class ExternalResult:
+    """
+    Class containing  external result.
+    """
+
+    def __init__(self, result_id, workspace_service=None):
+        self._result_id = result_id
+        self._workspace_sal = workspace_service
+
+    def __repr__(self):
+        return f"Result id '{self._result_id}'"
+
+    def __eq__(self, obj):
+        return isinstance(obj, ExternalResult) and obj._result_id == self._result_id
+
+    @property
+    def id(self):
+        """Result id"""
+        return self._result_id
+
+    @property
+    def metadata(self):
+        """External result metadata."""
+        upload_meta = self._workspace_sal.get_uploaded_result_meta(self._result_id)[
+            "data"
+        ]
+        id = upload_meta.get("id")
+        name = upload_meta.get("name")
+        description = upload_meta.get("description")
+        workspace_id = upload_meta.get("workspaceId")
+        return _ExternalResultMetaData(id, name, description, workspace_id)
+
+    def delete(self):
+        self._workspace_sal.delete_uploaded_result(self._result_id)
 
 
 class Log(str):

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -100,6 +100,32 @@ class WorkspaceService:
         with open(path_to_workspace, "rb") as f:
             return self._http_client.post_json(url, files={"file": f})
 
+    def result_upload(self, workspace_id, path_to_result, label=None, description=None):
+        url = (self._base_uri / "api/uploads/results").resolve()
+        options = {
+            "name": label if label else os.path.basename(path_to_result),
+            "description": description if description else "",
+            "context": {"workspaceId": workspace_id},
+        }
+        with open(path_to_result, "rb") as f:
+            multipart_form_data = {
+                'file': f,
+                'options': json.dumps(options),
+            }
+            return self._http_client.post_json(url, files=multipart_form_data)
+
+    def get_result_upload_status(self, upload_id):
+        url = (self._base_uri / f"api/uploads/results/{upload_id}").resolve()
+        return self._http_client.get_json(url)
+
+    def get_uploaded_result_meta(self, upload_id):
+        url = (self._base_uri / f"api/external-result/{upload_id}").resolve()
+        return self._http_client.get_json(url)
+
+    def delete_uploaded_result(self, upload_id):
+        url = (self._base_uri / f"api/external-result/{upload_id}").resolve()
+        return self._http_client.delete_json(url)
+
     def _workspace_get_export_id(self, workspace_id, options):
         url = (self._base_uri / f"api/workspaces/{workspace_id}/exports").resolve()
         return self._http_client.post_json(url, body=options)["export_id"]

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -235,6 +235,89 @@ def import_fmu(sem_ver_check, mock_server_base):
 
 
 @pytest.fixture
+def upload_result(sem_ver_check, mock_server_base):
+    json = {
+        "data": {
+            "id": "2f036b9fab6f45c788cc466da327cc78workspace",
+            "status": "ready",
+            "error": "None",
+        }
+    }
+
+    return with_json_route(mock_server_base, 'POST', 'api/uploads/results', json)
+
+
+@pytest.fixture
+def upload_result_status_ready(sem_ver_check, mock_server_base):
+    json = {
+        "data": {
+            "id": "2f036b9fab6f45c788cc466da327cc78workspace",
+            "status": "ready",
+            "data": {
+                "resourceUri": "api/external-result/2f036b9fab6f45c788cc466da327cc78workspace"
+            },
+            "error": "None",
+        }
+    }
+    return with_json_route(
+        mock_server_base,
+        'GET',
+        'api/uploads/results/2f036b9fab6f45c788cc466da327cc78workspace',
+        json,
+    )
+
+
+@pytest.fixture
+def upload_result_status_running(sem_ver_check, mock_server_base):
+    json = {
+        "data": {
+            "id": "2f036b9fab6f45c788cc466da327cc78workspace",
+            "status": "running",
+            "data": {
+                "resourceUri": "api/external-result/2f036b9fab6f45c788cc466da327cc78workspace"
+            },
+            "error": "None",
+        }
+    }
+
+    return with_json_route(
+        mock_server_base,
+        'GET',
+        'api/uploads/results/2f036b9fab6f45c788cc466da327cc78workspace',
+        json,
+    )
+
+
+@pytest.fixture
+def upload_result_meta(sem_ver_check, mock_server_base):
+    json = {
+        "data": {
+            "id": "2f036b9fab6f45c788cc466da327cc78workspace",
+            "createdAt": "2021-09-02T08:26:49.612000",
+            "name": "result_for_PID",
+            "description": "This is a result file for PID controller",
+            "workspaceId": "workspace",
+        }
+    }
+
+    return with_json_route(
+        mock_server_base,
+        'GET',
+        'api/external-result/2f036b9fab6f45c788cc466da327cc78workspace',
+        json,
+    )
+
+
+@pytest.fixture
+def upload_result_delete(sem_ver_check, mock_server_base):
+    return with_json_route_no_resp(
+        mock_server_base,
+        'DELETE',
+        'api/external-result/2f036b9fab6f45c788cc466da327cc78workspace',
+    )
+
+
+@pytest.fixture
 def upload_workspace(sem_ver_check, mock_server_base):
     json = {'id': 'newWorkspace'}
 


### PR DESCRIPTION
Code to test - 
```
from modelon.impact.client import Client

client = Client(url="http://127.0.0.1:8080/")
workspace = client.create_workspace('Test')
res_path = r"C:\Users\AbhilashKumar\Downloads\Result 1.mat"
a = workspace.upload_result(res_path ).wait()
a.delete()
```
@andrewwren-modelon I have a few questions on the API end - 
1. Is it possible to upload any file through this API, not just mat? What I observed that any file below 100 MB can be uploaded and the files are renamed to result.mat. 
2. Does the API POST/uploads/results hold the execution until the file is uploaded ? I wasn't able to slow it down so that the wait function can come into effect even with a larger file so was unsure of the behavior. 