### PR TITLE
fix: assert compilation is successful before calling download FMU api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install -U pip
 
 # update 
 RUN apt-get update && apt-get install -y curl apt-utils bash-completion vim
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
 RUN apt-get install -y nodejs
 RUN node -v
 RUN npm -v

--- a/modelon/impact/client/entities/model_executable.py
+++ b/modelon/impact/client/entities/model_executable.py
@@ -238,11 +238,18 @@ class ModelExecutable:
             path --
                 Local path to the downloaded FMU.
 
-        Example::
+        Raises:
 
-            fmu_path = model.compile().wait().download()
-            fmu_path = model.compile().wait().download('C:/Downloads')
+            OperationNotCompleteError if compilation process is in progress.
+            OperationFailureError if compilation process has failed or was cancelled.
+
+        Example::
+            fmu =  model.compile().wait()
+            if fmu.is_successful():
+                fmu_path = fmu.download()
+                fmu_path = fmu.download('C:/Downloads')
         """
+        assert_successful_operation(self.is_successful(), "Compilation")
         data = self._sal.workspace.fmu_download(self._workspace_id, self._fmu_id)
         if path is None:
             path = os.path.join(tempfile.gettempdir(), "impact-downloads")

--- a/tests/impact/client/entities/test_model_exe.py
+++ b/tests/impact/client/entities/test_model_exe.py
@@ -68,6 +68,11 @@ class TestModelExecutable:
         resp = fmu.download(tempfile.gettempdir())
         assert resp == t
 
+    def test_download_fmu_failed_compilation(self, fmu_compile_failed):
+        pytest.raises(
+            exceptions.OperationFailureError, fmu_compile_failed.download,
+        )
+
     def test_download_fmu_no_path(self, fmu):
         t = os.path.join(tempfile.gettempdir(), 'impact-downloads', fmu.id + '.fmu')
         resp = fmu.download()


### PR DESCRIPTION
```
from modelon.impact.client import Client

client = Client(url="https://jhmi.modelon.com/", interactive=True,)
workspace = client.get_workspace("test")

# Choose analysis type
dynamic = workspace.get_custom_function('dynamic')

# Get model
model = workspace.get_model("Test.PID_Controller")
compiler_options = dynamic.get_compiler_options().with_values(c_compiler='gcc')
runtime_options = {'cs_solver': 0}
fmu = model.compile(compiler_options, runtime_options).wait()
# Compilation fails
print(fmu.is_successful())
# Output :- False

# Trying to call the download method on the fmu object
fmu_path = fmu.download('/home/jovyan/impact/workspaces/test')
# Raises OperationFailureError: Compilation failed! See the log for more info!

# Cause of failure
log = fmu.get_log()
log.show()
# Output :-
# Error in flattened model:
#     Index reduction failed: There were unmatched equations and/or variables left after index reduction.
# Error in flattened model:
#     The system is structurally singular. The following variable(s) could not be matched to any equation:
#      der(spring.w_rel)
#      torque.flange.phi

#   The following equation(s) could not be matched to any variable:
#     spring.w_rel = der(spring.phi_rel)
#     0.0 = 0.0

```