### PR TITLE
Jupyterhub authorization

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,20 +1,18 @@
 {
-  "release": {
-    "branches":[
-      {name: 'master'},
-      {name: 'beta', prerelease: True},
-    ]
-  },
+  "branches":[
+    {"name": "master"},
+    {"name": "beta", "prerelease": true}
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "pyproject.toml"],
+      "assets": ["CHANGELOG.md", "pyproject.toml"]
     }],
     ["@semantic-release/exec", {
       "prepareCmd": "poetry version ${nextRelease.version}",
-      "publishCmd": "/opt/app/release.sh"
-    }],
+      "publishCmd": "/home/dev/src/release.sh"
+    }]
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.7
 
-WORKDIR /opt/app
+# Do not run as root
+RUN adduser dev
+WORKDIR /home/dev
 
 RUN pip install -U pip
 
@@ -15,13 +17,19 @@ RUN npm -v
 RUN npm i -g semantic-release @semantic-release/commit-analyzer @semantic-release/git @semantic-release/exec \
       @semantic-release/changelog @semantic-release/release-notes-generator
 
+USER dev
+
 # install poetry to container
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-ENV PATH /root/.poetry/bin:$PATH
+ENV POETRY_HOME /home/dev/poetry
+ENV POETRY_VIRTUALENVS_PATH /home/dev/poetry-virtualenvs
+ENV POETRY_CACHE_DIR /home/dev/poetry-cache
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
+ENV PATH $POETRY_HOME/bin:$PATH
 
 # build project env
