### PR TITLE
fix: Assert reinitialization with multiple entities

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1803,6 +1803,7 @@ class Case:
             raise TypeError(
                 "The value must be an instance of modelon.impact.client.entities.Case"
             )
+        self._assert_unique_case_initialization('initialize_from_external_result')
         self._info['input']['initialize_from_case'] = {
             'experimentId': case.experiment_id,
             'caseId': case.id,
@@ -1826,6 +1827,7 @@ class Case:
                 "The value must be an instance of "
                 "modelon.impact.client.entities.ExternalResult"
             )
+        self._assert_unique_case_initialization('initialize_from_case')
         self._info['input']['initialize_from_external_result'] = {"uploadId": result.id}
 
     def is_successful(self):
@@ -2013,6 +2015,15 @@ class Case:
             self._model_exe_sal,
             self._exp_sal,
         )
+
+    def _assert_unique_case_initialization(self, unsupported_init):
+        if self._info['input'][unsupported_init]:
+            raise ValueError(
+                "A case cannot use both 'initialize_from_case' and "
+                "'initialize_from_external_result' to specify what to initialize from! "
+                f"To resolve this, set the '{unsupported_init}' attribute "
+                "to None and re-try."
+            )
 
 
 class Result(Mapping):

--- a/modelon/impact/client/experiment_definition.py
+++ b/modelon/impact/client/experiment_definition.py
@@ -25,6 +25,15 @@ def _case_to_identifier_dict(case):
     }
 
 
+def _assert_unique_exp_initialization(*initializing_from):
+    initializing_from = [entity for entity in initializing_from if entity is not None]
+    if len(initializing_from) > 1:
+        raise ValueError(
+            "An experiment can only be initialized from one entity. Experiment is "
+            f"configured to initialize from {' and '.join(map(str, initializing_from))}"
+        )
+
+
 def assert_valid_args(
     model=None,
     fmu=None,
@@ -486,9 +495,18 @@ class SimpleFMUExperimentDefinition(BaseExperimentDefinition):
             self._simulation_options,
             self._simulation_log_level,
         )
+        new.initialize_from_experiment = self.initialize_from_experiment
+        new.initialize_from_case = self.initialize_from_case
+        new.initialize_from_external_result = self.initialize_from_external_result
         _validate_and_set_initialize_from(entity, new)
+        _assert_unique_exp_initialization(
+            new.initialize_from_experiment,
+            new.initialize_from_case,
+            new.initialize_from_external_result,
+        )
         new.variable_modifiers = self.variable_modifiers
         new.extensions = self.extensions
+
         return new
 
 
@@ -695,7 +713,15 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
             simulation_options=self._simulation_options,
             simulation_log_level=self._simulation_log_level,
         )
+        new.initialize_from_experiment = self.initialize_from_experiment
+        new.initialize_from_case = self.initialize_from_case
+        new.initialize_from_external_result = self.initialize_from_external_result
         _validate_and_set_initialize_from(entity, new)
+        _assert_unique_exp_initialization(
+            new.initialize_from_experiment,
+            new.initialize_from_case,
+            new.initialize_from_external_result,
+        )
         new.variable_modifiers = self.variable_modifiers
         new.extensions = self.extensions
         return new
@@ -991,7 +1017,12 @@ class SimpleExperimentExtension(BaseExperimentExtension):
                 "experiment extensions"
             )
 
+        new.initialize_from_experiment = self.initialize_from_experiment
+        new.initialize_from_case = self.initialize_from_case
         _validate_and_set_initialize_from(entity, new)
+        _assert_unique_exp_initialization(
+            new.initialize_from_experiment, new.initialize_from_case,
+        )
         new.variable_modifiers = self.variable_modifiers
         return new
 

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -1175,7 +1175,8 @@ def experiment():
             "parametrization": {},
             "structural_parametrization": {},
             "fmu_base_parametrization": {},
-            "initialize_from_case": "",
+            "initialize_from_case": None,
+            "initialize_from_external_result": None,
         },
     }
     case_put_return = copy.deepcopy(case_get_data)

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -444,7 +444,6 @@ class TestExperiment:
         pytest.raises(ValueError, experiment.entity.get_trajectories, ['s'])
 
 
-
 def get_case_put_json_input(mock_method_call):
     (args, _) = tuple(mock_method_call)
     (_, _, _, put_json_input) = args
@@ -454,6 +453,7 @@ def get_case_put_json_input(mock_method_call):
 def get_case_put_call_consistent_value(mock_method_call):
     json = get_case_put_json_input(mock_method_call)
     return json['run_info']['consistent']
+
 
 class TestCase:
     def test_case(self, experiment):
@@ -534,6 +534,7 @@ class TestCase:
                                 'experimentId': 'Test',
                                 'caseId': 'case_2',
                             },
+                            "initialize_from_external_result": None,
                         },
                     },
                 )
@@ -542,7 +543,9 @@ class TestCase:
         result = case.execute().wait()
         assert result == Case('case_1', 'AwesomeWorkspace', 'pid_2009')
 
-    def test_case_update_second_time_should_call_with_consistent_false(self, experiment):
+    def test_case_update_second_time_should_call_with_consistent_false(
+        self, experiment
+    ):
         exp = experiment.entity
         exp_sal = experiment.service
 
@@ -583,7 +586,7 @@ class TestCase:
                             'parametrization': {},
                             'structural_parametrization': {},
                             'fmu_base_parametrization': {},
-                            'initialize_from_case': '',
+                            'initialize_from_case': None,
                             'initialize_from_external_result': {
                                 'uploadId': 'upload_id'
                             },
@@ -591,6 +594,34 @@ class TestCase:
                     },
                 )
             ]
+        )
+
+    def test_reinitiazlizing_result_initialized_case_from_case(self, experiment):
+        result = entities.ExternalResult('upload_id')
+        case_to_init = entities.Case('Case_2', 'ws_id', 'exp_id')
+        case = experiment.entity.get_case("case_1")
+        case.initialize_from_external_result = result
+        with pytest.raises(Exception) as err:
+            case.initialize_from_case = case_to_init
+        assert (
+            str(err.value) == "A case cannot use both 'initialize_from_case' and "
+            "'initialize_from_external_result' to specify what to initialize from! "
+            "To resolve this, set the 'initialize_from_external_result' attribute "
+            "to None and re-try."
+        )
+
+    def test_reinitiazlizing_case_initialized_case_from_result(self, experiment):
+        result = entities.ExternalResult('upload_id')
+        case_to_init = entities.Case('Case_2', 'ws_id', 'exp_id')
+        case = experiment.entity.get_case("case_1")
+        case.initialize_from_case = case_to_init
+        with pytest.raises(Exception) as err:
+            case.initialize_from_external_result = result
+        assert (
+            str(err.value) == "A case cannot use both 'initialize_from_case' and "
+            "'initialize_from_external_result' to specify what to initialize from! "
+            "To resolve this, set the 'initialize_from_case' attribute "
+            "to None and re-try."
         )
 
     def test_set_case_label(self, experiment):

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -343,6 +343,36 @@ class TestSimpleModelicaExperimentDefinition:
             "caseId": case_1.id,
         }
 
+    def test_experiment_definition_initialize_from_multiple_entities(
+        self, model, custom_function_no_param, experiment
+    ):
+        experiment = experiment.entity
+        definition = SimpleModelicaExperimentDefinition(
+            model, custom_function=custom_function_no_param,
+        ).initialize_from(experiment)
+
+        # Reinitializing with case entity
+        case_to_init = entities.Case('Case_2', 'ws_id', 'exp_id')
+        err_str = "An experiment can only be initialized from one entity. "
+        with pytest.raises(Exception) as err:
+            definition = definition.initialize_from(case_to_init)
+        assert (
+            str(err.value)
+            == err_str
+            + "Experiment is configured to initialize from Experiment with id 'Test' "
+            + "and Case with id 'Case_2'"
+        )
+
+        # Reinitializing with external result entity
+        result_to_init = entities.ExternalResult('result_id')
+        with pytest.raises(Exception) as err:
+            definition = definition.initialize_from(result_to_init)
+        assert str(err.value) == (
+            err_str
+            + "Experiment is configured to initialize from Experiment with id 'Test' "
+            + "and Result id 'result_id'"
+        )
+
     def test_experiment_definition_with_extensions(
         self, model, custom_function_no_param
     ):
