### PR TITLE
feat: login again if there is an authentication error

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -140,11 +140,8 @@ class Client:
                 "No Modelon Impact API key could be found, "
                 "will log in as anonymous user. Permissions may be limited"
             )
-            login_data = {}
-        else:
-            login_data = {"secretKey": self._api_key}
 
-        self._sal.api_login(login_data)
+        self._sal.api_login(api_key=self._api_key)
         if self._api_key and interactive:
             # Save the api_key for next time if
             # running interactively and login was successfuly

--- a/modelon/impact/client/sal/exceptions.py
+++ b/modelon/impact/client/sal/exceptions.py
@@ -19,7 +19,9 @@ class UnauthorizedError(ServiceAccessError):
 
 
 class HTTPError(ServiceAccessError):
-    pass
+    def __init__(self, message, status_code):
+        self.status_code = status_code
+        super().__init__(message)
 
 
 class ErrorBodyIsNotJSONError(ServiceAccessError):

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -22,7 +22,7 @@ def _decorate_all_methods(cls, decorator):
 class Service:
     _JUPYTERHUB_VERSION_HEADER = 'x-jupyterhub-version'
 
-    def __init__(self, uri, context=None, credential_resolver=None):
+    def __init__(self, uri, context=None):
         self._base_uri = uri
         self._http_client = HTTPClient(context)
         self.workspace = WorkspaceService(self._base_uri, self._http_client)
@@ -32,10 +32,7 @@ class Service:
         self.experiment = ExperimentService(self._base_uri, self._http_client)
         self.custom_function = CustomFunctionService(self._base_uri, self._http_client)
 
-        if credential_resolver is not None:
-            self._add_retry_with(credential_resolver)
-
-    def _add_retry_with(self, credential_resolver):
+    def add_login_retry_with(self, api_key=None):
         def retry_with_login_decorator(func):
             def wrapped(*args, **kwargs):
                 try:
@@ -44,7 +41,7 @@ class Service:
                     if e.status_code != 401:
                         raise
 
-                    credential_resolver()
+                    self.api_login(api_key=api_key)
                     return func(*args, **kwargs)
 
             return wrapped

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -73,7 +73,8 @@ class Service:
 
         return response.data
 
-    def api_login(self, login_data):
+    def api_login(self, api_key=None):
+        login_data = {"secretKey": api_key} if api_key else {}
         url = (self._base_uri / "api/login").resolve()
         return self._http_client.post_json(url, login_data)
 

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -15,6 +15,80 @@ class TestService:
         data = service.api_get_metadata()
         assert data == {'version': '1.1.0'}
 
+    def test_given_no_error_when_access_then_no_login_and_ok(self, create_workspace):
+        # Given
+        uri = modelon.impact.client.sal.service.URI(create_workspace.url)
+        credential_resolver = mock.MagicMock()
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri,
+            context=create_workspace.context,
+            credential_resolver=credential_resolver,
+        )
+
+        # when
+        data = service.workspace.workspace_create('AwesomeWorkspace')
+
+        # Then
+        credential_resolver.assert_not_called()
+        assert data == {'id': 'newWorkspace'}
+
+    def test_given_authenticat_fail_once_when_access_then_login_and_ok(
+        self, create_workspace_fail_auth_once
+    ):
+        # Given
+        uri = modelon.impact.client.sal.service.URI(create_workspace_fail_auth_once.url)
+        credential_resolver = mock.MagicMock()
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri,
+            context=create_workspace_fail_auth_once.context,
+            credential_resolver=credential_resolver,
+        )
+
+        # When
+        data = service.workspace.workspace_create('AwesomeWorkspace')
+
+        # Then
+        credential_resolver.assert_called_once()
+        assert data == {'id': 'newWorkspace'}
+
+    def test_given_authenticat_fail_many_when_access_then_fail(
+        self, create_workspace_fail_auth_many
+    ):
+        # Given
+        uri = modelon.impact.client.sal.service.URI(create_workspace_fail_auth_many.url)
+        credential_resolver = mock.MagicMock()
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri,
+            context=create_workspace_fail_auth_many.context,
+            credential_resolver=credential_resolver,
+        )
+
+        # When
+        with pytest.raises(modelon.impact.client.sal.exceptions.HTTPError):
+            service.workspace.workspace_create('AwesomeWorkspace')
+
+        # Then
+        credential_resolver.assert_called_once()
+
+    def test_given_non_auth_failure_when_access_then_fail(
+        self, create_workspace_fail_bad_input
+    ):
+        # Given
+        uri = modelon.impact.client.sal.service.URI(create_workspace_fail_bad_input.url)
+        credential_resolver = mock.MagicMock()
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri,
+            context=create_workspace_fail_bad_input.context,
+            credential_resolver=credential_resolver,
+        )
+
+        # When
+        with pytest.raises(modelon.impact.client.sal.exceptions.HTTPError):
+            service.workspace.workspace_create('AwesomeWorkspace')
+
+        # Then
+        credential_resolver.assert_not_called()
+
 
 class TestWorkspaceService:
     def test_create_workspace(self, create_workspace):

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -18,18 +18,16 @@ class TestService:
     def test_given_no_error_when_access_then_no_login_and_ok(self, create_workspace):
         # Given
         uri = modelon.impact.client.sal.service.URI(create_workspace.url)
