### PR TITLE
Update case label

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -54,7 +54,7 @@ class Client:
         client = Client(url=impact_url, interactive=True)
     """
 
-    _SUPPORTED_VERSION_RANGE = ">=1.17.0,<2.0.0"
+    _SUPPORTED_VERSION_RANGE = ">=1.18.0,<2.0.0"
 
     def __init__(
         self, url=None, interactive=None, credential_manager=None, context=None,

--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1509,6 +1509,26 @@ class Experiment:
             case_data,
         )
 
+    def get_cases_with_label(self, case_label):
+        """
+        Returns a list of case objects for an experiment with the label.
+
+        Parameters:
+
+            case_label --
+                The case_label for the case.
+
+        Returns:
+
+            cases --
+                An list of case objects.
+
+        Example::
+
+            experiment.get_cases_with_label('Cruise condition')
+        """
+        return [case for case in self.get_cases() if case.meta.label == case_label]
+
     def get_trajectories(self, variables):
         """
         Returns a dictionary containing the result trajectories
@@ -1690,6 +1710,24 @@ class _CaseAnalysis:
         self._analysis['simulation_log_level'] = simulation_log_level
 
 
+class _CaseMeta:
+    """
+    Class containing Case meta
+    """
+
+    def __init__(self, data):
+        self._data = data
+
+    @property
+    def label(self):
+        """Label for the case."""
+        return self._data['label']
+
+    @label.setter
+    def label(self, label):
+        self._data['label'] = label
+
+
 class _CaseInput:
     """
     Class containing Case input
@@ -1700,7 +1738,7 @@ class _CaseInput:
 
     @property
     def analysis(self):
-        return _CaseAnalysis(self._data['input']['analysis'])
+        return _CaseAnalysis(self._data['analysis'])
 
     @property
     def parametrization(self):
@@ -1708,16 +1746,16 @@ class _CaseInput:
         Parameterization of the case, a list of key value pairs where key
         is variable name and value is the value to use for that variable.
         """
-        return self._data['input']['parametrization']
+        return self._data['parametrization']
 
     @parametrization.setter
     def parametrization(self, parameterization):
-        self._data['input']['parametrization'] = parameterization
+        self._data['parametrization'] = parameterization
 
     @property
     def fmu_id(self):
         """Reference ID to the compiled model used running the case."""
-        return self._data['input']['fmu_id']
+        return self._data['fmu_id']
 
     @property
     def structural_parametrization(self):
@@ -1726,7 +1764,7 @@ class _CaseInput:
         key is variable name and value is the value to use for that variable.
         These are values that cannot be applied to the FMU/Model after compilation.
         """
-        return self._data['input']['structural_parametrization']
+        return self._data['structural_parametrization']
 
     @property
     def fmu_base_parametrization(self):
@@ -1735,7 +1773,7 @@ class _CaseInput:
         it to be valid running this case. It often comes as a result from of
         caching to reuse the FMU.
         """
-        return self._data['input']['fmu_base_parametrization']
+        return self._data['fmu_base_parametrization']
 
 
 class Case:
