### PR TITLE
Update case multiple times fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test-watch:
 	$(call _run_it, poetry run pytest-watch -- -vv)
 
 lint:
-	$(call _run,  bash -c "poetry run black modelon && poetry run flake8 modelon && poetry run mypy modelon")
+	$(call _run,  bash -c "poetry run black -S modelon && poetry run flake8 modelon && poetry run mypy modelon")
 
 wheel:
 	$(call _run,  poetry build -f wheel)

--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -57,11 +57,7 @@ class Client:
     _SUPPORTED_VERSION_RANGE = ">=1.17.0,<2.0.0"
 
     def __init__(
-        self,
-        url=None,
-        interactive=None,
-        credential_manager=None,
-        context=None,
+        self, url=None, interactive=None, credential_manager=None, context=None,
     ):
         if url is None:
             url = modelon.impact.client.configuration.get_client_url()

--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1981,7 +1981,7 @@ class Case:
         )
 
     def update(self):
-        self._exp_sal.case_put(
+        self._info = self._exp_sal.case_put(
             self._workspace_id, self._exp_id, self._case_id, self._info
         )
 

--- a/modelon/impact/client/operations.py
+++ b/modelon/impact/client/operations.py
@@ -520,7 +520,9 @@ class CaseOperation(ExecutionOperation):
             experiment --
                 An Case class instance.
         """
-        case_data = self._exp_sal.case_get(self._workspace_id, self._exp_id, self._case_id)
+        case_data = self._exp_sal.case_get(
+            self._workspace_id, self._exp_id, self._case_id
+        )
         return entities.Case(
             self._case_id,
             self._workspace_id,

--- a/modelon/impact/client/options.py
+++ b/modelon/impact/client/options.py
@@ -15,10 +15,7 @@ class ExecutionOptions(Mapping):
     """
 
     def __init__(
-        self,
-        values,
-        custom_function_name,
-        custom_function_service=None,
+        self, values, custom_function_name, custom_function_service=None,
     ):
         self._values = values
         self._name = custom_function_name
@@ -54,8 +51,5 @@ class ExecutionOptions(Mapping):
             sol_opts = custom_function.get_solver_options().with_values(rtol=1e-7)
             sim_opts = custom_function.get_simulation_options().with_values(ncp=500)
         """
-        values = _set_options(
-            self._values,
-            **modified,
-        )
+        values = _set_options(self._values, **modified,)
         return ExecutionOptions(values, self._name, self._custom_func_sal)

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -279,7 +279,7 @@ class ExperimentService:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/experiments/{exp_id}"
         ).resolve()
-        return self._http_client.put_json_no_responsoe_body(url, body={"label": label})
+        return self._http_client.put_json_no_response_body(url, body={"label": label})
 
     def execute_status(self, workspace_id, experiment_id):
         url = (
@@ -450,7 +450,7 @@ class HTTPClient:
     def delete_json(self, url, body=None):
         RequestJSON(self._context, "DELETE", url, body).execute()
 
-    def put_json_no_responsoe_body(self, url, body=None):
+    def put_json_no_response_body(self, url, body=None):
         RequestJSON(self._context, "PUT", url, body).execute()
 
     def put_json(self, url, body=None):

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -279,7 +279,7 @@ class ExperimentService:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/experiments/{exp_id}"
         ).resolve()
-        return self._http_client.put_json(url, body={"label": label})
+        return self._http_client.put_json_no_responsoe_body(url, body={"label": label})
 
     def execute_status(self, workspace_id, experiment_id):
         url = (
@@ -450,8 +450,12 @@ class HTTPClient:
     def delete_json(self, url, body=None):
         RequestJSON(self._context, "DELETE", url, body).execute()
 
-    def put_json(self, url, body=None):
+    def put_json_no_responsoe_body(self, url, body=None):
         RequestJSON(self._context, "PUT", url, body).execute()
+
+    def put_json(self, url, body=None):
+        request = RequestJSON(self._context, "PUT", url, body)
+        return request.execute().data
 
 
 class URI:

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -1,4 +1,5 @@
 import collections
+import copy
 import unittest.mock
 import pytest
 import requests
@@ -649,9 +650,10 @@ def get_case(sem_ver_check, mock_server_base):
 
 @pytest.fixture
 def put_case(sem_ver_check, mock_server_base):
+    json = {"id": "case_1"}
 
-    return with_json_route_no_resp(
-        mock_server_base, 'PUT', 'api/workspaces/WS/experiments/pid_2009/cases/case_1',
+    return with_json_route(
+        mock_server_base, 'PUT', 'api/workspaces/WS/experiments/pid_2009/cases/case_1', json
     )
 
 
@@ -1158,9 +1160,9 @@ def experiment():
     exp_service.execute_status.return_value = {"status": "done"}
     exp_service.result_variables_get.return_value = ["inertia.I", "time"]
     exp_service.cases_get.return_value = {"data": {"items": [{"id": "case_1"}]}}
-    exp_service.case_get.return_value = {
+    case_get_data = {
         "id": "case_1",
-        "run_info": {"status": "successful"},
+        "run_info": {"status": "successful", "consistent": True},
         "input": {
             "fmu_id": "modelica_fluid_examples_heatingsystem_20210130_114628_bbd91f1",
             "analysis": {
@@ -1176,6 +1178,11 @@ def experiment():
             "initialize_from_case": "",
         },
     }
+    case_put_return = copy.deepcopy(case_get_data)
+    case_put_return['run_info']['consistent'] = False
+    
+    exp_service.case_get.return_value = case_get_data
+    exp_service.case_put.return_value = case_put_return
     exp_service.case_get_log.return_value = "Successful Log"
     exp_service.case_result_get.return_value = (bytes(4), 'result.mat')
     exp_service.case_artifact_get.return_value = (bytes(4), 'result.mat')


### PR DESCRIPTION
⚠️⚠️ Second commit contains only lint changes, reviewing the commits separately will be easier ⚠️⚠️

This PR fixes the issue where multiple case updates are done and the wrong value for 'consistent' where sent to the server, resulting in a server error. With this PR this code is possible to run with no errors:
```
from modelon.impact.client import Client
c = Client()
w = client.create_workspace('test_multiple_updates')
m = w.get_model('Modelica.Blocks.Examples.PID_Controller')
dynamic = w.get_custom_function('dynamic')
exp_def = m.new_experiment_definition(dynamic)
exp = w.create_experiment(exp_def).execute().wait()
case = exp.get_case('case_1')
case.input.parametrization = {'inertia1.J': 5}
case.update()
case.input.parametrization = {'inertia1.J': 6}
case.update()
```