### PR TITLE
Check license after login

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -56,7 +56,7 @@ class Client:
         client = Client(url=impact_url, interactive=True)
     """
 
-    _SUPPORTED_VERSION_RANGE = ">=1.18.0,<2.0.0"
+    _SUPPORTED_VERSION_RANGE = ">=1.21.0,<2.0.0"
 
     def __init__(
         self,
@@ -104,6 +104,13 @@ class Client:
                 raise
 
         self._sal.add_login_retry_with(api_key)
+
+        resp = self._sal.users.get_me()
+        if 'license' not in resp['data']:
+            raise exceptions.NoAssignedLicenseError(
+                "No assigned license during login. Either out of floating "
+                "licenses or your assigned license could not be validated"
+            )
 
     def _validate_compatible_api_version(self):
         try:

--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -108,8 +108,8 @@ class Client:
         resp = self._sal.users.get_me()
         if 'license' not in resp['data']:
             raise exceptions.NoAssignedLicenseError(
-                "No assigned license during login. Either out of floating "
-                "licenses or your assigned license could not be validated"
+                "No assigned license during login. Either out of floating Deployment "
+                "Add-on licenses or your assigned user license could not be validated"
             )
 
     def _validate_compatible_api_version(self):

--- a/modelon/impact/client/exceptions.py
+++ b/modelon/impact/client/exceptions.py
@@ -6,6 +6,10 @@ class UnsupportedSemanticVersionError(Error):
     pass
 
 
+class NoAssignedLicenseError(Error):
+    pass
+
+
 class OperationTimeOutError(Error):
     pass
 

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -31,6 +31,7 @@ class Service:
         )
         self.experiment = ExperimentService(self._base_uri, self._http_client)
         self.custom_function = CustomFunctionService(self._base_uri, self._http_client)
+        self.users = UsersService(self._base_uri, self._http_client)
 
     def add_login_retry_with(self, api_key=None):
         def retry_with_login_decorator(func):
@@ -58,6 +59,7 @@ class Service:
         self.custom_function = _decorate_all_methods(
             self.custom_function, retry_with_login_decorator
         )
+        self.users = _decorate_all_methods(self.users, retry_with_login_decorator)
 
     def api_get_metadata(self):
         url = (self._base_uri / "api/").resolve()
@@ -74,6 +76,16 @@ class Service:
         login_data = {"secretKey": api_key} if api_key else {}
         url = (self._base_uri / "api/login").resolve()
         return self._http_client.post_json(url, login_data)
+
+
+class UsersService:
+    def __init__(self, uri, HTTPClient):
+        self._base_uri = uri
+        self._http_client = HTTPClient
+
+    def get_me(self):
+        url = (self._base_uri / "api/users/me").resolve()
+        return self._http_client.get_json(url)
 
 
 class WorkspaceService:

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -304,63 +304,41 @@ def import_fmu(sem_ver_check, mock_server_base):
     )
 
 
-@pytest.fixture
-def upload_result(sem_ver_check, mock_server_base):
-    json = {
-        "data": {
-            "id": "2f036b9fab6f45c788cc466da327cc78workspace",
-            "status": "ready",
-            "error": "None",
-        }
-    }
-
-    return with_json_route(mock_server_base, 'POST', 'api/uploads/results', json)
-
-
-@pytest.fixture
-def upload_result_status_ready(sem_ver_check, mock_server_base):
-    json = {
+def get_upload_result_ready_data():
+    return {
         "data": {
             "id": "2f036b9fab6f45c788cc466da327cc78workspace",
             "status": "ready",
             "data": {
                 "resourceUri": "api/external-result/2f036b9fab6f45c788cc466da327cc78workspace"
             },
-            "error": "None",
         }
     }
-    return with_json_route(
-        mock_server_base,
-        'GET',
-        'api/uploads/results/2f036b9fab6f45c788cc466da327cc78workspace',
-        json,
-    )
 
 
-@pytest.fixture
-def upload_result_status_running(sem_ver_check, mock_server_base):
-    json = {
+def get_upload_result_running_data():
+    return {
         "data": {
             "id": "2f036b9fab6f45c788cc466da327cc78workspace",
             "status": "running",
             "data": {
                 "resourceUri": "api/external-result/2f036b9fab6f45c788cc466da327cc78workspace"
             },
-            "error": "None",
         }
     }
 
-    return with_json_route(
-        mock_server_base,
-        'GET',
-        'api/uploads/results/2f036b9fab6f45c788cc466da327cc78workspace',
-        json,
-    )
+
+def get_result_upload_post_data():
+    return {
+        "data": {
+            "id": "2f036b9fab6f45c788cc466da327cc78workspace",
+            "status": "running",
+        }
+    }
 
 
-@pytest.fixture
-def upload_result_meta(sem_ver_check, mock_server_base):
-    json = {
+def get_external_result_data():
+    return {
         "data": {
             "id": "2f036b9fab6f45c788cc466da327cc78workspace",
             "createdAt": "2021-09-02T08:26:49.612000",
@@ -370,11 +348,68 @@ def upload_result_meta(sem_ver_check, mock_server_base):
         }
     }
 
+
+@pytest.fixture
+def workspace_sal_upload_base():
+    workspace_service = unittest.mock.MagicMock()
+    workspace_service.result_upload.return_value = get_result_upload_post_data()
+    workspace_service.get_uploaded_result_meta.return_value = get_external_result_data()
+
+    return workspace_service
+
+
+@pytest.fixture
+def workspace_sal_upload_result_ready(workspace_sal_upload_base):
+    workspace_sal_upload_base.get_result_upload_status.return_value = (
+        get_upload_result_ready_data()
+    )
+
+    return workspace_sal_upload_base
+
+
+@pytest.fixture
+def workspace_sal_upload_result_running(workspace_sal_upload_base):
+    workspace_sal_upload_base.get_result_upload_status.return_value = (
+        get_upload_result_running_data()
+    )
+
+    return workspace_sal_upload_base
+
+
+@pytest.fixture
+def upload_result_status_ready(sem_ver_check, mock_server_base):
+    return with_json_route(
+        mock_server_base,
+        'GET',
+        'api/uploads/results/2f036b9fab6f45c788cc466da327cc78workspace',
+        get_upload_result_ready_data(),
+    )
+
+
+@pytest.fixture
+def upload_result_status_running(sem_ver_check, mock_server_base):
+    return with_json_route(
+        mock_server_base,
+        'GET',
+        'api/uploads/results/2f036b9fab6f45c788cc466da327cc78workspace',
+        get_upload_result_running_data(),
+    )
+
+
+@pytest.fixture
+def upload_result(sem_ver_check, mock_server_base):
+    return with_json_route(
+        mock_server_base, 'POST', 'api/uploads/results', get_result_upload_post_data()
+    )
+
+
+@pytest.fixture
+def upload_result_meta(sem_ver_check, mock_server_base):
     return with_json_route(
         mock_server_base,
         'GET',
         'api/external-result/2f036b9fab6f45c788cc466da327cc78workspace',
-        json,
+        get_external_result_data(),
     )
 
 

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -98,6 +98,11 @@ class TestWorkspaceService:
         )
         service.workspace.workspace_delete('AwesomeWorkspace')
         assert delete_workspace.adapter.called
+        delete_call = delete_workspace.adapter.request_history[0]
+        assert (
+            'http://mock-impact.com/api/workspaces/AwesomeWorkspace' == delete_call.url
+        )
+        assert 'DELETE' == delete_call.method
 
     def test_get_workspace(self, single_workspace):
         uri = modelon.impact.client.sal.service.URI(single_workspace.url)
@@ -124,6 +129,12 @@ class TestWorkspaceService:
         )
         service.workspace.library_import('AwesomeWorkspace', SINGLE_FILE_LIBRARY_PATH)
         assert import_lib.adapter.called
+        import_call = import_lib.adapter.request_history[0]
+        assert (
+            'http://mock-impact.com/api/workspaces/AwesomeWorkspace/libraries'
+            == import_call.url
+        )
+        assert 'POST' == import_call.method
 
     def test_workspace_upload(self, upload_workspace):
         uri = modelon.impact.client.sal.service.URI(upload_workspace.url)
@@ -145,8 +156,7 @@ class TestWorkspaceService:
         assert data == {
             "data": {
                 "id": "2f036b9fab6f45c788cc466da327cc78workspace",
-                "status": "ready",
-                "error": "None",
+                "status": "running",
             }
         }
 
@@ -166,7 +176,6 @@ class TestWorkspaceService:
                 "data": {
                     "resourceUri": "api/external-result/2f036b9fab6f45c788cc466da327cc78workspace"
                 },
-                "error": "None",
             }
         }
 
@@ -218,6 +227,13 @@ class TestWorkspaceService:
             "library": {"id": "Workspace", "uses": {}, "name": "Workspace"},
         }
 
+        import_fmu_call = import_fmu.adapter.request_history[0]
+        assert (
+            'http://mock-impact.com/api/workspaces/AwesomeWorkspace/libraries/Workspace/models'
+            == import_fmu_call.url
+        )
+        assert 'POST' == import_fmu_call.method
+
     def test_workspace_download(self, download_workspace):
         uri = modelon.impact.client.sal.service.URI(download_workspace.url)
         service = modelon.impact.client.sal.service.Service(
@@ -233,6 +249,12 @@ class TestWorkspaceService:
         )
         service.workspace.workspace_lock("AwesomeWorkspace")
         assert lock_workspace.adapter.called
+        lock_call = lock_workspace.adapter.request_history[0]
+        assert (
+            'http://mock-impact.com/api/workspaces/AwesomeWorkspace/lock'
+            == lock_call.url
+        )
+        assert 'POST' == lock_call.method
 
     def test_unlock_workspace(self, unlock_workspace):
         uri = modelon.impact.client.sal.service.URI(unlock_workspace.url)
@@ -241,6 +263,12 @@ class TestWorkspaceService:
         )
         service.workspace.workspace_unlock("AwesomeWorkspace")
         assert unlock_workspace.adapter.called
+        unlock_call = unlock_workspace.adapter.request_history[0]
+        assert (
+            'http://mock-impact.com/api/workspaces/AwesomeWorkspace/lock'
+            == unlock_call.url
+        )
+        assert 'DELETE' == unlock_call.method
 
     def test_clone_workspace(self, clone_workspace):
         uri = modelon.impact.client.sal.service.URI(clone_workspace.url)


### PR DESCRIPTION
This PR uses the new version of the API where you can get the license of current user. If no license an exception is raised informing the user. I am very open to improvements to the error message; this was the best I could think of.