@@ -1804,7 +1842,21 @@ class Case:
             help(case.input.analysis) # See help for attribute
             dir(case.input) # See nested attributes
         """
-        return _CaseInput(self._info)
+        return _CaseInput(self._info['input'])
+
+    @property
+    def meta(self):
+        """Case meta attributes
+
+           Example::
+
+            case.meta.label = 'Cruise condition'
+            case.sync()
+
+            help(case.meta) # See help for attribute
+            dir(case.input) # See nested attributes
+        """
+        return _CaseMeta(self._info['meta'])
 
     @property
     def initialize_from_case(self):

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -123,7 +123,7 @@ def api_get_metadata(mock_server_base):
 
 @pytest.fixture
 def sem_ver_check(mock_server_base):
-    json = {"version": "1.17.0"}
+    json = {"version": "1.18.0"}
 
     return with_json_route(mock_server_base, 'GET', 'api/', json)
 
@@ -653,7 +653,10 @@ def put_case(sem_ver_check, mock_server_base):
     json = {"id": "case_1"}
 
     return with_json_route(
-        mock_server_base, 'PUT', 'api/workspaces/WS/experiments/pid_2009/cases/case_1', json
+        mock_server_base,
+        'PUT',
+        'api/workspaces/WS/experiments/pid_2009/cases/case_1',
+        json,
     )
 
 
@@ -1160,6 +1163,7 @@ def experiment():
             "initialize_from_case": None,
             "initialize_from_external_result": None,
         },
+        "meta": {"label": "Cruise operating point"},
     }
     case_put_return = copy.deepcopy(case_get_data)
     case_put_return['run_info']['consistent'] = False
@@ -1216,10 +1220,10 @@ def batch_experiment_with_case_filter():
     exp_service.cases_get.return_value = {
         "data": {
             "items": [
-                {"id": "case_1"},
-                {"id": "case_2"},
-                {"id": "case_3"},
-                {"id": "case_4"},
+                {"id": "case_1", "meta": {"label": None}},
+                {"id": "case_2", "meta": {"label": "Cruise operating point"}},
+                {"id": "case_3", "meta": {"label": None}},
+                {"id": "case_4", "meta": {"label": "Cruise operating point"}},
             ]
         }
     }
@@ -1231,7 +1235,9 @@ def batch_experiment_with_case_filter():
         },
     }
     return ExperimentMock(
-        Experiment("Workspace", "Experiment", ws_service, model_exe_service, exp_service),
+        Experiment(
+            "Workspace", "Experiment", ws_service, model_exe_service, exp_service
+        ),
         exp_service,
     )
 
@@ -1352,5 +1358,8 @@ def cancelled_experiment():
     }
     exp_service.cases_get.return_value = {"data": {"items": [{"id": "case_1"}]}}
     exp_service.case_get.return_value = {"id": "case_1"}
-    exp_service.execute_status.return_value = {"status": "cancelled", "consistent": True}
+    exp_service.execute_status.return_value = {
+        "status": "cancelled",
+        "consistent": True,
+    }
     return Experiment("Workspace", "Test", ws_service, exp_service=exp_service)

--- a/tests/impact/client/test_client.py
+++ b/tests/impact/client/test_client.py
@@ -61,7 +61,7 @@ def test_semantic_version_error(semantic_version_error):
         )
     assert (
         "Version '3.1.0' of the HTTP REST API is not supported, must be in the "
-        "range '>=1.17.0,<2.0.0'! Updgrade or downgrade this package to a version"
+        "range '>=1.18.0,<2.0.0'! Updgrade or downgrade this package to a version"
         " that supports version '3.1.0' of the HTTP REST API." in str(excinfo.value)
     )
 
@@ -98,8 +98,7 @@ def test_client_login_api_key_missing(sem_ver_check):
     )
 
     assert_login_called(
-        adapter=sem_ver_check.adapter,
-        body={},
+        adapter=sem_ver_check.adapter, body={},
     )
 
 


### PR DESCRIPTION
This PR adds support for specifying and updating labels - https://modelonproducts.atlassian.net/browse/WAMS-7558
**Code to test**
```
from modelon.impact.client import Client, SimpleExperimentExtension

client = Client(url='http://127.0.0.1:8080/')
workspace = client.create_workspace('CaseLabels2')

# Choose analysis type
dynamic = workspace.get_custom_function('dynamic')

# Get model
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")

experiment_definition = model.new_experiment_definition(
    dynamic.with_parameters(start_time=0.0, final_time=2.0),
    simulation_options=dynamic.get_simulation_options().with_values(ncp=500),
    solver_options={'atol': 1e-8},
).with_modifiers({'inertia1.J': 2})

simulate_ext1 = (
    SimpleExperimentExtension({'final_time': 5}, {'atol': 1e-7})
    .with_modifiers({'PI.k': 40})
    .with_case_labels(['avg_case'])
)
simulate_ext2 = (
    SimpleExperimentExtension({'final_time': 6}, {'atol': 1e-6})
    .with_modifiers({'PI.k': 50})
    .with_case_labels(['very_avg_case', 'avg_case'])
)

experiment_definition = experiment_definition.with_extensions(
    [simulate_ext1, simulate_ext2]
)
exp = workspace.create_experiment(experiment_definition)
exp = exp.execute([]).wait()
cases = exp.get_cases()
case_label = [case.meta.label for case in cases]
assert case_label == ['avg_case', 'very_avg_case']
case_1, case_2 = cases
case_1.meta.label = 'new avg_case'
case_2.meta.label = 'new very_avg_case'
case_1.sync()
case_2.sync()
cases = exp.get_cases()
case_label = [case.meta.label for case in cases]
assert case_label == ['new avg_case', 'new very_avg_case']

```
**Additional changes -** 
1. It was noted that experiment definition didn't always result in the same json.  A fix has been pushed to correct this behavior so that irrespective of the order the . with_cases(), .with_modifiers(),  .initialize_from() and .with_extensions() are added the json remains the same.
```
exp_def  = (
            SimpleModelicaExperimentDefinition(
                model, custom_function=custom_function_no_param
            )
            .with_cases([{'p': 3}])
            .with_modifiers({'h0': Range(0.1, 0.5, 3)})
            .initialize_from(experiment)
            .with_extensions([ext1])
            .to_dict()
        )
```