### PR TITLE
fix: added instructions for non-interactive JHub token authentication

### DIFF
--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -35,6 +35,8 @@ Revoking the token will cause the prompt to be shown again and a new token needs
 Once the JupyterHub API has been authenticated, the user need to authenticate the client for Modelon Impact 
 following the section :ref:`below<Authentication with API keys>`.
 
+For non-interactive usage, the API token can be set as the ``MODELON_IMPACT_JUPYTERHUB_CLIENT_API_TOKEN`` environment variable.
+
 Authentication with API keys
 ****************************
 

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -10,7 +10,21 @@ Authentication with JupyterHub
 This section is ONLY applicable for users running Modelon Impact in a JupyterHub environment,
 otherwise skip to the section :ref:`below<Authentication with API keys>`.
 To use the client on JupyterHub, the users needs to first authenticate with a token
-for Jupyterhub. To generate the key, go to the JupyterHub token manager 
+for Jupyterhub. 
+
+Using python client within JupyterHub environment
+#################################################
+
+By default, JupyterHub always generates a new token and sets the token value to 
+JUPYTERHUB_API_TOKEN environment variable on startup. When using the python client within
+JupyterHub environment, the default token value set in the JUPYTERHUB_API_TOKEN environment
+variable is used and no user input is required for authentication.
+
+Using python client outside JupyterHub environment
+##################################################
+To use the python client outside the jupyter environment, the user could generate a new token
+and use that for authenticating against JupyterHub API.
+To generate the token, go to the JupyterHub token manager 
 (located at <JupyterHub url>/token).You can get a secret token by clicking the 
 "Request new API token" button. These are tokens with full access to the JupyterHub API. 
 Anything you can do with JupyterHub can be done with these tokens.
@@ -29,13 +43,13 @@ While initializing the client, you will be asked to enter the JupyterHub API tok
     Enter JupyterHub API token:
 
 When the token has been entered the first time, it will be stored and used in future requests, 
-and the prompt will not be shown again. To view a list of active tokens or revoke active tokens, 
+and the prompt will not be shown again.To view a list of active tokens or revoke active tokens, 
 the user can go to the JupyterHub token manager (located at <JupyterHub url>/token).
 Revoking the token will cause the prompt to be shown again and a new token needs to be created.
-Once the JupyterHub API has been authenticated, the user need to authenticate the client for Modelon Impact 
-following the section :ref:`below<Authentication with API keys>`.
+following the section :ref:`below<Authentication with API keys>`. For non-interactive usage, the
+API token can be set as the ``JUPYTERHUB_API_TOKEN`` environment variable.
 
-For non-interactive usage, the API token can be set as the ``MODELON_IMPACT_JUPYTERHUB_CLIENT_API_TOKEN`` environment variable.
+Once the JupyterHub API has been authenticated, the user need to authenticate the client for Modelon Impact 
 
 Authentication with API keys
 ****************************

--- a/modelon/impact/client/jupyterhub/authorize.py
+++ b/modelon/impact/client/jupyterhub/authorize.py
@@ -1,5 +1,5 @@
 import logging
-
+import os
 from modelon.impact.client.credential_manager import CredentialManager
 from modelon.impact.client.jupyterhub import exceptions
 from modelon.impact.client.jupyterhub import sal
@@ -17,9 +17,13 @@ def _get_jupyter_token(credential_manager, interactive, context=None):
 
 
 def authorize(uri, interactive, context=None, credential_manager=None, service=None):
+    # Checking for deprecated environment variable
+    # MODELON_IMPACT_JUPYTERHUB_CLIENT_API_TOKEN for backward compatibility
     credential_manager = credential_manager or CredentialManager(
         file_id="jupyterhub-api.key",
-        env_name="MODELON_IMPACT_JUPYTERHUB_CLIENT_API_TOKEN",
+        env_name="JUPYTERHUB_API_TOKEN"
+        if os.environ.get("JUPYTERHUB_API_TOKEN")
+        else "MODELON_IMPACT_JUPYTERHUB_CLIENT_API_TOKEN",
         interactive_help_text="Enter JupyterHub API token:",
     )
     context = sal.JupyterContext(base=context)


### PR DESCRIPTION
Customer request - https://github.com/modelon-community/impact-client-python/pull/154