### PR TITLE
fix: add started to CaseStatus enum to mirror impact Case statuses

### DIFF
--- a/modelon/impact/client/entities.py
+++ b/modelon/impact/client/entities.py
@@ -98,6 +98,7 @@ class CaseStatus(Enum):
     FAILED = "failed"
     CANCELLED = "cancelled"
     NOT_STARTED = "not_started"
+    STARTED = 'started'
 
 
 class Workspace:


### PR DESCRIPTION
A small PR to address this ticket -> https://otrs.modelon.com/index.pl?Action=AgentTicketZoom;TicketID=39712