### PR TITLE
Experiment user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ make lint
 
 ## Build
 
-Building chimp is done by running
+Building modelon-impact-client is done by running
 
 ```
 make wheel

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -194,9 +194,13 @@ class WorkspaceService:
             url, headers={"Accept": "application/vnd.impact.experiment.v2+json"}
         )
 
-    def experiment_create(self, workspace_id, definition):
+    def experiment_create(self, workspace_id, definition, user_data=None):
         url = (self._base_uri / f"api/workspaces/{workspace_id}/experiments").resolve()
-        return self._http_client.post_json(url, body=definition)
+        body = {
+            **definition,
+            **({"userData": user_data} if user_data is not None else {}),
+        }
+        return self._http_client.post_json(url, body=body)
 
 
 class ModelExecutableService:

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -15,6 +15,7 @@ from modelon.impact.client.entities import (
 
 MockedServer = collections.namedtuple('MockedServer', ['url', 'context', 'adapter'])
 ExperimentMock = collections.namedtuple('ExperimentMock', ['entity', 'service'])
+WorkspaceMock = collections.namedtuple('WorkspaceMock', ['entity', 'service'])
 
 
 def with_json_route(
@@ -42,7 +43,9 @@ def with_exception(mock_server_base, method, url, exce):
 
 def with_json_route_no_resp(mock_server_base, method, url, status_code=200):
     mock_server_base.adapter.register_uri(
-        method, f'{mock_server_base.url}/{url}', status_code=status_code,
+        method,
+        f'{mock_server_base.url}/{url}',
+        status_code=status_code,
     )
     return mock_server_base
 
@@ -851,11 +854,14 @@ def workspace():
         }
     }
     exp_service.experiment_execute.return_value = "pid_2009"
-    return Workspace(
-        'AwesomeWorkspace',
+    return WorkspaceMock(
+        Workspace(
+            'AwesomeWorkspace',
+            ws_service,
+            experiment_service=exp_service,
+            custom_function_service=custom_function_service,
+        ),
         ws_service,
-        experiment_service=exp_service,
-        custom_function_service=custom_function_service,
     )
 
 

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -7,7 +7,7 @@ from tests.impact.client.fixtures import *
 
 
 class TestService:
-    def test_api_get_meta_data(self, api_get_metadata):
+    def test_api_get_metadata(self, api_get_metadata):
         uri = modelon.impact.client.sal.service.URI(api_get_metadata.url)
         service = modelon.impact.client.sal.service.Service(
             uri=uri, context=api_get_metadata.context
@@ -232,6 +232,11 @@ class TestWorkspaceService:
         data = service.workspace.experiment_create("WS", {})
         assert experiment_create.adapter.called
         assert data == {"experiment_id": "pid_2009"}
+
+        user_data = {"value": 42}
+        data = service.workspace.experiment_create("WS", {}, user_data)
+        request_data = experiment_create.adapter.request_history[1].json()
+        assert request_data == {'userData': user_data}
 
 
 class TestModelExecutbleService:

--- a/tests/impact/client/test_operations.py
+++ b/tests/impact/client/test_operations.py
@@ -90,16 +90,17 @@ class TestCachedModelExecutableOperation:
 
 class TestExperimentOperation:
     def test_execute_wait_done(
-        self, workspace,
+        self,
+        workspace,
     ):
-        exp = workspace.execute({})
+        exp = workspace.entity.execute({})
         assert exp.id == "pid_2009"
         assert exp.status() == Status.DONE
         assert exp.is_complete()
         assert exp.wait() == Experiment('AwesomeWorkspace', 'pid_2009')
 
     def test_execute_wait_cancel_timeout(self, workspace):
-        exp = workspace.execute({})
+        exp = workspace.entity.execute({})
         assert exp.id == "pid_2009"
         assert exp.status() == Status.DONE
         assert exp.is_complete()
@@ -133,7 +134,8 @@ class TestExperimentOperation:
 
 class TestCaseOperation:
     def test_execute_wait_done(
-        self, experiment,
+        self,
+        experiment,
     ):
         case = experiment.entity.get_case('case_1')
         case_ops = case.execute()


### PR DESCRIPTION
This PR adds support for attaching a custom user_data dictionary object to experiments.

It can be added like this:

```
experiment = workspace.create_experiment(experiment_definition, user_data={"customProp": customValue})
```

or like this:

```
experiment = workspace.execute(experiment_definition, user_data={"customProp": customValue}).wait()
```

and then later retrieved:

```
user_data = experiment.metadata.user_data
```

The test additions are probably the main pain-point in this PR, suggestions for improvements are most welcome :pray: 