### PR TITLE
feat: added possibility to set defaults for custom functions and specify variable filter as a list of strings

### DIFF
--- a/modelon/impact/client/asserts.py
+++ b/modelon/impact/client/asserts.py
@@ -1,4 +1,9 @@
-from modelon.impact.client.options import ExecutionOptions
+from modelon.impact.client.options import (
+    SolverOptions,
+    SimulationOptions,
+    RuntimeOptions,
+    CompilerOptions,
+)
 from modelon.impact.client.entities.model import Model
 from modelon.impact.client.entities.custom_function import CustomFunction
 from modelon.impact.client.entities.model_executable import ModelExecutable
@@ -20,30 +25,30 @@ def assert_valid_args(
     if custom_function and not isinstance(custom_function, CustomFunction):
         raise TypeError("Custom_function must be an instance of CustomFunction class!")
     if solver_options is not None and not isinstance(
-        solver_options, (ExecutionOptions, dict)
+        solver_options, (SolverOptions, dict)
     ):
         raise TypeError(
-            "Solver options must be an instance of ExecutionOptions class or a "
+            "Solver options must be an instance of SolverOptions class or a "
             "dictionary class object!"
         )
     if simulation_options is not None and not isinstance(
-        simulation_options, (ExecutionOptions, dict)
+        simulation_options, (SimulationOptions, dict)
     ):
         raise TypeError(
-            "Simulation options must be an instance of ExecutionOptions class or"
+            "Simulation options must be an instance of SimulationOptions class or"
             " a dictionary class object!"
         )
     if compiler_options is not None and not isinstance(
-        compiler_options, (ExecutionOptions, dict)
+        compiler_options, (CompilerOptions, dict)
     ):
         raise TypeError(
             "Compiler options object must either be a dictionary or an "
-            "instance of modelon.impact.client.options.ExecutionOptions class!"
+            "instance of modelon.impact.client.options.CompilerOptions class!"
         )
     if runtime_options is not None and not isinstance(
-        runtime_options, (ExecutionOptions, dict)
+        runtime_options, (RuntimeOptions, dict)
     ):
         raise TypeError(
             "Runtime options object must either be a dictionary or an "
-            "instance of modelon.impact.client.options.ExecutionOptions class!"
+            "instance of modelon.impact.client.options.RuntimeOptions class!"
         )

--- a/modelon/impact/client/entities/custom_function.py
+++ b/modelon/impact/client/entities/custom_function.py
@@ -1,7 +1,12 @@
 import logging
 from typing import Any, List, Dict
 from modelon.impact.client.sal.custom_function import CustomFunctionService
-from modelon.impact.client.options import ExecutionOptions
+from modelon.impact.client.options import (
+    CompilerOptions,
+    RuntimeOptions,
+    SimulationOptions,
+    SolverOptions,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -111,80 +116,88 @@ class CustomFunction:
         """Custom_function parameters and value as a dictionary"""
         return {p.name: p.value for p in self._param_by_name.values()}
 
-    def get_compiler_options(self) -> ExecutionOptions:
+    def _get_options(self, use_defaults):
+        if use_defaults:
+            return self._custom_func_sal.custom_function_default_options_get(
+                self._workspace_id, self._name
+            )
+        return self._custom_func_sal.custom_function_options_get(
+            self._workspace_id, self._name
+        )
+
+    def get_compiler_options(self, use_defaults: bool = False) -> CompilerOptions:
         """
-        Return a modelon.impact.client.options.ExecutionOptions object.
+        Return a modelon.impact.client.options.CompilerOptions object.
 
         Returns:
 
             compiler_options --
-                A modelon.impact.client.options.ExecutionOptions object.
+                A modelon.impact.client.options.CompilerOptions object.
 
+            use_defaults --
+                If true, default compiler options are used.
         Example::
 
             opts = custom_function.get_compiler_options()
             opts_2 = opts.with_values(c_compiler='gcc')
         """
-        options = self._custom_func_sal.custom_function_options_get(
-            self._workspace_id, self._name
-        )
-        return ExecutionOptions(options["compiler"], self._name, self._custom_func_sal)
+        options = self._get_options(use_defaults=use_defaults)
+        return CompilerOptions(options["compiler"], self._name)
 
-    def get_runtime_options(self) -> ExecutionOptions:
+    def get_runtime_options(self, use_defaults: bool = False) -> RuntimeOptions:
         """
-        Return a modelon.impact.client.options.ExecutionOptions object.
+        Return a modelon.impact.client.options.RuntimeOptions object.
 
         Returns:
 
             runtime_options --
-                A modelon.impact.client.options.ExecutionOptions object.
+                A modelon.impact.client.options.RuntimeOptions object.
 
+            use_defaults --
+                If true, default runtime options are used.
         Example::
 
             opts = custom_function.get_runtime_options()
             opts_2 = opts.with_values(cs_solver=0)
         """
-        options = self._custom_func_sal.custom_function_options_get(
-            self._workspace_id, self._name
-        )
-        return ExecutionOptions(options["runtime"], self._name, self._custom_func_sal)
+        options = self._get_options(use_defaults=use_defaults)
+        return RuntimeOptions(options["runtime"], self._name)
 
-    def get_solver_options(self) -> ExecutionOptions:
+    def get_solver_options(self, use_defaults: bool = False) -> SolverOptions:
         """
-        Return a modelon.impact.client.options.ExecutionOptions object.
+        Return a modelon.impact.client.options.SolverOptions object.
 
         Returns:
 
             solver_options --
-                A modelon.impact.client.options.ExecutionOptions object.
+                A modelon.impact.client.options.SolverOptions object.
+
+            use_defaults --
+                If true, default solver options are used.
 
         Example::
 
             opts = custom_function.get_solver_options()
             opts_2 = opts.with_values(rtol=1e-7)
         """
-        options = self._custom_func_sal.custom_function_options_get(
-            self._workspace_id, self._name
-        )
-        return ExecutionOptions(options["solver"], self._name, self._custom_func_sal)
+        options = self._get_options(use_defaults=use_defaults)
+        return SolverOptions(options["solver"], self._name)
 
-    def get_simulation_options(self) -> ExecutionOptions:
+    def get_simulation_options(self, use_defaults: bool = False) -> SimulationOptions:
         """
-        Return a modelon.impact.client.options.ExecutionOptions object.
+        Return a modelon.impact.client.options.SimulationOptions object.
 
         Returns:
 
             simulation_options --
-                A modelon.impact.client.options.ExecutionOptions object.
+                A modelon.impact.client.options.SimulationOptions object.
 
+            use_defaults --
+                If true, default simulation options are used.
         Example::
 
             opts = custom_function.get_simulation_options()
             opts_2 = opts.with_values(ncp=500)
         """
-        options = self._custom_func_sal.custom_function_options_get(
-            self._workspace_id, self._name
-        )
-        return ExecutionOptions(
-            options["simulation"], self._name, self._custom_func_sal
-        )
+        options = self._get_options(use_defaults=use_defaults)
+        return SimulationOptions(options["simulation"], self._name)

--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -9,13 +9,22 @@ from modelon.impact.client.operations.model_executable import (
 
 from modelon.impact.client.experiment_definition import base
 from modelon.impact.client.entities.custom_function import CustomFunction
-from modelon.impact.client.options import ExecutionOptions
+from modelon.impact.client.options import (
+    CompilerOptions,
+    RuntimeOptions,
+    SimulationOptions,
+    SolverOptions,
+)
 from modelon.impact.client import asserts
 
 logger = logging.getLogger(__name__)
 
-Options = Union[ExecutionOptions, Dict[str, Any]]
 CompilationOperations = Union[ModelExecutableOperation, CachedModelExecutableOperation]
+
+RuntimeOptionsOrDict = Union[RuntimeOptions, Dict[str, Any]]
+CompilerOptionsOrDict = Union[CompilerOptions, Dict[str, Any]]
+SimulationOptionsOrDict = Union[SimulationOptions, Dict[str, Any]]
+SolverOptionsOrDict = Union[SolverOptions, Dict[str, Any]]
 
 
 class Model:
@@ -48,8 +57,8 @@ class Model:
 
     def compile(
         self,
-        compiler_options: Options,
-        runtime_options: Optional[Options] = None,
+        compiler_options: CompilerOptionsOrDict,
+        runtime_options: Optional[RuntimeOptionsOrDict] = None,
         compiler_log_level: str = "warning",
         fmi_target: str = "me",
         fmi_version: str = "2.0",
@@ -64,12 +73,12 @@ class Model:
 
             compiler_options --
                 An compilation options class instance of
-                modelon.impact.client.options.ExecutionOptions or
+                modelon.impact.client.options.CompilerOptions or
                 a dictionary object containing the compiler options.
 
             runtime_options --
                 An runtime options class instance of
-                modelon.impact.client.options.ExecutionOptions or
+                modelon.impact.client.options.RuntimeOptions or
                 a dictionary object containing the runtime options. Default: None.
 
             compiler_log_level --
@@ -120,14 +129,14 @@ class Model:
         )
         compiler_options = (
             dict(compiler_options)
-            if isinstance(compiler_options, ExecutionOptions)
+            if isinstance(compiler_options, CompilerOptions)
             else compiler_options
             if isinstance(compiler_options, dict)
             else {}
         )
         runtime_options = (
             dict(runtime_options)
-            if isinstance(runtime_options, ExecutionOptions)
+            if isinstance(runtime_options, RuntimeOptions)
             else runtime_options
             if isinstance(runtime_options, dict)
             else {}
@@ -172,14 +181,14 @@ class Model:
         self,
         custom_function: CustomFunction,
         *,
-        compiler_options: Optional[Options] = None,
+        compiler_options: Optional[CompilerOptionsOrDict] = None,
         fmi_target: str = "me",
         fmi_version: str = "2.0",
         platform: str = "auto",
         compiler_log_level: str = "warning",
-        runtime_options: Optional[Options] = None,
-        solver_options: Optional[Options] = None,
-        simulation_options: Optional[Options] = None,
+        runtime_options: Optional[RuntimeOptionsOrDict] = None,
+        solver_options: Optional[SolverOptionsOrDict] = None,
+        simulation_options: Optional[SimulationOptionsOrDict] = None,
         simulation_log_level: str = "WARNING",
     ):
         """
@@ -192,7 +201,7 @@ class Model:
 
             compiler_options --
                 An compilation options class instance of
-                modelon.impact.client.options.ExecutionOptions or
+                modelon.impact.client.options.CompilerOptions or
                 a dictionary object containing the compiler options.
 
             fmi_target --
@@ -221,7 +230,7 @@ class Model:
 
             runtime_options --
                 An runtime options class instance of
-                modelon.impact.client.options.ExecutionOptions or
+                modelon.impact.client.options.RuntimeOptions or
                 a dictionary object containing the runtime options. Default: None.
 
             solver_options --

--- a/modelon/impact/client/entities/model_executable.py
+++ b/modelon/impact/client/entities/model_executable.py
@@ -8,14 +8,15 @@ from modelon.impact.client.sal.model_executable import ModelExecutableService
 from modelon.impact.client.entities.asserts import assert_successful_operation
 from modelon.impact.client.entities.custom_function import CustomFunction
 from modelon.impact.client.entities.log import Log
-from modelon.impact.client.options import ExecutionOptions
+from modelon.impact.client.options import SimulationOptions, SolverOptions
 from modelon.impact.client.experiment_definition import base
 from modelon.impact.client import exceptions
 
 
 logger = logging.getLogger(__name__)
 
-Options = Union[ExecutionOptions, Dict[str, Any]]
+SimulationOptionsOrDict = Union[SimulationOptions, Dict[str, Any]]
+SolverOptionsOrDict = Union[SolverOptions, Dict[str, Any]]
 
 
 def _assert_compilation_is_complete(status, operation_name="Operation"):
@@ -194,8 +195,8 @@ class ModelExecutable:
     def new_experiment_definition(
         self,
         custom_function: CustomFunction,
-        solver_options: Optional[Options] = None,
-        simulation_options: Optional[Options] = None,
+        solver_options: Optional[SolverOptionsOrDict] = None,
+        simulation_options: Optional[SimulationOptionsOrDict] = None,
         simulation_log_level: str = "WARNING",
     ):
         """

--- a/modelon/impact/client/experiment_definition/extension.py
+++ b/modelon/impact/client/experiment_definition/extension.py
@@ -34,14 +34,14 @@ class SimpleExperimentExtension(BaseExperimentExtension):
 
         solver_options --
             A solver options class instance of
-            modelon.impact.client.options.ExecutionOptions or
+            modelon.impact.client.options.SolverOptions or
             a dictionary object containing the solver options. By
             default, the options is set to None, which means an empty dictionary
             is passed in the experiment extension.
 
         simulation_options --
             A simulation options class instance of
-            modelon.impact.client.options.ExecutionOptions or
+            modelon.impact.client.options.SimulationOptions or
             a dictionary object containing the simulation options. By
             default, the options is set to None, which means an empty dictionary
             is passed in the experiment extension.

--- a/modelon/impact/client/experiment_definition/util.py
+++ b/modelon/impact/client/experiment_definition/util.py
@@ -1,4 +1,4 @@
-from modelon.impact.client.options import ExecutionOptions
+from modelon.impact.client.options import BaseExecutionOptions
 
 
 def get_options(default_options, options):
@@ -6,7 +6,7 @@ def get_options(default_options, options):
         dict(default_options())
         if options is None
         else dict(options)
-        if isinstance(options, ExecutionOptions)
+        if isinstance(options, BaseExecutionOptions)
         else options
     )
 

--- a/tests/impact/client/entities/test_custom_function.py
+++ b/tests/impact/client/entities/test_custom_function.py
@@ -1,6 +1,10 @@
-import modelon.impact.client.sal.service
 import pytest
-import modelon.impact.client.options
+from modelon.impact.client.options import (
+    CompilerOptions,
+    SimulationOptions,
+    SolverOptions,
+    RuntimeOptions,
+)
 
 from tests.impact.client.fixtures import *
 
@@ -49,19 +53,27 @@ class TestCustomFunction:
     def test_compiler_options(self, custom_function):
         new = custom_function.get_compiler_options().with_values(c_compiler='gcc')
         assert dict(new) == {"c_compiler": "gcc"}
-        assert isinstance(new, modelon.impact.client.options.ExecutionOptions)
+        assert isinstance(new, CompilerOptions)
+        defaults = custom_function.get_compiler_options(use_defaults=True)
+        assert dict(defaults) == {'c_compiler': 'msvs'}
 
     def test_runtime_options(self, custom_function):
         new = custom_function.get_runtime_options().with_values(cs_solver=0)
         assert dict(new) == {"cs_solver": 0}
-        assert isinstance(new, modelon.impact.client.options.ExecutionOptions)
+        assert isinstance(new, RuntimeOptions)
+        defaults = custom_function.get_runtime_options(use_defaults=True)
+        assert dict(defaults) == {'log_level': 2}
 
     def test_simulation_options(self, custom_function):
         new = custom_function.get_simulation_options().with_values(ncp=500)
         assert dict(new) == {"ncp": 500}
-        assert isinstance(new, modelon.impact.client.options.ExecutionOptions)
+        assert isinstance(new, SimulationOptions)
+        defaults = custom_function.get_simulation_options(use_defaults=True)
+        assert dict(defaults) == {'ncp': 500}
 
     def test_solver_options(self, custom_function):
         new = custom_function.get_solver_options().with_values(atol=1e-7, rtol=1e-9)
         assert dict(new) == {'atol': 1e-7, 'rtol': 1e-9}
-        assert isinstance(new, modelon.impact.client.options.ExecutionOptions)
+        assert isinstance(new, SolverOptions)
+        defaults = custom_function.get_solver_options(use_defaults=True)
+        assert dict(defaults) == {'rtol': 1e-05}

--- a/tests/impact/client/fixtures.py
+++ b/tests/impact/client/fixtures.py
@@ -5,7 +5,12 @@ import pytest
 import requests
 import requests_mock
 from modelon.impact.client import Client
-from modelon.impact.client.options import ExecutionOptions
+from modelon.impact.client.options import (
+    CompilerOptions,
+    SimulationOptions,
+    SolverOptions,
+    RuntimeOptions,
+)
 from tests.impact.client.helpers import (
     create_workspace_entity,
     create_model_exe_entity,
@@ -1057,6 +1062,12 @@ def custom_function():
         "simulation": {"ncp": 500},
         "solver": {'atol': 1e-7, 'rtol': 1e-9},
     }
+    custom_function_service.custom_function_default_options_get.return_value = {
+        "compiler": {"c_compiler": "msvs"},
+        "runtime": {"log_level": 2},
+        "simulation": {"ncp": 500},
+        "solver": {"rtol": 1e-5},
+    }
     return create_custom_function_entity(
         'test_ws', 'dynamic', _custom_function_parameter_list(), custom_function_service
     )
@@ -1125,15 +1136,8 @@ def compiler_options():
         "simulation": {"ncp": 2000},
         "solver": {"rtol": 0.0001},
     }
-    def_opts = {
-        "compiler": {"c_compiler": "msvs"},
-        "runtime": {"log_level": 2},
-        "simulation": {"ncp": 500},
-        "solver": {"rtol": 1e-5},
-    }
     custom_function_service.custom_function_options_get.return_value = opts
-    custom_function_service.custom_function_default_options_get.return_value = def_opts
-    return ExecutionOptions(opts["compiler"], "dynamic", custom_function_service)
+    return CompilerOptions(opts["compiler"], "dynamic")
 
 
 @pytest.fixture
@@ -1145,15 +1149,8 @@ def runtime_options():
         "simulation": {"ncp": 2000},
         "solver": {"rtol": 0.0001},
     }
