### PR TITLE
chore: add dev container as a developer alternative

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,47 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/docker-existing-dockerfile
+{
+	"name": "VS Code extension of Poetry Docker dev image",
+
+	// Base on Dockerfile one level up:
+	"context": "..",
+	"dockerFile": "../Dockerfile",
+
+	// Mount to WORKDIR as specified in Dockerfile:
+	"workspaceMount": "source=${localWorkspaceFolder},target=/home/dev/src,type=bind",
+	"workspaceFolder": "/home/dev/src",
+
+	// Python IDE settings:
+	"settings": {
+		"python.pythonPath": "/home/dev/poetry-virtualenvs/modelon-impact-client-1JqLc1Zx-py3.7/bin/python",
+		"python.defaultInterpreterPath": "/home/dev/poetry-virtualenvs/modelon-impact-client-1JqLc1Zx-py3.7/bin/python",
+		"terminal.integrated.profiles.linux": {
+			"poetry shell": {
+			  "path": "poetry",
+			  "args": ["shell"]
+			}
+		},
+		"terminal.integrated.defaultProfile.linux": "poetry shell",
+		"python.formatting.provider": "black",
+		"python.formatting.blackArgs": [
+			"-S"
+		],
+		"[python]": {
+			"editor.formatOnSave": true,
+			"editor.formatOnSaveTimeout": 3000
+		},
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.flake8Enabled": true,
+		"python.testing.pytestEnabled": true,
+	},
+	
+	// Python IDE extensions:
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance"
+	],
+
+	// User from Dockerfile:
+	"remoteUser": "dev",
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /home/dev
 RUN pip install -U pip
 
 # update 
-RUN apt-get update && apt-get install -y curl apt-utils
+RUN apt-get update && apt-get install -y curl apt-utils bash-completion
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash
 RUN apt-get install -y nodejs
 RUN node -v

--- a/README.md
+++ b/README.md
@@ -5,8 +5,27 @@ Client library for easy scripting against Modelon Impact
 
 For installation instructions and requirements, please refer to the [documentation](https://modelon-impact-client.readthedocs.io).
 
-
 ## Develop
+
+### Devcontainer
+If you are developing with VS Code you can use the devcontainer which gives gives you a ready to use environment for development. Just click the "Reopen in Container" button after opening the project in VS Code.
+
+#### Tips and tricks
+It is possible to run the 'make' commands listed bellow using the devcontainer. It will detect being in a container and bypass Docker parts of the commands.
+
+You can open a project with the dev-container directly without having to open and then re-load. Standing in the project directory you can run:
+```
+devcontainer open .
+```
+Note that this requires the [devcontainer-cli](https://code.visualstudio.com/docs/remote/devcontainer-cli).
+
+You can add your own extensions to devcontainers. These extensions will be added for all devcontainers. First open your 'settings' as JSON. Then, to add for example the "GitLens" extension, put the following at the bottom of the settings:
+```
+    ...
+    "remote.containers.defaultExtensions": ["eamodio.gitlens"]
+}
+```
+VS Code also have a `'Install Local Extensions in 'Remote'` command, but it must be repeated for each devcontainer and everytime a devcontainer is re-built.
 
 ### Creating a shell
 Modelon-impact-client is developed using a Docker container for all build tools.


### PR DESCRIPTION
An early present to help with writing code 😄. This configuration builds on the existing Dockerfile and should not require too much work to keep up to date. It gives an out of box working dev environment in VS Code that is very nice and productive.

### How to test
 * Open project and click "Reopen in Container"
 * Observe that you have autoformat on save and flake8 warnings
 * It is also possible to run a single test directly from the code! (though it seems you have to wait a 10-20s after opening the first test file until you see the icons):
![bild](https://user-images.githubusercontent.com/18346319/146979323-24f8e4b1-7acb-451e-8e5a-d26e825b4c96.png)
