### PR TITLE
Initialize from external result

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1808,6 +1808,26 @@ class Case:
             'caseId': case.id,
         }
 
+    @property
+    def initialize_from_external_result(self):
+        init_from_dict = self._info['input'].get('initialize_from_external_result')
+
+        if init_from_dict is None:
+            return None
+
+        result_id = init_from_dict.get('uploadId')
+
+        return ExternalResult(result_id, self._workspace_sal)
+
+    @initialize_from_external_result.setter
+    def initialize_from_external_result(self, result):
+        if not isinstance(result, ExternalResult):
+            raise TypeError(
+                "The value must be an instance of "
+                "modelon.impact.client.entities.ExternalResult"
+            )
+        self._info['input']['initialize_from_external_result'] = {"uploadId": result.id}
+
     def is_successful(self):
         """
         Returns True if a case has completed successfully.

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -1,3 +1,4 @@
+from modelon.impact.client import entities
 import modelon.impact.client.sal.service
 import pytest
 import os
@@ -529,6 +530,44 @@ class TestCase:
         )
         result = case.execute().wait()
         assert result == Case('case_1', 'AwesomeWorkspace', 'pid_2009')
+
+    def test_case_initialize_from_external_result(self, experiment):
+        result = entities.ExternalResult('upload_id')
+        case = experiment.entity.get_case("case_1")
+        case.initialize_from_external_result = result
+        case.update()
+        assert case.initialize_from_external_result == result
+        exp_sal = experiment.service
+        exp_sal.case_put.assert_has_calls(
+            [
+                mock.call(
+                    'Workspace',
+                    'Test',
+                    'case_1',
+                    {
+                        'id': 'case_1',
+                        'run_info': {'status': 'successful'},
+                        'input': {
+                            'fmu_id': 'modelica_fluid_examples_heatingsystem_20210130_114628_bbd91f1',
+                            'analysis': {
+                                'analysis_function': 'dynamic',
+                                'parameters': {'start_time': 0, 'final_time': 1},
+                                'simulation_options': {},
+                                'solver_options': {},
+                                'simulation_log_level': 'NOTHING',
+                            },
+                            'parametrization': {},
+                            'structural_parametrization': {},
+                            'fmu_base_parametrization': {},
+                            'initialize_from_case': '',
+                            'initialize_from_external_result': {
+                                'uploadId': 'upload_id'
+                            },
+                        },
+                    },
+                )
+            ]
+        )
 
     def test_set_case_label(self, experiment):
         exp = experiment.entity


### PR DESCRIPTION
Code to test
```
from modelon.impact.client.experiment_definition import (
    SimpleModelicaExperimentDefinition,
)
from modelon.impact.client.client import Client
import uuid

base_url = "http://127.0.0.1:8080/"
workspace_id = uuid.uuid4().hex
client = Client(url=base_url)
workspace = client.create_workspace(workspace_id)
steady_state = workspace.get_custom_function('steady state')
workspace.upload_model_library(
    r"C:\UserData\Modelon\WEP\IMPACT\diraction\src\mimp-base\tests\files\test_mo_files\steady_state.mo"
)
ss_fail_model = workspace.get_model('ExampleModels.SSFail')

exp_def_1 = exp_definition = SimpleModelicaExperimentDefinition(
    ss_fail_model, steady_state
)
result = workspace.upload_result(
    r"C:\Users\AbhilashKumar\Downloads\result_to_init.mat"
).wait()

experiment_1 = workspace.create_experiment(exp_definition)
experiment_1 = experiment_1.execute().wait(timeout=120)
assert experiment_1.is_successful()
case_1 = experiment_1.get_case('case_1')

# Convergence failure
exp_def_2 = exp_def_1.with_modifiers({'sweep': 6})
experiment_2 = workspace.create_experiment(exp_def_2)
experiment_2 = experiment_2.execute().wait(timeout=120)
assert not experiment_2.is_successful()

# Resimulate with initialize_from_external_result setter
case_1_fail = experiment_2.get_case('case_1')
case_1_fail.initialize_from_external_result = result
case_1_fail.update()
case_1_fail = case_1_fail.execute().wait(timeout=120)
assert case_1_fail.is_successful()

# Resimulate with initilizing from result
exp_def_3 = exp_def_2.initialize_from(result)
experiment_3 = workspace.create_experiment(exp_def_3)
experiment_3 = experiment_3.execute().wait(timeout=120)
assert experiment_3.is_successful()
```