-    def_opts = {
-        "compiler": {"c_compiler": "msvs"},
-        "runtime": {"log_level": 2},
-        "simulation": {"ncp": 500},
-        "solver": {"rtol": 1e-5},
-    }
     custom_function_service.custom_function_options_get.return_value = opts
-    custom_function_service.custom_function_default_options_get.return_value = def_opts
-    return ExecutionOptions(opts["runtime"], "dynamic", custom_function_service)
+    return RuntimeOptions(opts["runtime"], "dynamic")
 
 
 @pytest.fixture
@@ -1165,15 +1162,8 @@ def simulation_options():
         "simulation": {"ncp": 2000},
         "solver": {"rtol": 0.0001},
     }
-    def_opts = {
-        "compiler": {"c_compiler": "msvs"},
-        "runtime": {"log_level": 2},
-        "simulation": {"ncp": 500},
-        "solver": {"rtol": 1e-5},
-    }
     custom_function_service.custom_function_options_get.return_value = opts
-    custom_function_service.custom_function_default_options_get.return_value = def_opts
-    return ExecutionOptions(opts["simulation"], "dynamic", custom_function_service)
+    return SimulationOptions(opts["simulation"], "dynamic")
 
 
 @pytest.fixture
@@ -1185,15 +1175,8 @@ def solver_options():
         "simulation": {"ncp": 2000},
         "solver": {"rtol": 0.0001},
     }
