### PR TITLE
Token api key url hint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install -U pip
 
 # update 
 RUN apt-get update && apt-get install -y curl apt-utils bash-completion
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
 RUN apt-get install -y nodejs
 RUN node -v
 RUN npm -v

--- a/docs/source/setup.rst
+++ b/docs/source/setup.rst
@@ -26,7 +26,7 @@ While initializing the client, you will be asked to enter the JupyterHub API tok
 
     >>>> from modelon.impact.client import Client
     >>>> client = Client(url=<JupyterHub url>, interactive=True)
-    Enter JupyterHub API token:
+    Enter JupyterHub API token (can be generated at <JupyterHub url>/token):
 
 When the token has been entered the first time, it will be stored and used in future requests, 
 and the prompt will not be shown again. To view a list of active tokens or revoke active tokens, 
@@ -85,7 +85,7 @@ prompt.
 
     >>>> from modelon.impact.client import Client
     >>>> client = Client(url=impact_url, interactive=True)
-    Enter API key:
+    Enter Modelon Impact API key (can be generated at <impact_url>/admin/keys):
 
 
 When the key has been entered the first time, it will be stored in the credentials file

--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -72,14 +72,8 @@ class Client:
         if interactive is None:
             interactive = modelon.impact.client.configuration.get_client_interactive()
 
-        if credential_manager is None:
-            credential_manager = (
-                modelon.impact.client.credential_manager.CredentialManager()
-            )
-
         self._uri = URI(url)
         self._sal = modelon.impact.client.sal.service.Service(self._uri, context)
-        self._credential_manager = credential_manager
 
         try:
             self._validate_compatible_api_version()
@@ -92,6 +86,16 @@ class Client:
             )
             self._sal = modelon.impact.client.sal.service.Service(self._uri, context)
             self._validate_compatible_api_version()
+
+        if credential_manager is None:
+            help_hint = f"can be generated at {self._uri / 'admin/keys'}"
+            help_text = f"Enter Modelon Impact API key ({help_hint}):"
+            credential_manager = (
+                modelon.impact.client.credential_manager.CredentialManager(
+                    interactive_help_text=help_text
+                )
+            )
+        self._credential_manager = credential_manager
 
         try:
             api_key = self._authenticate_against_api(interactive)

--- a/modelon/impact/client/jupyterhub/authorize.py
+++ b/modelon/impact/client/jupyterhub/authorize.py
@@ -17,10 +17,11 @@ def _get_jupyter_token(credential_manager, interactive, context=None):
 
 
 def authorize(uri, interactive, context=None, credential_manager=None, service=None):
+    help_text = f"Enter JupyterHub API token (can be generated at {uri / 'token'}):"
     credential_manager = credential_manager or CredentialManager(
         file_id="jupyterhub-api.key",
         env_name="MODELON_IMPACT_JUPYTERHUB_CLIENT_API_TOKEN",
-        interactive_help_text="Enter JupyterHub API token:",
+        interactive_help_text=help_text,
     )
     context = sal.JupyterContext(base=context)
     service = service or sal.JupyterHubService()


### PR DESCRIPTION
This PR adds hints for the interactive help text during login with URL to where key/token can be generated. This should in particularly help with users not know for sure where the boundary between JH and Impact goes.

![login-interactive](https://user-images.githubusercontent.com/18346319/211569990-2efd3e03-b6d0-4ba2-81a3-b2413d7c161b.gif)


### How to test
Run the following code (be sure you do not already have setup token/key for impact.modelon.cloud)
```
from modelon.impact.client import Client

client = Client('https://impact.modelon.cloud/', interactive=True)
```

And follow the prompts to where token/key can be generated:
