### PR TITLE
feat: possible to check if a case is consistent

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1566,13 +1566,20 @@ class _CaseRunInfo:
     Class containing Case run info.
     """
 
-    def __init__(self, status):
+    def __init__(self, status, consistent):
         self._status = status
+        self._consistent = consistent
 
     @property
     def status(self):
         """Status info for a Case, its type is CaseStatus."""
         return self._status
+
+    @property
+    def consistent(self):
+        """True if the case has not been updated since it was executed,
+        false otherwise."""
+        return self._consistent
 
 
 class _ExternalResultMetaData:
@@ -1758,7 +1765,7 @@ class Case:
     def run_info(self):
         """Case run information"""
         run_info = self._info["run_info"]
-        return _CaseRunInfo(CaseStatus(run_info["status"]))
+        return _CaseRunInfo(CaseStatus(run_info["status"]), run_info["consistent"])
 
     @property
     def input(self):

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -1242,7 +1242,7 @@ def batch_experiment_with_case_filter():
     }
     exp_service.case_get.return_value = {
         "id": "case_3",
-        "run_info": {"status": "successful"},
+        "run_info": {"status": "successful", "consistent": True},
         "input": {
             "fmu_id": "modelica_fluid_examples_heatingsystem_20210130_114628_bbd91f1"
         },
@@ -1267,7 +1267,7 @@ def batch_experiment():
     }
     exp_service.case_get.return_value = {
         "id": "case_2",
-        "run_info": {"status": "successful"},
+        "run_info": {"status": "successful", "consistent": True},
     }
     exp_service.case_get_log.return_value = "Successful Log"
     exp_service.case_result_get.return_value = (bytes(4), 'result.mat')
@@ -1328,7 +1328,7 @@ def experiment_with_failed_case():
     exp_service.cases_get.return_value = {"data": {"items": [{"id": "case_1"}]}}
     exp_service.case_get.return_value = {
         "id": "case_1",
-        "run_info": {"status": "failed"},
+        "run_info": {"status": "failed", "consistent": True},
     }
     exp_service.result_variables_get.return_value = ["inertia.I", "time"]
     exp_service.trajectories_get.return_value = [[[1, 2, 3, 4]], [[5, 2, 9, 4]]]
@@ -1369,5 +1369,5 @@ def cancelled_experiment():
     }
     exp_service.cases_get.return_value = {"data": {"items": [{"id": "case_1"}]}}
     exp_service.case_get.return_value = {"id": "case_1"}
-    exp_service.execute_status.return_value = {"status": "cancelled"}
+    exp_service.execute_status.return_value = {"status": "cancelled", "consistent": True}
     return Experiment("Workspace", "Test", ws_service, exp_service=exp_service)

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -460,6 +460,7 @@ class TestCase:
         case = experiment.entity.get_case("case_1")
         assert case.id == "case_1"
         assert case.run_info.status == CaseStatus.SUCCESSFUL
+        assert case.run_info.consistent is True
         assert case.get_log() == "Successful Log"
         result, name = case.get_result()
         assert (result, name) == (b'\x00\x00\x00\x00', 'result.mat')


### PR DESCRIPTION
This PR adds the attribute 'consistent' to the case entity. This will help a user know if they should use the result of a case or not.

Example code on a workspace with at least one experiment with at least one case:
```
all_experiments = workspace.get_experiments()
case = all_experiments[0].get_cases()[0]
case.run_info.consistent
True
case.input.parametrization = {'a': 5}
case.update()
case.run_info.consistent
False
```