-    def_opts = {
-        "compiler": {"c_compiler": "msvs"},
-        "runtime": {"log_level": 2},
-        "simulation": {"ncp": 500},
-        "solver": {"rtol": 1e-5},
-    }
     custom_function_service.custom_function_options_get.return_value = opts
-    custom_function_service.custom_function_default_options_get.return_value = def_opts
-    return ExecutionOptions(opts["solver"], "dynamic", custom_function_service)
+    return SolverOptions(opts["solver"], "dynamic")
 
 
 @pytest.fixture

--- a/tests/impact/client/test_options.py
+++ b/tests/impact/client/test_options.py
@@ -29,3 +29,10 @@ def test_append_options(
     assert dict(runtime_opts) == {'log_level': 3, 'b': 'hello'}
     assert dict(simulation_opts) == {'ncp': 2000, 'a': 10}
     assert dict(solver_opts) == {'rtol': 0.0001, 'c': 5.0}
+
+
+def test_simulation_options_with_result_filter(simulation_options):
+
+    simulation_opts = simulation_options.with_result_filter(pattern=['*.phi'])
+
+    assert dict(simulation_opts) == {'filter': "['*.phi']", 'ncp': 2000}


### PR DESCRIPTION
Code to test
```
from modelon.impact.client import Client

client = Client(url="https://jhmi.modelon.com", interactive=True)

workspace = client.create_workspace("pop")

# Choose analysis type
dynamic = workspace.get_custom_function('dynamic')

# Get model
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")
# Execute experiment
experiment_definition = model.new_experiment_definition(
    dynamic.with_parameters(start_time=0.0, final_time=2.0),
    simulation_options=dynamic.get_simulation_options().with_result_filter(
        ['*.phi', '*.y']
    ),
    solver_options={'atol': 1e-8},
)
exp = workspace.execute(experiment_definition).wait()
```
**Jira** - https://modelonproducts.atlassian.net/browse/WAMS-10828