### PR TITLE
fix: given empty string as API key, do anon login and don't save key

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -108,10 +108,10 @@ class Client:
 
     def _authenticate_against_api(self, interactive):
 
-        if self._api_key is None:
+        if not self._api_key:
             self._api_key = self._credentials.get_key(interactive=interactive)
 
-        if self._api_key is None:
+        if not self._api_key:
             logger.warning(
                 "No API key could be found, will log in as anonymous user. "
                 "Permissions may be limited"
@@ -121,7 +121,7 @@ class Client:
             login_data = {"secretKey": self._api_key}
 
         self._sal.api_login(login_data)
-        if interactive:
+        if self._api_key and interactive:
             # Save the api_key for next time if
             # running interactively and login was successfuly
             self._credentials.write_key_to_file(self._api_key)

--- a/tests/impact/client/test_client.py
+++ b/tests/impact/client/test_client.py
@@ -158,7 +158,7 @@ def test_client_login_fail_lets_user_enter_new_key(_, login_fails):
     cred_manager.get_key_from_prompt.assert_called()
 
 
-def test_client_login_api_key_empty_string_anon_login_and_dont_save_key(sem_ver_check):
+def test_empty_api_key_when_login_then_anon_login_and_dont_save_key(sem_ver_check):
     cred_manager = unittest.mock.MagicMock()
     cred_manager.get_key.return_value = ''
     modelon.impact.client.Client(

--- a/tests/impact/client/test_client.py
+++ b/tests/impact/client/test_client.py
@@ -156,3 +156,17 @@ def test_client_login_fail_lets_user_enter_new_key(_, login_fails):
     )
 
     cred_manager.get_key_from_prompt.assert_called()
+
+
+def test_client_login_api_key_empty_string_anon_login_and_dont_save_key(sem_ver_check):
+    cred_manager = unittest.mock.MagicMock()
+    cred_manager.get_key.return_value = ''
+    modelon.impact.client.Client(
+        url=sem_ver_check.url,
+        context=sem_ver_check.context,
+        credential_manager=cred_manager,
+        interactive=True,
+    )
+
+    assert_login_called(adapter=sem_ver_check.adapter, body={})
+    cred_manager.write_key_to_file.assert_not_called()


### PR DESCRIPTION
This fixes the issue where you don't have any API key configured (remove api.key file) and would run
```
from modelon.impact.client import Client
c = Client(url='https://impact.modelon.com/', interactive=True)
```
and then in the prompt for API key just press enter. Then it would not count this as an Anonymous login in Client (but would do so server side), so you don't get any warning. We would also save this empty string to disk for next time as if it was a valid API key.