### PR TITLE
fix: concatination of URLs handles starting slash on relative part

### DIFF
--- a/modelon/impact/client/sal/uri.py
+++ b/modelon/impact/client/sal/uri.py
@@ -15,7 +15,7 @@ class URI:
         return self.content.format(**kwargs)
 
     def _with_path(self, path):
-        return URI(urllib.parse.urljoin(self.content + "/", path))
+        return URI(urllib.parse.urljoin(self.content + "/", path.lstrip('/')))
 
     def __floordiv__(self, other):
         return self._with_path(other)

--- a/tests/impact/client/sal/test_uri.py
+++ b/tests/impact/client/sal/test_uri.py
@@ -1,0 +1,26 @@
+from modelon.impact.client.sal.uri import URI
+
+
+def test_uri_concat_no_slashes():
+    uri = URI('http://modelon.com/impact') / 'api'
+    assert 'http://modelon.com/impact/api' == uri.resolve()
+
+
+def test_uri_concat_base_ends_with_slash():
+    uri = URI('http://modelon.com/impact/') / 'api'
+    assert 'http://modelon.com/impact/api' == uri.resolve()
+
+
+def test_uri_concat_relativ_starts_with_slash():
+    uri = URI('http://modelon.com/impact') / '/api'
+    assert 'http://modelon.com/impact/api' == uri.resolve()
+
+
+def test_uri_concat_both_base_and_rel_part_have_slashes():
+    uri = URI('http://modelon.com/impact/') / '/api'
+    assert 'http://modelon.com/impact/api' == uri.resolve()
+
+
+def test_uri_concat_rel_part_ends_with_slash():
+    uri = URI('http://modelon.com/impact') / 'api/'
+    assert 'http://modelon.com/impact/api/' == uri.resolve()


### PR DESCRIPTION
Some of the relative URLs added in new methods where starting with a slash. This would lead to incorrect concatenated results for some cases. This PR changes the URI class so it does not care about this.