### PR TITLE
feat: Added possibility to specify result format

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -56,7 +56,7 @@ class Client:
         client = Client(url=impact_url, interactive=True)
     """
 
-    _SUPPORTED_VERSION_RANGE = ">=1.21.0,<4.0.0"
+    _SUPPORTED_VERSION_RANGE = ">=1.21.3,<4.0.0"
 
     def __init__(
         self,

--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import logging
+import modelon.impact.client.sal.service
 from modelon.impact.client import operations
 
 from modelon.impact.client.experiment_definition import (
@@ -1957,9 +1958,16 @@ class Case:
             self._exp_sal.case_get_log(self._workspace_id, self._exp_id, self._case_id)
         )
 
-    def get_result(self):
+    def get_result(self, format='mat'):
         """
         Returns the result stream and the file name for a finished case.
+
+        Parameters:
+
+            format --
+                The file format to download the result in. The only possible values
+                are 'mat' and 'csv'.
+                Default: 'mat'
 
         Returns:
 
@@ -1979,13 +1987,14 @@ class Case:
 
         Example::
 
-            result, file_name = case.get_result()
-            with open(file_name, "wb") as f:
+            result, file_name = case.get_result(format = 'csv')
+            with open(file_name, "w") as f:
                 f.write(result)
         """
         _assert_successful_operation(self.is_successful(), self._case_id)
+        result_format = modelon.impact.client.sal.service.ResultFormat(format)
         result, file_name = self._exp_sal.case_result_get(
-            self._workspace_id, self._exp_id, self._case_id
+            self._workspace_id, self._exp_id, self._case_id, result_format
         )
         return result, file_name
 

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -78,6 +78,60 @@ def with_text_route(mock_server_base, method, url, text_response, status_code=20
     return mock_server_base
 
 
+def with_csv_route(
+    mock_server_base, method, url, text_response, status_code=200, content_header=None
+):
+    text = text_response
+    content_header = (
+        {
+            'content-type': 'text/csv',
+            'content-disposition': 'attachment; '
+            'filename="BouncingBall_2020-09-01_14-33_case_1.csv"',
+            'connection': 'close',
+            'date': 'Tue, 01 Sep 2020 14:33:56 GMT',
+            'server': '127.0.0.1',
+            'Transfer-Encoding': 'chunked',
+        }
+        if content_header is None
+        else content_header
+    )
+    mock_server_base.adapter.register_uri(
+        method,
+        f'{mock_server_base.url}/{url}',
+        text=text,
+        headers=content_header,
+        status_code=status_code,
+    )
+    return mock_server_base
+
+
+def with_mat_stream_route(
+    mock_server_base, method, url, mat_response, status_code=200, content_header=None
+):
+    content = mat_response
+    content_header = (
+        {
+            'content-type': 'application/vnd.impact.mat.v1+octet-stream',
+            'content-disposition': 'attachment; '
+            'filename="BouncingBall_2020-09-01_14-33_case_1.mat"',
+            'connection': 'close',
+            'date': 'Tue, 01 Sep 2020 14:33:56 GMT',
+            'server': '127.0.0.1',
+            'Transfer-Encoding': 'chunked',
+        }
+        if content_header is None
+        else content_header
+    )
+    mock_server_base.adapter.register_uri(
+        method,
+        f'{mock_server_base.url}/{url}',
+        content=content,
+        headers=content_header,
+        status_code=status_code,
+    )
+    return mock_server_base
+
+
 def with_octet_stream_route(
     mock_server_base, method, url, octet_response, status_code=200, content_header=None
 ):
@@ -131,7 +185,7 @@ def api_get_metadata(mock_server_base):
 
 @pytest.fixture
 def sem_ver_check(mock_server_base):
-    json = {"version": "1.21.0"}
+    json = {"version": "1.21.3"}
     return with_json_route(mock_server_base, 'GET', 'api/', json)
 
 
@@ -778,7 +832,7 @@ def get_case_log(sem_ver_check, mock_server_base):
 
 
 @pytest.fixture
-def get_case_results(sem_ver_check, mock_server_base):
+def get_mat_case_results(sem_ver_check, mock_server_base):
     binary = bytes(4)
 
     return with_octet_stream_route(
@@ -788,7 +842,30 @@ def get_case_results(sem_ver_check, mock_server_base):
         binary,
         content_header={
             'X-Powered-By': 'Express',
-            'content-type': 'application/octet-stream',
+            'content-type': 'application/vnd.impact.mat.v1+octet-stream',
+            'content-disposition': 'attachment; filename="Modelica.Blocks.Examples.PID_Controller_2020-10-22_06-03.mat"',
+            'connection': 'close',
+            'date': 'Thu, 22 Oct 2020 06:03:46 GMT',
+            'server': '127.0.0.1',
+            'Content-Length': '540',
+            'ETag': 'W/"21c-YYNaLhSng67+inxuWx+DHndUdno"',
+            'Vary': 'Accept-Encoding',
+        },
+    )
+
+
+@pytest.fixture
+def get_csv_case_results(sem_ver_check, mock_server_base):
+    text = "1;2;3"
+
+    return with_csv_route(
+        mock_server_base,
+        'GET',
+        'api/workspaces/WS/experiments/pid_2009/cases/case_1/result',
+        text,
+        content_header={
+            'X-Powered-By': 'Express',
+            'content-type': 'text/csv',
             'content-disposition': 'attachment; filename="Modelica.Blocks.Examples.PID_Controller_2020-10-22_06-03.csv"',
             'connection': 'close',
             'date': 'Thu, 22 Oct 2020 06:03:46 GMT',

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -534,13 +534,32 @@ class TestExperimentService:
         data = service.experiment.case_get_log("WS", "pid_2009", "case_1")
         assert data == 'Simulation log..'
 
-    def test_get_case_result(self, get_case_results):
-        uri = modelon.impact.client.sal.service.URI(get_case_results.url)
+    def test_get_mat_case_result(self, get_mat_case_results):
+        uri = modelon.impact.client.sal.service.URI(get_mat_case_results.url)
         service = modelon.impact.client.sal.service.Service(
-            uri=uri, context=get_case_results.context
+            uri=uri, context=get_mat_case_results.context
         )
-        data, name = service.experiment.case_result_get("WS", "pid_2009", "case_1")
+        data, name = service.experiment.case_result_get(
+            "WS",
+            "pid_2009",
+            "case_1",
+            modelon.impact.client.sal.service.ResultFormat.MAT,
+        )
         assert data == b'\x00\x00\x00\x00'
+        assert name == 'Modelica.Blocks.Examples.PID_Controller_2020-10-22_06-03.mat'
+
+    def test_get_csv_case_result(self, get_csv_case_results):
+        uri = modelon.impact.client.sal.service.URI(get_csv_case_results.url)
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri, context=get_csv_case_results.context
+        )
+        data, name = service.experiment.case_result_get(
+            "WS",
+            "pid_2009",
+            "case_1",
+            modelon.impact.client.sal.service.ResultFormat.CSV,
+        )
+        assert data == '1;2;3'
         assert name == 'Modelica.Blocks.Examples.PID_Controller_2020-10-22_06-03.csv'
 
     def test_get_case_artifact(self, get_case_artifact):

--- a/tests/impact/client/test_client.py
+++ b/tests/impact/client/test_client.py
@@ -61,7 +61,7 @@ def test_semantic_version_error(semantic_version_error):
         )
     assert (
         "Version '4.1.0' of the HTTP REST API is not supported, must be in the "
-        "range '>=1.21.0,<4.0.0'! Updgrade or downgrade this package to a version"
+        "range '>=1.21.3,<4.0.0'! Updgrade or downgrade this package to a version"
         " that supports version '4.1.0' of the HTTP REST API." in str(excinfo.value)
     )
 

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -675,3 +675,8 @@ class TestCase:
         assert case.input.analysis.solver_options == {'atol': 1e-8}
         assert case.input.analysis.simulation_log_level == "DEBUG"
         assert case.input.parametrization == {'PI.k': 120}
+
+    def test_get_result_invalid_format(self, experiment):
+        case = experiment.entity.get_case("case_1")
+        pytest.raises(ValueError, case.get_result, 'ma')
+


### PR DESCRIPTION
Jira - https://modelonproducts.atlassian.net/browse/WAMS-8882
Code to test
```
from modelon.impact.client import Client


client = Client(url="http://127.0.0.1:8080")
workspace = client.create_workspace("Pop1")

# Choose analysis type
# dynamic = workspace.get_custom_function('steady state')
dynamic = workspace.get_custom_function('dynamic')

# Get model class
model = workspace.get_model("Modelica.Mechanics.Translational.Examples.SignConvention")
# Execute experiment
experiment_definition = model.new_experiment_definition(dynamic)
exp = workspace.execute(experiment_definition).wait()

# Getting the simulated FMU object from the case object
case = exp.get_case('case_1')
result, file_name = case.get_result(format="csv")
with open(file_name, "w") as f:
    f.write(result)
result, file_name = case.get_result(format="mat")
with open(file_name, "wb") as f:
    f.write(result)

```