### PR TITLE
feat: remove workspace locks

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -56,7 +56,7 @@ class Client:
         client = Client(url=impact_url, interactive=True)
     """
 
-    _SUPPORTED_VERSION_RANGE = ">=1.21.0,<3.0.0"
+    _SUPPORTED_VERSION_RANGE = ">=1.21.0,<4.0.0"
 
     def __init__(
         self,

--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -327,24 +327,6 @@ class Workspace:
             self._model_exe_sal,
         )
 
-    def lock(self):
-        """Locks the workspace to the user.
-
-        Example::
-
-            workspace.lock()
-        """
-        self._workspace_sal.workspace_lock(self._workspace_id)
-
-    def unlock(self):
-        """Unlocks the workspace for other users.
-
-        Example::
-
-            workspace.unlock()
-        """
-        self._workspace_sal.workspace_unlock(self._workspace_id)
-
     def download(self, options, path):
         """Downloads the workspace as a binary compressed archive.
         Returns the local path to the downloaded workspace archive.

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -196,14 +196,6 @@ class WorkspaceService:
         ).resolve()
         return self._http_client.get_zip(url)
 
-    def workspace_lock(self, workspace_id):
-        url = (self._base_uri / f"api/workspaces/{workspace_id}/lock").resolve()
-        self._http_client.post_json_no_response_body(url)
-
-    def workspace_unlock(self, workspace_id):
-        url = (self._base_uri / f"api/workspaces/{workspace_id}/lock").resolve()
-        self._http_client.delete_json(url)
-
     def workspace_clone(self, workspace_id):
         url = (self._base_uri / f"api/workspaces/{workspace_id}/clone").resolve()
         return self._http_client.post_json(url)

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -268,7 +268,7 @@ def create_workspace_error(user_with_license):
 
 @pytest.fixture
 def semantic_version_error(mock_server_base):
-    json = {"version": "3.1.0"}
+    json = {"version": "4.1.0"}
 
     return with_json_route(mock_server_base, 'GET', 'api/', json)
 
@@ -461,22 +461,6 @@ def download_workspace(sem_ver_check, mock_server_base, get_export_id):
 
     return with_zip_route(
         mock_server_base, 'GET', 'api/workspaces/Workspace/exports/0d96b08c8d', content
-    )
-
-
-@pytest.fixture
-def lock_workspace(sem_ver_check, mock_server_base):
-
-    return with_json_route_no_resp(
-        mock_server_base, 'POST', 'api/workspaces/AwesomeWorkspace/lock'
-    )
-
-
-@pytest.fixture
-def unlock_workspace(sem_ver_check, mock_server_base):
-
-    return with_json_route_no_resp(
-        mock_server_base, 'DELETE', 'api/workspaces/AwesomeWorkspace/lock'
     )
 
 

--- a/tests/impact/client/sal/test_services.py
+++ b/tests/impact/client/sal/test_services.py
@@ -242,34 +242,6 @@ class TestWorkspaceService:
         data = service.workspace.workspace_download("Workspace", '0d96b08c8d')
         assert data == b'\x00\x00\x00\x00'
 
-    def test_lock_workspace(self, lock_workspace):
-        uri = modelon.impact.client.sal.service.URI(lock_workspace.url)
-        service = modelon.impact.client.sal.service.Service(
-            uri=uri, context=lock_workspace.context
-        )
-        service.workspace.workspace_lock("AwesomeWorkspace")
-        assert lock_workspace.adapter.called
-        lock_call = lock_workspace.adapter.request_history[0]
-        assert (
-            'http://mock-impact.com/api/workspaces/AwesomeWorkspace/lock'
-            == lock_call.url
-        )
-        assert 'POST' == lock_call.method
-
-    def test_unlock_workspace(self, unlock_workspace):
-        uri = modelon.impact.client.sal.service.URI(unlock_workspace.url)
-        service = modelon.impact.client.sal.service.Service(
-            uri=uri, context=unlock_workspace.context
-        )
-        service.workspace.workspace_unlock("AwesomeWorkspace")
-        assert unlock_workspace.adapter.called
-        unlock_call = unlock_workspace.adapter.request_history[0]
-        assert (
-            'http://mock-impact.com/api/workspaces/AwesomeWorkspace/lock'
-            == unlock_call.url
-        )
-        assert 'DELETE' == unlock_call.method
-
     def test_clone_workspace(self, clone_workspace):
         uri = modelon.impact.client.sal.service.URI(clone_workspace.url)
         service = modelon.impact.client.sal.service.Service(

--- a/tests/impact/client/test_client.py
+++ b/tests/impact/client/test_client.py
@@ -60,9 +60,9 @@ def test_semantic_version_error(semantic_version_error):
             url=semantic_version_error.url, context=semantic_version_error.context
         )
     assert (
-        "Version '3.1.0' of the HTTP REST API is not supported, must be in the "
-        "range '>=1.21.0,<3.0.0'! Updgrade or downgrade this package to a version"
-        " that supports version '3.1.0' of the HTTP REST API." in str(excinfo.value)
+        "Version '4.1.0' of the HTTP REST API is not supported, must be in the "
+        "range '>=1.21.0,<4.0.0'! Updgrade or downgrade this package to a version"
+        " that supports version '4.1.0' of the HTTP REST API." in str(excinfo.value)
     )
 
 

--- a/tests/impact/client/test_entities.py
+++ b/tests/impact/client/test_entities.py
@@ -79,18 +79,6 @@ class TestWorkspace:
         )
         assert upload_op.id == "2f036b9fab6f45c788cc466da327cc78workspace"
 
-    def test_lock(self):
-        workspace_service = unittest.mock.MagicMock()
-        workspace = Workspace('lockedWorksapce', workspace_service)
-        workspace.lock()
-        workspace_service.workspace_lock.assert_called_with('lockedWorksapce')
-
-    def test_unlock(self):
-        workspace_service = unittest.mock.MagicMock()
-        workspace = Workspace('unlockedWorksapce', workspace_service)
-        workspace.unlock()
-        workspace_service.workspace_unlock.assert_called_with('unlockedWorksapce')
-
     def test_download_workspace(self, workspace):
         t = os.path.join(tempfile.gettempdir(), workspace.entity.id + '.zip')
         resp = workspace.entity.download({}, tempfile.gettempdir())


### PR DESCRIPTION
This PR aims to remove workspace lock/unlock functionality and the corresponding tests.

As a consequence this could mean that the new client API release would require Impact API version 2.0.0 or higher where locks are removed.

However since in practice the python client is only changed to use a subset of the Impact API (i.e. the current Impact API minus locks) it is compatible with older impact versions. So a suggestion is to not update the supported version range to exclude older versions.