@@ -413,6 +443,23 @@ class TestSimpleModelicaExperimentDefinition:
                 "analysis": {"parameters": {'final_time': 10}},
             },
         ]
+
+    def test_experiment_definition_with_extensions_initialize_from_multiple_entities(
+        self, model, custom_function_no_param, experiment
+    ):
+        experiment = experiment.entity
+        case_1 = experiment.get_case('case_1')
+        ext1 = (
+            SimpleExperimentExtension({'final_time': 10})
+            .with_modifiers(p=3)
+            .initialize_from(case_1)
+        )
+
+        # Reinitializing with experiment entity
+        expected_err = "An experiment can only be initialized from one entity. Experiment is configured to initialize from Experiment with id 'Test' and Case with id 'case_1'"
+        with pytest.raises(Exception) as err:
+            ext1 = ext1.initialize_from(experiment)
+        assert str(err.value) == expected_err
 
     def test_experiment_definition_with_cases(self, model, custom_function_no_param):
         definition = SimpleModelicaExperimentDefinition(


### PR DESCRIPTION
**Code to test**
The following code snippets should raise an exception for trying to re-init. Also please test if reint with the same entity works.
```
from modelon.impact.client import Client
import uuid

workspace_id = uuid.uuid4().hex
c = Client(url="http://127.0.0.1:8080")
w = c.create_workspace(workspace_id)
m = w.get_model('Modelica.Blocks.Examples.PID_Controller')
res = w.upload_result(r"C:\Users\AbhilashKumar\Downloads\result_to_init.mat").wait()
dynamic = w.get_custom_function('dynamic')
exp_def = m.new_experiment_definition(dynamic)
exp_1 = w.create_experiment(exp_def).execute().wait()
exp_2 = w.create_experiment(exp_def).execute().wait()
case_exp_2 = exp_2.get_case('case_1')

case_exp_1 = exp_1.get_case('case_1')

case_exp_1.initialize_from_case = case_exp_2
case_exp_1.initialize_from_external_result = res
```
and

```
from modelon.impact.client import Client, SimpleExperimentExtension
import uuid

workspace_id = uuid.uuid4().hex
c = Client(url="http://127.0.0.1:8080")
w = c.create_workspace(workspace_id)
m = w.get_model('Modelica.Blocks.Examples.PID_Controller')
res = w.upload_result(r"C:\Users\AbhilashKumar\Downloads\result_to_init.mat").wait()
dynamic = w.get_custom_function('dynamic')
exp_def = m.new_experiment_definition(dynamic)
exp_1 = w.create_experiment(exp_def).execute().wait()

case_exp_1 = exp_1.get_case('case_1')

ext1 = (
    SimpleExperimentExtension({'final_time': 10})
    .with_modifiers(p=3)
    .initialize_from(case_exp_1)
)
ext1.initialize_from(exp_1)
```
and 
```
from modelon.impact.client import Client
import uuid

workspace_id = uuid.uuid4().hex
c = Client(url="http://127.0.0.1:8080")
w = c.create_workspace(workspace_id)
m = w.get_model('Modelica.Blocks.Examples.PID_Controller')
res = w.upload_result(r"C:\Users\AbhilashKumar\Downloads\result_to_init.mat").wait()
dynamic = w.get_custom_function('dynamic')
exp_def = m.new_experiment_definition(dynamic)
exp_1 = w.create_experiment(exp_def).execute().wait()
case_exp_1 = exp_1.get_case('case_1')
exp_def = exp_def.initialize_from(case_exp_1)
exp_def = exp_def.initialize_from(exp_1)
```