-        credential_resolver = mock.MagicMock()
         service = modelon.impact.client.sal.service.Service(
-            uri=uri,
-            context=create_workspace.context,
-            credential_resolver=credential_resolver,
+            uri=uri, context=create_workspace.context
         )
+        service.add_login_retry_with(api_key=None)
 
         # when
         data = service.workspace.workspace_create('AwesomeWorkspace')
 
         # Then
-        credential_resolver.assert_not_called()
+        assert len(create_workspace.adapter.request_history) == 1
         assert data == {'id': 'newWorkspace'}
 
     def test_given_authenticat_fail_once_when_access_then_login_and_ok(
@@ -37,18 +35,16 @@ class TestService:
     ):
         # Given
         uri = modelon.impact.client.sal.service.URI(create_workspace_fail_auth_once.url)
-        credential_resolver = mock.MagicMock()
         service = modelon.impact.client.sal.service.Service(
-            uri=uri,
-            context=create_workspace_fail_auth_once.context,
-            credential_resolver=credential_resolver,
+            uri=uri, context=create_workspace_fail_auth_once.context
         )
+        service.add_login_retry_with(api_key=None)
 
         # When
         data = service.workspace.workspace_create('AwesomeWorkspace')
 
         # Then
-        credential_resolver.assert_called_once()
+        assert len(create_workspace_fail_auth_once.adapter.request_history) == 3
         assert data == {'id': 'newWorkspace'}
 
     def test_given_authenticat_fail_many_when_access_then_fail(
@@ -56,38 +52,34 @@ class TestService:
     ):
         # Given
         uri = modelon.impact.client.sal.service.URI(create_workspace_fail_auth_many.url)
-        credential_resolver = mock.MagicMock()
         service = modelon.impact.client.sal.service.Service(
-            uri=uri,
-            context=create_workspace_fail_auth_many.context,
-            credential_resolver=credential_resolver,
+            uri=uri, context=create_workspace_fail_auth_many.context
         )
+        service.add_login_retry_with(api_key=None)
 
         # When
         with pytest.raises(modelon.impact.client.sal.exceptions.HTTPError):
             service.workspace.workspace_create('AwesomeWorkspace')
 
         # Then
-        credential_resolver.assert_called_once()
+        assert len(create_workspace_fail_auth_many.adapter.request_history) == 3
 
     def test_given_non_auth_failure_when_access_then_fail(
         self, create_workspace_fail_bad_input
     ):
         # Given
         uri = modelon.impact.client.sal.service.URI(create_workspace_fail_bad_input.url)
-        credential_resolver = mock.MagicMock()
         service = modelon.impact.client.sal.service.Service(
-            uri=uri,
-            context=create_workspace_fail_bad_input.context,
-            credential_resolver=credential_resolver,
+            uri=uri, context=create_workspace_fail_bad_input.context
         )
+        service.add_login_retry_with(api_key=None)
 
         # When
         with pytest.raises(modelon.impact.client.sal.exceptions.HTTPError):
             service.workspace.workspace_create('AwesomeWorkspace')
 
         # Then
-        credential_resolver.assert_not_called()
+        assert len(create_workspace_fail_bad_input.adapter.request_history) == 1
 
 
 class TestWorkspaceService:

--- a/tests/impact/client/test_operations.py
+++ b/tests/impact/client/test_operations.py
@@ -89,10 +89,7 @@ class TestCachedModelExecutableOperation:
 
 
 class TestExperimentOperation:
-    def test_execute_wait_done(
-        self,
-        workspace,
-    ):
+    def test_execute_wait_done(self, workspace):
         exp = workspace.entity.execute({})
         assert exp.id == "pid_2009"
         assert exp.status() == Status.DONE
@@ -133,10 +130,7 @@ class TestExperimentOperation:
 
 
 class TestCaseOperation:
-    def test_execute_wait_done(
-        self,
-        experiment,
-    ):
+    def test_execute_wait_done(self, experiment):
         case = experiment.entity.get_case('case_1')
         case_ops = case.execute()
         assert case_ops.id == "case_1"


### PR DESCRIPTION
This PR solves so you will login again if your JWT expires. This is particularly important for long running simulations that run over the night. The implementation is done by a decorator that is applied to all methods of the service classes. This decorator will look for a HTTP 401 failure, re-login, and retry.

### How to test:
```
from modelon.impact.client import Client
 c = Client(url='...', interactive=True)
print(c.get_workspaces())
c._sal._http_client._context.session.cookies.clear() # Ugly hack to ensure next request will fail with a 401
print(c.get_workspaces())
```
Previously this code would fail but now it should recover.