-COPY ./pyproject.toml /opt/app/pyproject.toml
-COPY ./poetry.lock /opt/app/poetry.lock
-COPY ./modelon/__init__.py /opt/app/modelon/__init__.py
-COPY ./README.md /opt/app/README.md
+WORKDIR /home/dev/src
+COPY ./pyproject.toml pyproject.toml
+COPY ./poetry.lock poetry.lock
+COPY ./modelon/__init__.py modelon/__init__.py
+COPY ./README.md README.md
 RUN poetry install

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,6 @@ node('docker'){
   }
 
   stage ('test') {
-    sh 'make lint'
     sh 'make test'
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,36 +1,22 @@
 node('docker'){
 
-  try {
+  stage ('scm') {
+    checkout(scm)
+  }
 
-    stage ('scm') {
-      checkout(scm)
-    }
+  stage ('test') {
+    sh 'make lint'
+    sh 'make test'
+  }
 
-    stage ('build') {
-      sh 'make build'
-    }
-
-    stage ('test') {
-      sh 'make lint'
-      sh 'make test'
-    }
-
-    stage ('publish') {
-      withCredentials([usernamePassword(credentialsId: 'GitHub-Jenkins', usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
-        withCredentials([usernamePassword(credentialsId: 'pypi-modelon-api-key', usernameVariable: 'PYPI_USERNAME', passwordVariable: 'PYPI_PASSWORD')]) {
-          env.GIT_CREDENTIALS = "${GIT_USERNAME}:${GIT_PASSWORD}"
-          env.PYPI_USERNAME = "${PYPI_USERNAME}"
-          env.PYPI_PASSWORD = "${PYPI_PASSWORD}"
-          sh 'make publish'
-        }
+  stage ('publish') {
+    withCredentials([usernamePassword(credentialsId: 'GitHub-Jenkins', usernameVariable: 'GIT_USERNAME', passwordVariable: 'GIT_PASSWORD')]) {
+      withCredentials([usernamePassword(credentialsId: 'pypi-modelon-api-key', usernameVariable: 'PYPI_USERNAME', passwordVariable: 'PYPI_PASSWORD')]) {
+        env.GIT_CREDENTIALS = "${GIT_USERNAME}:${GIT_PASSWORD}"
+        env.PYPI_USERNAME = "${PYPI_USERNAME}"
+        env.PYPI_PASSWORD = "${PYPI_PASSWORD}"
+        sh 'make publish'
       }
     }
-
-  } catch (e) {
-    // Since we're catching the exception in order to report on it,
-    // we need to re-throw it, to ensure that the build is marked as failed
-    throw e
-  } finally {
-    sh 'make set-permissions'
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,52 @@
-.PHONY: build coverage shell test test-watch lint wheel publish set-permissions
-USER_ID := `id -u`
-GROUP_ID := `id -g`
+.PHONY: build coverage shell unit-test test test-watch lint wheel publish
+USER_ID := $(shell id -u)
+GROUP_ID := $(shell id -g)
 
 define _run
 	docker run \
-	--rm \
-	-v $(CURDIR):/opt/app \
+	--rm $(1) \
+	-v $(CURDIR):/home/dev/src \
+	-u $(USER_ID):$(GROUP_ID) \
 	-e GIT_CREDENTIALS \
 	-e PYPI_USERNAME \
 	-e PYPI_PASSWORD \
 	modelon-impact-client-build:latest \
-	$(1)
+	$(2)
 endef
 
-define _run_it
-	docker run \
-	--rm -it \
-	-v $(CURDIR):/opt/app \
-	-e GIT_CREDENTIALS \
-	-e PYPI_USERNAME \
-	-e PYPI_PASSWORD \
-	modelon-impact-client-build:latest \
-	$(1)
+define _run_interactive
+	$(call _run, -it, $(1))
+endef
+
+define _run_bare
+	$(call _run, , $(1))
 endef
 
 build:
 	docker build -t modelon-impact-client-build:latest .
 
 coverage:
-	$(call _run, poetry run pytest --cov-report=html:htmlcov --cov-report=term --cov=modelon)
+	$(call _run_bare, poetry run pytest --cov-report=html:htmlcov --cov-report=term --cov=modelon)
 
 shell:
-	$(call _run_it, /bin/bash)
+	$(call _run_interactive, //bin/bash)
 
-test:
-	$(call _run, poetry run pytest -vv)
+poetry:
+	$(call _run_interactive, //bin/sh -c "poetry shell")
 
-test-watch:
-	$(call _run_it, poetry run pytest-watch -- -vv)
+unit-test:
+	$(call _run_bare, poetry run pytest -vv)
+
+test: build unit-test lint
+
+test-watch: build
+	$(call _run_interactive, poetry run pytest-watch -- -vv)
 
 lint:
-	$(call _run,  bash -c "poetry run black -S modelon && poetry run flake8 modelon && poetry run mypy modelon")
+	$(call _run_bare, bash -c "poetry run black -S modelon && poetry run flake8 modelon && poetry run mypy modelon")
 
-wheel:
-	$(call _run,  poetry build -f wheel)
+wheel: build
+	$(call _run_bare, poetry build -f wheel)
 
-publish:
-	$(call _run,  npx semantic-release --ci false)
-
-set-permissions:
-	docker run -v $(CURDIR):/opt/data busybox sh -c "chmod -R 777 /opt/data && chown -R ${USER_ID}:${GROUP_ID} /opt/data"
+publish: build
+	$(call _run_bare, npx semantic-release --ci false)

--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -82,7 +82,8 @@ class Client:
         except modelon.impact.client.sal.exceptions.HTTPError:
             if interactive:
                 logger.warning(
-                    "The provided API key is not valid, please enter a new key"
+                    "The provided Modelon Impact API key is not valid, "
+                    "please enter a new key"
                 )
                 self._api_key = self._credentials.get_key_from_prompt()
                 self._authenticate_against_api(interactive)
@@ -113,8 +114,8 @@ class Client:
 
         if not self._api_key:
             logger.warning(
-                "No Modelon Impact API key could be found, will log in as anonymous user. "
-                "Permissions may be limited"
+                "No Modelon Impact API key could be found, "
+                "will log in as anonymous user. Permissions may be limited"
             )
             login_data = {}
         else:

--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -6,9 +6,11 @@ import modelon.impact.client.exceptions
 import modelon.impact.client.sal.service
 import modelon.impact.client.sal.exceptions
 import modelon.impact.client.credential_manager
+import modelon.impact.client.jupyterhub
 
 from semantic_version import SimpleSpec, Version  # type: ignore
 from modelon.impact.client import exceptions
+
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +77,14 @@ class Client:
         self._credentials = credential_manager
         self._api_key = None
 
-        self._validate_compatible_api_version()
+        try:
+            self._validate_compatible_api_version()
+        except modelon.impact.client.sal.exceptions.AccessingJupyterHubError:
+            self._uri, context = modelon.impact.client.jupyterhub.authorize(
+                self._uri, interactive, context
+            )
+            self._sal = modelon.impact.client.sal.service.Service(self._uri, context)
+            self._validate_compatible_api_version()
 
         try:
             self._authenticate_against_api(interactive)

--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -113,7 +113,7 @@ class Client:
 
         if not self._api_key:
             logger.warning(
-                "No API key could be found, will log in as anonymous user. "
+                "No Modelon Impact API key could be found, will log in as anonymous user. "
                 "Permissions may be limited"
             )
             login_data = {}

--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -59,7 +59,12 @@ class Client:
     _SUPPORTED_VERSION_RANGE = ">=1.18.0,<2.0.0"
 
     def __init__(
-        self, url=None, interactive=None, credential_manager=None, context=None,
+        self,
+        url=None,
+        interactive=None,
+        credential_manager=None,
+        context=None,
+        jupyterhub_credential_manager=None,
     ):
         if url is None:
             url = modelon.impact.client.configuration.get_client_url()
@@ -81,7 +86,7 @@ class Client:
             self._validate_compatible_api_version()
         except modelon.impact.client.sal.exceptions.AccessingJupyterHubError:
             self._uri, context = modelon.impact.client.jupyterhub.authorize(
-                self._uri, interactive, context
+                self._uri, interactive, context, jupyterhub_credential_manager,
             )
             self._sal = modelon.impact.client.sal.service.Service(self._uri, context)
             self._validate_compatible_api_version()

--- a/modelon/impact/client/credential_manager.py
+++ b/modelon/impact/client/credential_manager.py
@@ -4,12 +4,22 @@ from getpass import getpass
 
 
 class CredentialManager:
+    def __init__(
+        self,
+        file_id="api.key",
+        env_name="MODELON_IMPACT_CLIENT_API_KEY",
+        interactive_help_text="Enter Modelon Impact API key:",
+    ):
+        self._file_id = file_id
+        self._env_name = env_name
+        self._interactive_help_text = interactive_help_text
+
     def get_key_from_env(self):
-        return os.environ.get("MODELON_IMPACT_CLIENT_API_KEY")
+        return os.environ.get(self._env_name)
 
     def _cred_file(self):
         home_dir = os.path.expanduser("~")
-        return os.path.join(home_dir, ".impact", "api.key")
+        return os.path.join(home_dir, ".impact", self._file_id)
 
     def get_key_from_file(self):
         credentials_file = self._cred_file()
@@ -20,7 +30,7 @@ class CredentialManager:
             return credentials.read().strip()
 
     def get_key_from_prompt(self):
-        return getpass("Enter API key:")
+        return getpass(self._interactive_help_text)
 
     def write_key_to_file(self, api_key):
         credentials_file = self._cred_file()

--- a/modelon/impact/client/credential_manager.py
+++ b/modelon/impact/client/credential_manager.py
@@ -1,6 +1,9 @@
 import os
+import logging
 
 from getpass import getpass
+
+logger = logging.getLogger(__name__)
 
 
 class CredentialManager:
@@ -30,7 +33,13 @@ class CredentialManager:
             return credentials.read().strip()
 
     def get_key_from_prompt(self):
-        return getpass(self._interactive_help_text)
+        key = getpass(self._interactive_help_text)
+        if key == '\x16':
+            # This is a getpass Windows bug...
+            logger.error("Does not support Ctrl+V on Windows")
+            return self.get_key_from_prompt()
+
+        return key
 
     def write_key_to_file(self, api_key):
         credentials_file = self._cred_file()

--- a/modelon/impact/client/jupyterhub/__init__.py
+++ b/modelon/impact/client/jupyterhub/__init__.py
@@ -1,0 +1,1 @@
+from modelon.impact.client.jupyterhub.authorize import authorize

--- a/modelon/impact/client/jupyterhub/authorize.py
+++ b/modelon/impact/client/jupyterhub/authorize.py
@@ -1,0 +1,51 @@
+import logging
+
+from modelon.impact.client.credential_manager import CredentialManager
+import modelon.impact.client.jupyterhub.exceptions as exceptions
+import modelon.impact.client.jupyterhub.sal as sal
+
+
+logger = logging.getLogger(__name__)
+
+
+def _get_jupyter_token(credential_manager, interactive, context=None):
+    jupyter_token = credential_manager.get_key(interactive=interactive)
+    if not jupyter_token:
+        raise exceptions.NoJupyterHubTokenError("No JupyterHub API token is given")
+
+    return jupyter_token
+
+
+def authorize(uri, interactive, context=None):
+    credential_manager = CredentialManager(
+        file_id="jupyterhub-api.key",
+        env_name="MODELON_IMPACT_JUPYTERHUB_CLIENT_API_TOKEN",
+        interactive_help_text="Enter JupyterHub API token:",
+    )
+    context = sal.JupyterContext(base=context)
+
+    try:
+        context.token = _get_jupyter_token(credential_manager, interactive)
+        user = sal.get_user_data(uri, context)
+    except exceptions.JupyterHubAuthrizationError:
+        if interactive:
+            logger.warning(
+                "Could not authorize with the provided JupyterHub API token, "
+                "please enter a new token"
+            )
+            context.token = _get_jupyter_token(credential_manager, interactive)
+            user = sal.get_user_data(uri, context)
+        else:
+            raise
+
+    if interactive:
+        credential_manager.write_key_to_file(context.token)
+
+    if not user.server_running():
+        uri_to_start_server = uri / 'hub/home'
+        raise exceptions.NoJupyterHubServerRunningError(
+            "The user does not have a server running. "
+            f"Go to {uri_to_start_server} and start a server."
+        )
+
+    return user.impact_server_uri(uri), context

--- a/modelon/impact/client/jupyterhub/authorize.py
+++ b/modelon/impact/client/jupyterhub/authorize.py
@@ -16,25 +16,26 @@ def _get_jupyter_token(credential_manager, interactive, context=None):
     return jupyter_token
 
 
-def authorize(uri, interactive, context=None):
-    credential_manager = CredentialManager(
+def authorize(uri, interactive, context=None, credential_manager=None, service=None):
+    credential_manager = credential_manager or CredentialManager(
         file_id="jupyterhub-api.key",
         env_name="MODELON_IMPACT_JUPYTERHUB_CLIENT_API_TOKEN",
         interactive_help_text="Enter JupyterHub API token:",
     )
     context = sal.JupyterContext(base=context)
+    service = service or sal.JupyterHubService()
 
     try:
         context.token = _get_jupyter_token(credential_manager, interactive)
-        user = sal.get_user_data(uri, context)
+        user = service.get_user_data(uri, context)
     except exceptions.JupyterHubAuthrizationError:
         if interactive:
             logger.warning(
                 "Could not authorize with the provided JupyterHub API token, "
                 "please enter a new token"
             )
-            context.token = _get_jupyter_token(credential_manager, interactive)
-            user = sal.get_user_data(uri, context)
+            context.token = credential_manager.get_key_from_prompt()
+            user = service.get_user_data(uri, context)
         else:
             raise
 

--- a/modelon/impact/client/jupyterhub/exceptions.py
+++ b/modelon/impact/client/jupyterhub/exceptions.py
@@ -1,0 +1,22 @@
+class Error(Exception):
+    pass
+
+
+class JupyterHubAuthrizationError(Error):
+    pass
+
+
+class NotAJupyterHubUrl(Error):
+    pass
+
+
+class NoJupyterHubServerRunningError(Error):
+    pass
+
+
+class UnknownJupyterHubError(Error):
+    pass
+
+
+class NoJupyterHubTokenError(Error):
+    pass

--- a/modelon/impact/client/jupyterhub/sal.py
+++ b/modelon/impact/client/jupyterhub/sal.py
@@ -1,0 +1,73 @@
+import json.decoder
+
+import requests
+
+import modelon.impact.client.jupyterhub.exceptions as exceptions
+import modelon.impact.client.sal.service
+
+
+class JupyterContext:
+    def __init__(self, base=None):
+        self._base = base if base else modelon.impact.client.sal.service.Context()
+        self._token = None
+
+    @property
+    def session(self):
+        return self._base.session
+
+    @property
+    def token(self):
+        return self._token
+
+    @token.setter
+    def token(self, token):
+        self._token = token
+        self.session.headers.update({'Authorization': 'token %s' % token})
+
+
+class JupyterUser:
+    def __init__(self, user_id, server):
+        self.id = user_id
+        self._server = server
+
+    def server_running(self):
+        return self._server is not None
+
+    def impact_server_uri(self, jupyterhub_uri):
+        return jupyterhub_uri / f'user/{self.id}/impact'
+
+
+def get_user_data(uri, context):
+    auth_token_url = (uri / f'hub/api/authorizations/token/{context.token}').resolve()
+
+    try:
+        user_respons = context.session.get(auth_token_url)
+    except requests.exceptions.RequestException as e:
+        raise exceptions.NotAJupyterHubUrl(
+            f"Did not get a response from {uri}, is the URL correct?"
+        ) from e
+
+    if not user_respons.ok:
+        if user_respons.status_code == 403:
+            raise exceptions.JupyterHubAuthrizationError(
+                "Could not authorize against JupyterHub, is the token correct?"
+            )
+        elif user_respons.status_code == 404:
+            raise exceptions.NotAJupyterHubUrl(
+                f"Missing resource '{auth_token_url}'. Possible errors are "
+                f"that the URL '{uri}' don't points to a JupyterHub or "
+                "that the user of the API key as been deleted."
+            )
+        else:
+            raise exceptions.UnknownJupyterHubError(
+                "Something went wrong calling JupyterHub. Got the response "
+                f"'{user_respons}' with content '{user_respons.content}'"
+            )
+
+    try:
+        user_data = user_respons.json()
+        return JupyterUser(user_data['name'], user_data['server'])
+    except (KeyError, json.decoder.JSONDecodeError) as e:
+        raise exceptions.NotAJupyterHubUrl(
+            f"User response data is not correct, is the URL '{uri}' for a JupyterHub?"
+        ) from e

--- a/modelon/impact/client/sal/exceptions.py
+++ b/modelon/impact/client/sal/exceptions.py
@@ -32,3 +32,7 @@ class ErrorJSONInvalidFormatError(ServiceAccessError):
 
 class NoResponseFetchVersionError(ServiceAccessError):
     pass
+
+
+class AccessingJupyterHubError(ServiceAccessError):
+    pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [flake8]
 per-file-ignores =
     modelon/impact/client/__init__.py:F401
+    modelon/impact/client/jupyterhub/__init__.py:F401

--- a/tests/impact/client/jupyterhub/fixtures.py
+++ b/tests/impact/client/jupyterhub/fixtures.py
@@ -1,0 +1,76 @@
+import pytest
+import requests.exceptions
+
+from tests.impact.client.fixtures import *
+
+
+@pytest.fixture
+def get_user_ok(mock_server_base):
+    jupyter_user_json = {'name': 'user-name', 'server': 'ok'}
+
+    return with_json_route(
+        mock_server_base,
+        'GET',
+        'hub/api/authorizations/token/secret-token',
+        jupyter_user_json,
+    )
+
+
+@pytest.fixture
+def get_user_auth_error(mock_server_base):
+    return with_json_route(
+        mock_server_base,
+        'GET',
+        'hub/api/authorizations/token/secret-token',
+        {},
+        status_code=403,
+    )
+
+
+@pytest.fixture
+def get_user_no_such_resource_error(mock_server_base):
+    return with_json_route(
+        mock_server_base,
+        'GET',
+        'hub/api/authorizations/token/secret-token',
+        {},
+        status_code=404,
+    )
+
+
+@pytest.fixture
+def get_user_unknown_error(mock_server_base):
+    return with_json_route(
+        mock_server_base,
+        'GET',
+        'hub/api/authorizations/token/secret-token',
+        {},
+        status_code=500,
+    )
+
+
+@pytest.fixture
+def get_user_response_missing_fields(mock_server_base):
+    return with_json_route(
+        mock_server_base, 'GET', 'hub/api/authorizations/token/secret-token', {},
+    )
+
+
+@pytest.fixture
+def token_response_not_json(mock_server_base):
+    return with_text_route(
+        mock_server_base,
+        'GET',
+        'hub/api/authorizations/token/secret-token',
+        'not JSON',
+    )
+
+
+@pytest.fixture
+def token_no_response_exception(mock_server_base):
+    return with_exception(
+        mock_server_base,
+        'GET',
+        'hub/api/authorizations/token/secret-token',
+        requests.exceptions.RequestException,
+    )

--- a/tests/impact/client/jupyterhub/test_authorize.py
+++ b/tests/impact/client/jupyterhub/test_authorize.py
@@ -1,0 +1,186 @@
+import unittest.mock
+
+import pytest
+
+from modelon.impact.client.jupyterhub.authorize import authorize
+from modelon.impact.client.jupyterhub.sal import JupyterUser
+from modelon.impact.client.sal.service import URI
+import modelon.impact.client.jupyterhub.exceptions as exceptions
+
+
+TEST_URI = URI('https//:impact-mock.com')
+
+
+def test_given_token_when_authorize_then_ok():
+    cred_manager = unittest.mock.MagicMock()
+    service = unittest.mock.MagicMock()
+    context = unittest.mock.MagicMock()
+
+    # Given
+    interactive = False
+    cred_manager.get_key.return_value = 'ok-secret'
+
+    # When
+    _, context = authorize(
+        TEST_URI,
+        interactive,
+        context=context,
+        credential_manager=cred_manager,
+        service=service,
+    )
+
+    # Then
+    assert context.token == 'ok-secret'
+    cred_manager.write_key_to_file.assert_not_called()
+    cred_manager.get_key.assert_called()
+
+
+def test_given_token_interactive_when_authorize_then_save_token():
+    cred_manager = unittest.mock.MagicMock()
+    service = unittest.mock.MagicMock()
+    context = unittest.mock.MagicMock()
+
+    # Given
+    interactive = True
+    cred_manager.get_key.return_value = 'ok-secret'
+
+    # When
+    _, context = authorize(
+        TEST_URI,
+        interactive,
+        context=context,
+        credential_manager=cred_manager,
+        service=service,
+    )
+
+    # Then
+    assert context.token == 'ok-secret'
+    cred_manager.write_key_to_file.assert_called_with('ok-secret')
+    cred_manager.get_key.assert_called()
+
+
+def test_given_no_token_when_authorize_then_no_token_error():
+    cred_manager = unittest.mock.MagicMock()
+    service = unittest.mock.MagicMock()
+    context = unittest.mock.MagicMock()
+
+    # Given
+    interactive = False
+    cred_manager.get_key.return_value = None
+
+    # When
+    pytest.raises(
+        exceptions.NoJupyterHubTokenError,
+        authorize,
+        TEST_URI,
+        interactive,
+        context=context,
+        credential_manager=cred_manager,
+        service=service,
+    )
+
+    # Then
+    cred_manager.write_key_to_file.assert_not_called()
+    cred_manager.get_key.assert_called()
+
+
+def test_given_wrong_token_when_authorize_then_error():
+    cred_manager = unittest.mock.MagicMock()
+    service = unittest.mock.MagicMock()
+    context = unittest.mock.MagicMock()
+
+    # Given
+    interactive = False
+    cred_manager.get_key.return_value = 'wrong-secret'
+    service.get_user_data.side_effect = exceptions.JupyterHubAuthrizationError('oh no')
+
+    # When
+    pytest.raises(
+        exceptions.JupyterHubAuthrizationError,
+        authorize,
+        TEST_URI,
+        interactive,
+        context=context,
+        credential_manager=cred_manager,
+        service=service,
+    )
+
+    # Then
+    cred_manager.write_key_to_file.assert_not_called()
+    cred_manager.get_key_from_prompt.assert_not_called()
+
+
+def test_given_wrong_token_and_interactive_when_authorize_then_prompt_for_key_and_write():
+    cred_manager = unittest.mock.MagicMock()
+    service = unittest.mock.MagicMock()
+    context = unittest.mock.MagicMock()
+
+    # Given
+    interactive = True
+    cred_manager.get_key.return_value = 'wrong-secret'
+    cred_manager.get_key_from_prompt.return_value = 'ok-secret'
+    service.get_user_data.side_effect = [
+        exceptions.JupyterHubAuthrizationError('oh no'),
+        unittest.mock.MagicMock(),
+    ]
+
+    # When
+    _, context = authorize(
+        TEST_URI,
+        interactive,
+        context=context,
+        credential_manager=cred_manager,
+        service=service,
+    )
+
+    # Then
+    assert context.token == 'ok-secret'
+    cred_manager.write_key_to_file.assert_called_with('ok-secret')
+    cred_manager.get_key_from_prompt.assert_called()
+
+
+def test_given_wrong_token_many_times_and_interactive_when_authorize_then_prompt_for_key_but_fail():
+    cred_manager = unittest.mock.MagicMock()
+    service = unittest.mock.MagicMock()
+    context = unittest.mock.MagicMock()
+
+    # Given
+    interactive = True
+    cred_manager.get_key.return_value = 'wrong-secret'
+    cred_manager.get_key_from_prompt.return_value = 'wrong-secret'
+    service.get_user_data.side_effect = exceptions.JupyterHubAuthrizationError('oh no')
+
+    # When
+    pytest.raises(
+        exceptions.JupyterHubAuthrizationError,
+        authorize,
+        TEST_URI,
+        interactive,
+        context=context,
+        credential_manager=cred_manager,
+        service=service,
+    )
+
+    # Then
+    cred_manager.write_key_to_file.assert_not_called()
+    cred_manager.get_key_from_prompt.assert_called()
+
+
+def test_given_user_has_no_server_when_authorize_then_error():
+    cred_manager = unittest.mock.MagicMock()
+    service = unittest.mock.MagicMock()
+    context = unittest.mock.MagicMock()
+
+    # Given
+    service.get_user_data.return_value = JupyterUser('some-user', None)
+
+    # When, then
+    pytest.raises(
+        exceptions.NoJupyterHubServerRunningError,
+        authorize,
+        TEST_URI,
+        True,
+        context=context,
+        credential_manager=cred_manager,
+        service=service,
+    )

--- a/tests/impact/client/jupyterhub/test_sal.py
+++ b/tests/impact/client/jupyterhub/test_sal.py
@@ -1,0 +1,97 @@
+import unittest.mock
+
+from modelon.impact.client.sal.service import URI
+from modelon.impact.client.jupyterhub.sal import JupyterHubService, JupyterContext
+from tests.impact.client.jupyterhub.fixtures import *
+import modelon.impact.client.jupyterhub.exceptions as exceptions
+
+
+def test_given_no_jupyter_error_when_get_user(get_user_ok):
+    uri = URI(get_user_ok.url)
+    context = JupyterContext(get_user_ok.context)
+    context.token = 'secret-token'
+
+    user = JupyterHubService.get_user_data(uri, context)
+
+    expected_impact_user_uri = uri / 'user/user-name/impact'
+    assert user.server_running() is True
+    assert user.impact_server_uri(uri).resolve() == expected_impact_user_uri.resolve()
+
+
+def test_given_jupyter_auth_error_when_get_user(get_user_auth_error):
+    uri = URI(get_user_auth_error.url)
+    context = JupyterContext(get_user_auth_error.context)
+    context.token = 'secret-token'
+
+    pytest.raises(
+        exceptions.JupyterHubAuthrizationError,
+        JupyterHubService.get_user_data,
+        uri,
+        context,
+    )
+
+
+def test_given_jupyter_no_such_resource_error_when_get_user(
+    get_user_no_such_resource_error,
+):
+    uri = URI(get_user_no_such_resource_error.url)
+    context = JupyterContext(get_user_no_such_resource_error.context)
+    context.token = 'secret-token'
+
+    pytest.raises(
+        exceptions.NotAJupyterHubUrl, JupyterHubService.get_user_data, uri, context
+    )
+
+
+def test_given_jupyter_no_such_resource_error_when_get_user(
+    get_user_no_such_resource_error,
+):
+    uri = URI(get_user_no_such_resource_error.url)
+    context = JupyterContext(get_user_no_such_resource_error.context)
+    context.token = 'secret-token'
+
+    pytest.raises(
+        exceptions.NotAJupyterHubUrl, JupyterHubService.get_user_data, uri, context
+    )
+
+
+def test_given_jupyter_unknown_error_when_get_user(get_user_unknown_error):
+    uri = URI(get_user_unknown_error.url)
+    context = JupyterContext(get_user_unknown_error.context)
+    context.token = 'secret-token'
+
+    pytest.raises(
+        exceptions.UnknownJupyterHubError, JupyterHubService.get_user_data, uri, context
+    )
+
+
+def test_given_jupyter_response_misses_fields_when_get_user(
+    get_user_response_missing_fields,
+):
+    uri = URI(get_user_response_missing_fields.url)
+    context = JupyterContext(get_user_response_missing_fields.context)
+    context.token = 'secret-token'
+
+    pytest.raises(
+        exceptions.NotAJupyterHubUrl, JupyterHubService.get_user_data, uri, context
+    )
+
+
+def test_given_jupyter_response_not_json_when_get_user(token_response_not_json):
+    uri = URI(token_response_not_json.url)
+    context = JupyterContext(token_response_not_json.context)
+    context.token = 'secret-token'
+
+    pytest.raises(
+        exceptions.NotAJupyterHubUrl, JupyterHubService.get_user_data, uri, context
+    )
+
+
+def test_given_jupyter_no_response_when_get_user(token_no_response_exception):
+    uri = URI(token_no_response_exception.url)
+    context = JupyterContext(token_no_response_exception.context)
+    context.token = 'secret-token'
+
+    pytest.raises(
+        exceptions.NotAJupyterHubUrl, JupyterHubService.get_user_data, uri, context
+    )

--- a/tests/impact/client/test_client.py
+++ b/tests/impact/client/test_client.py
@@ -170,3 +170,19 @@ def test_empty_api_key_when_login_then_anon_login_and_dont_save_key(sem_ver_chec
 
     assert_login_called(adapter=sem_ver_check.adapter, body={})
     cred_manager.write_key_to_file.assert_not_called()
+
+
+def test_client_connect_against_jupyterhub_can_authorize(jupyterhub_api):
+    cred_manager = unittest.mock.MagicMock()
+    cred_manager.get_key.return_value = None
+    jupyterhub_cred_manager = unittest.mock.MagicMock()
+    jupyterhub_cred_manager.get_key.return_value = 'secret-token'
+
+    client = modelon.impact.client.Client(
+        url=jupyterhub_api.url,
+        context=jupyterhub_api.context,
+        credential_manager=cred_manager,
+        interactive=True,
+        jupyterhub_credential_manager=jupyterhub_cred_manager,
+    )
+    jupyterhub_cred_manager.write_key_to_file.assert_called_with('secret-token')


### PR DESCRIPTION
This PR adds support to the client to access an Impact server running in a Jupyterhub. It will be automatically detected if the server the user is pointing against is a Jupyterhub and if that case we will authorize against. This authorization is like how we handle API keys in Impact. Once authorized a new URL and context exists to start the regular Impact client business.