### PR TITLE
Sync/update case changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN pip install -U pip
 
 # update 
 RUN apt-get update && apt-get install -y curl apt-utils
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash
 RUN apt-get install -y nodejs
 RUN node -v
 RUN npm -v

--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1377,8 +1377,9 @@ class Experiment:
             with_cases --
                 A list of cases objects to execute.
             sync_case_changes --
-                Boolean specifying if to sync the cases given with the 'with_cases' argument
-                against the server before executing the experiment. Default is True.
+                Boolean specifying if to sync the cases given with the 'with_cases'
+                argument against the server before executing the experiment.
+                Default is True.
 
         Returns:
 
@@ -1595,7 +1596,7 @@ class _CaseRunInfo:
 
     @property
     def consistent(self):
-        """True if the case has not been updated since it was executed,
+        """True if the case has not been synced since it was executed,
         false otherwise."""
         return self._consistent
 

--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1791,7 +1791,7 @@ class Case:
             case.input.analysis.simulation_options = {'ncp': 600}
             case.input.analysis.solver_options = {'atol': 1e-8}
             case.input.parametrization = {'PI.k': 120}
-            case.update()
+            case.sync()
 
             help(case.input.analysis) # See help for attribute
             dir(case.input) # See nested attributes
@@ -2003,7 +2003,14 @@ class Case:
             self._workspace_id, fmu_id, self._workspace_sal, self._model_exe_sal
         )
 
-    def update(self):
+    def sync(self):
+        """Sync case state against server, pushing any changes that has been
+        done to the object client side.
+
+        Example::
+            case.input.parametrization = {'PI.k': 120}
+            case.sync()
+        """
         self._info = self._exp_sal.case_put(
             self._workspace_id, self._exp_id, self._case_id, self._info
         )
@@ -2020,7 +2027,7 @@ class Case:
         Example::
             case = experiment.get_case('case_1')
             case.input.parametrization = {'PI.k': 120}
-            case.update()
+            case.sync()
             case_ops = case.execute()
             case_ops.cancel()
             case_ops.status()

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -1211,7 +1211,7 @@ def batch_experiment_with_case_filter():
             "not_started": 3,
         }
     }
-    exp_service.experiment_execute.return_value = "pid_2009"
+    exp_service.experiment_execute.return_value = "Experiment"
     exp_service.execute_status.return_value = {"status": "done"}
     exp_service.cases_get.return_value = {
         "data": {
@@ -1231,7 +1231,7 @@ def batch_experiment_with_case_filter():
         },
     }
     return ExperimentMock(
-        Experiment("Workspace", "Test", ws_service, model_exe_service, exp_service),
+        Experiment("Workspace", "Experiment", ws_service, model_exe_service, exp_service),
         exp_service,
     )
 

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -497,7 +497,7 @@ class TestCase:
             experiment_with_failed_case.get_case("case_2").get_result,
         )
 
-    def test_case_update(self, experiment, batch_experiment):
+    def test_case_sync(self, experiment, batch_experiment):
         exp = experiment.entity
         exp_sal = experiment.service
 
@@ -509,7 +509,7 @@ class TestCase:
         case.input.analysis.parameters = {"start_time": 1, "final_time": 2e5}
         case_2 = batch_experiment.get_case('case_2')
         case.initialize_from_case = case_2
-        case.update()
+        case.sync()
         exp_sal.case_put.assert_has_calls(
             [
                 mock.call(
@@ -552,8 +552,8 @@ class TestCase:
 
         case = exp.get_case("case_1")
         case.input.parametrization = {'PI.k': 120}
-        case.update()
-        case.update()
+        case.sync()
+        case.sync()
         case_put_calls = exp_sal.case_put.call_args_list
         assert len(case_put_calls) == 2
         assert get_case_put_call_consistent_value(case_put_calls[0]) is True
@@ -564,7 +564,7 @@ class TestCase:
         case = experiment.entity.get_case("case_1")
         case.initialize_from_external_result = result
         assert case.initialize_from_external_result == result
-        case.update()
+        case.sync()
         exp_sal = experiment.service
         exp_sal.case_put.assert_has_calls(
             [

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -579,7 +579,7 @@ class TestCase:
         exp_sal.case_put.assert_not_called()
         assert result == Case('case_1', 'AwesomeWorkspace', 'pid_2009')
 
-    def test_case_update_second_time_should_call_with_consistent_false(
+    def test_case_sync_second_time_should_call_with_consistent_false(
         self, experiment
     ):
         exp = experiment.entity


### PR DESCRIPTION
This PR make chagnes to the update functionality after discussion:
 * update method renamed to sync
 * sync is called automatically when executing a case(s). There is a flag for turning this of if needed.