### PR TITLE
Add instructions for JHub token authentication

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -35,6 +35,8 @@ Revoking the token will cause the prompt to be shown again and a new token needs
 Once the JupyterHub API has been authenticated, the user need to authenticate the client for Modelon Impact 
 following the section :ref:`below<Authentication with API keys>`.
 
+For non-interactive usage, the API token can be set as the ``MODELON_IMPACT_JUPYTERHUB_CLIENT_API_TOKEN`` environment variable.
+
 Authentication with API keys
 ****************************
 


### PR DESCRIPTION
It took me 5 minutes to dig through the code and find the correct environment variable, so I figured adding it to the docs might save 5 minutes to the next user. Essential piece of documentation for use cases where interactive is not an option (CI etc..).
Thanks!