### PR TITLE
chore: updating devcontainer to use new recommended settings from microsoft

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,50 +1,70 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/docker-existing-dockerfile
 {
-	"name": "VS Code extension of Poetry Docker dev image",
-
+	"name": "impact_python_client",
 	// Base on Dockerfile one level up:
 	"context": "..",
 	"dockerFile": "../Dockerfile",
-
-	// Mount to WORKDIR as specified in Dockerfile:
-	"workspaceMount": "source=${localWorkspaceFolder},target=/home/dev/src,type=bind",
-	"workspaceFolder": "/home/dev/src",
-
-	// Python IDE settings:
-	"settings": {
-		"python.pythonPath": "/home/dev/poetry-virtualenvs/modelon-impact-client-1JqLc1Zx-py3.7/bin/python",
-		"python.defaultInterpreterPath": "/home/dev/poetry-virtualenvs/modelon-impact-client-1JqLc1Zx-py3.7/bin/python",
-		"terminal.integrated.profiles.linux": {
-			"poetry shell": {
-			  "path": "poetry",
-			  "args": ["shell"]
-			}
-		},
-		"terminal.integrated.defaultProfile.linux": "poetry shell",
-		"python.formatting.provider": "black",
-		"python.formatting.blackArgs": [
-			"-S"
-		],
-		"[python]": {
-			"editor.formatOnSave": true,
-			"editor.formatOnSaveTimeout": 3000
-		},
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.linting.mypyEnabled": true,
-		"python.linting.flake8Enabled": true,
-		"python.testing.pytestEnabled": true,
-		"python.analysis.typeCheckingMode": "basic",
+	"containerEnv": {
+		"IN_DEVCONTAINER": "1"
 	},
-	
-	// Python IDE extensions:
-	"extensions": [
-		"ms-python.python",
-		"ms-python.vscode-pylance",
-		"njpwerner.autodocstring"
-	],
-
+	// Mount to WORKDIR as specified in Dockerfile:
+	"workspaceMount": "source=${localWorkspaceFolder},target=/src,type=bind",
+	"workspaceFolder": "/src",
+	// Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	// Python IDE settings:
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.venvFolders": [
+					"/home/dev/.poetry-virtualenvs"
+				],
+				"python.venvPath": "/home/dev/.poetry-virtualenvs",
+				"python.defaultInterpreterPath": "/home/dev/.poetry-virtualenvs",
+				"python.poetryPath": "/home/dev/.local/bin/poetry",
+				"terminal.integrated.profiles.linux": {
+					"poetry shell": {
+						"path": "poetry",
+						"args": [
+							"shell"
+						]
+					}
+				},
+				"terminal.integrated.defaultProfile.linux": "poetry shell",
+				"python.formatting.provider": "black",
+				"python.formatting.blackArgs": [
+					"-S"
+				],
+				"[python]": {
+					"editor.formatOnSave": true,
+					"editor.formatOnSaveTimeout": 3000
+				},
+				"python.linting.enabled": true,
+				"python.linting.pylintEnabled": true,
+				"python.linting.mypyEnabled": true,
+				"python.linting.flake8Enabled": true,
+				"python.linting.flake8Args": [
+					"--config",
+					".flake8"
+				],
+				"python.testing.pytestEnabled": true,
+				"python.analysis.typeCheckingMode": "basic",
+				"flake8.args": [
+					"--config",
+					".flake8"
+				]
+			},
+			// Python IDE extensions:
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.flake8",
+				"ms-python.pylint",
+				"njpwerner.autodocstring"
+			]
+		}
+	},
 	// User from Dockerfile:
-	"remoteUser": "dev",
+	"remoteUser": "dev"
 }

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ commitlint:
 
 
 lint: commitlint
-	$(call _run_bare, bash -c "poetry run -- black -S modelon && poetry run -- flake8 modelon --config .flake8 && poetry run -- mypy modelon")
+	$(call _run_bare, bash -c "poetry run -- black -S modelon && poetry run -- flake8 modelon --config .flake8 && poetry run -- mypy --disallow-untyped-defs modelon")
 
 
 wheel: build

--- a/modelon/impact/client/configuration.py
+++ b/modelon/impact/client/configuration.py
@@ -5,7 +5,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_client_url():
+def get_client_url() -> str:
     """Returns the default URL the client will use if unspecified.
 
     Can be overridden by the environment variable
@@ -19,7 +19,7 @@ def get_client_url():
     return url
 
 
-def get_client_interactive():
+def get_client_interactive() -> bool:
     """Returns the default for if client will run interactive or not if
     unspecified.
 

--- a/modelon/impact/client/credential_manager.py
+++ b/modelon/impact/client/credential_manager.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from typing import List
+from typing import List, Optional
 
 from getpass import getpass
 
@@ -18,17 +18,18 @@ class CredentialManager:
         self._env_names = env_names
         self._interactive_help_text = interactive_help_text
 
-    def get_key_from_env(self):
+    def get_key_from_env(self) -> Optional[str]:
         for env_name in self._env_names:
             env_value = os.environ.get(env_name)
             if env_value:
                 return env_value
+        return None
 
-    def _cred_file(self):
+    def _cred_file(self) -> str:
         home_dir = os.path.expanduser("~")
         return os.path.join(home_dir, ".impact", self._file_id)
 
-    def get_key_from_file(self):
+    def get_key_from_file(self) -> Optional[str]:
         credentials_file = self._cred_file()
         if not os.path.isfile(credentials_file):
             return None
@@ -36,7 +37,7 @@ class CredentialManager:
         with open(credentials_file, "r") as credentials:
             return credentials.read().strip()
 
-    def get_key_from_prompt(self):
+    def get_key_from_prompt(self) -> str:
         key = getpass(self._interactive_help_text)
         if key == '\x16':
             # This is a getpass Windows bug...
@@ -45,13 +46,13 @@ class CredentialManager:
 
         return key
 
-    def write_key_to_file(self, api_key):
+    def write_key_to_file(self, api_key: str) -> None:
         credentials_file = self._cred_file()
         os.makedirs(os.path.dirname(credentials_file), exist_ok=True)
         with open(credentials_file, "w") as credentials:
             credentials.write(str(api_key))
 
-    def get_key(self, interactive=False):
+    def get_key(self, interactive: bool = False) -> Optional[str]:
         api_key = self.get_key_from_env() or self.get_key_from_file()
         if api_key or not interactive:
             return api_key

--- a/modelon/impact/client/entities/asserts.py
+++ b/modelon/impact/client/entities/asserts.py
@@ -1,14 +1,19 @@
+from typing import List
 from modelon.impact.client import exceptions
 
 
-def assert_successful_operation(is_successful, operation_name="Operation"):
+def assert_successful_operation(
+    is_successful: bool, operation_name: str = "Operation"
+) -> None:
     if not is_successful:
         raise exceptions.OperationFailureError(
             f"{operation_name} failed! See the log for more info!"
         )
 
 
-def assert_variable_in_result(variables, result_variables):
+def assert_variable_in_result(
+    variables: List[str], result_variables: List[str]
+) -> None:
     add = set(variables) - set(result_variables)
     if add:
         raise ValueError(

--- a/modelon/impact/client/entities/content.py
+++ b/modelon/impact/client/entities/content.py
@@ -1,14 +1,15 @@
-#
-# Copyright (c) 2022 Modelon AB
-#
+from __future__ import annotations
 import enum
 import os
 import logging
 from pathlib import Path
-from typing import List, Dict, Optional, Union
+from typing import List, Dict, Optional, Union, TYPE_CHECKING
 
-import modelon.impact.client.entities.model
+from modelon.impact.client.entities.model import Model
 from modelon.impact.client.sal.service import Service
+
+if TYPE_CHECKING:
+    from modelon.impact.client.entities.workspace import Workspace
 
 logger = logging.getLogger(__name__)
 
@@ -33,14 +34,14 @@ class ProjectContent:
         self._project_id = project_id
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Project content with id '{self.id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return isinstance(obj, ProjectContent) and obj.id == self.id
 
     @property
-    def relpath(self):
+    def relpath(self) -> Path:
         """Relative path in the project.
 
         Can be file (e.g., SomeLib.mo) or folder
@@ -54,20 +55,20 @@ class ProjectContent:
         return ContentType(self._content['contentType'])
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Content ID."""
         return self._content['id']
 
     @property
-    def name(self):
+    def name(self) -> Optional[str]:
         """Modelica library name."""
         return self._content.get('name')
 
     @property
-    def default_disabled(self):
+    def default_disabled(self) -> str:
         return self._content['defaultDisabled']
 
-    def delete(self):
+    def delete(self) -> None:
         """Deletes a project content.
 
         Example::
@@ -79,7 +80,7 @@ class ProjectContent:
 
     def upload_fmu(
         self,
-        workspace,
+        workspace: Workspace,
         fmu_path: str,
         class_name: Optional[str] = None,
         overwrite: bool = False,
@@ -87,7 +88,7 @@ class ProjectContent:
         exclude_patterns: Optional[Union[str, List[str]]] = None,
         top_level_inputs: Optional[Union[str, List[str]]] = None,
         step_size: float = 0.0,
-    ):
+    ) -> Model:
         """Uploads a FMU to the workspace.
 
         Args:
@@ -165,6 +166,4 @@ class ProjectContent:
 
         if resp["importWarnings"]:
             logger.warning(f"Import Warnings: {'. '.join(resp['importWarnings'])}")
-        return modelon.impact.client.entities.model.Model(
-            resp['fmuClassPath'], workspace.id, self._project_id, self._sal
-        )
+        return Model(resp['fmuClassPath'], workspace.id, self._project_id, self._sal)

--- a/modelon/impact/client/entities/custom_function.py
+++ b/modelon/impact/client/entities/custom_function.py
@@ -1,7 +1,16 @@
+from __future__ import annotations
 import logging
-from typing import Any, List, Dict, Optional
+from typing import Any, List, Dict, Optional, TYPE_CHECKING
 from modelon.impact.client.sal.service import Service
 from modelon.impact.client.options import ProjectExecutionOptions
+
+if TYPE_CHECKING:
+    from modelon.impact.client.options import (
+        CompilerOptions,
+        RuntimeOptions,
+        SimulationOptions,
+        SolverOptions,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +39,11 @@ class _Parameter:
         return self._name
 
     @property
-    def value(self):
+    def value(self) -> Any:
         return self._value
 
     @value.setter
-    def value(self, value):
+    def value(self, value: Any) -> None:
         if not isinstance(value, self._JSON_2_PY_TYPE[self._value_type]):
             raise ValueError(
                 f"Cannot set {self._name} to {value}, its type is {self._value_type}"
@@ -73,10 +82,10 @@ class CustomFunction:
         }
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Custom function '{self._name}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return isinstance(obj, CustomFunction) and obj._name == self._name
 
     @property
@@ -84,7 +93,7 @@ class CustomFunction:
         "Custom function name"
         return self._name
 
-    def with_parameters(self, **modified) -> 'CustomFunction':
+    def with_parameters(self, **modified: Any) -> CustomFunction:
         """Sets/updates the custom_function parameters for an experiment.
 
         Args:
@@ -118,7 +127,9 @@ class CustomFunction:
         """Custom_function parameters and value as a dictionary."""
         return {p.name: p.value for p in self._param_by_name.values()}
 
-    def get_options(self, use_defaults: Optional[bool] = False):
+    def get_options(
+        self, use_defaults: Optional[bool] = False
+    ) -> ProjectExecutionOptions:
         """Get project execution option.
 
         Args:
@@ -141,7 +152,7 @@ class CustomFunction:
             )
         return ProjectExecutionOptions(options, self.name)
 
-    def get_compiler_options(self, use_defaults: bool = False):
+    def get_compiler_options(self, use_defaults: bool = False) -> CompilerOptions:
         """Return a modelon.impact.client.options.CompilerOptions object.
 
         Returns:
@@ -159,7 +170,7 @@ class CustomFunction:
         """
         return self.get_options(use_defaults=use_defaults).compiler_options
 
-    def get_runtime_options(self, use_defaults: bool = False):
+    def get_runtime_options(self, use_defaults: bool = False) -> RuntimeOptions:
         """Return a modelon.impact.client.options.RuntimeOptions object.
 
         Returns:
@@ -177,7 +188,7 @@ class CustomFunction:
         """
         return self.get_options(use_defaults=use_defaults).runtime_options
 
-    def get_solver_options(self, use_defaults: bool = False):
+    def get_solver_options(self, use_defaults: bool = False) -> SolverOptions:
         """Return a modelon.impact.client.options.SolverOptions object.
 
         Returns:
@@ -196,7 +207,7 @@ class CustomFunction:
         """
         return self.get_options(use_defaults=use_defaults).solver_options
 
-    def get_simulation_options(self, use_defaults: bool = False):
+    def get_simulation_options(self, use_defaults: bool = False) -> SimulationOptions:
         """Return a modelon.impact.client.options.SimulationOptions object.
 
         Returns:

--- a/modelon/impact/client/entities/experiment.py
+++ b/modelon/impact/client/entities/experiment.py
@@ -10,7 +10,9 @@ from modelon.impact.client import exceptions
 logger = logging.getLogger(__name__)
 
 
-def _assert_experiment_is_complete(status, operation_name="Operation"):
+def _assert_experiment_is_complete(
+    status: ExperimentStatus, operation_name: str = "Operation"
+) -> None:
     if status == ExperimentStatus.NOTSTARTED:
         raise exceptions.OperationNotCompleteError.for_operation(operation_name, status)
     elif status == ExperimentStatus.CANCELLED:
@@ -35,12 +37,12 @@ class _ExperimentRunInfo:
         self._not_started = not_started
 
     @property
-    def status(self):
+    def status(self) -> ExperimentStatus:
         """Status info for an Experiment."""
         return self._status
 
     @property
-    def errors(self):
+    def errors(self) -> List[str]:
         """A list of errors.
 
         Is empty unless 'status' attribute is 'FAILED'
@@ -49,22 +51,22 @@ class _ExperimentRunInfo:
         return self._errors
 
     @property
-    def successful(self):
+    def successful(self) -> int:
         """Number of cases in experiment that are successful."""
         return self._successful
 
     @property
-    def failed(self):
+    def failed(self) -> int:
         """Number of cases in experiment thar have failed."""
         return self._failed
 
     @property
-    def cancelled(self):
+    def cancelled(self) -> int:
         """Number of cases in experiment that are cancelled."""
         return self._cancelled
 
     @property
-    def not_started(self):
+    def not_started(self) -> int:
         """Number of cases in experiment that have not yet started."""
         return self._not_started
 
@@ -94,10 +96,10 @@ class Experiment:
         self._sal = service
         self._info = info
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Experiment with id '{self._exp_id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return isinstance(obj, Experiment) and obj._exp_id == self._exp_id
 
     @property
@@ -154,7 +156,7 @@ class Experiment:
 
     def execute(
         self, with_cases: Optional[List[Case]] = None, sync_case_changes: bool = True
-    ):
+    ) -> experiment.ExperimentOperation:
         """Exceutes an experiment. Returns an
         modelon.impact.client.operations.experiment.ExperimentOperation class
         object.
@@ -358,7 +360,7 @@ class Experiment:
             for j in case_nbrs
         }
 
-    def delete(self):
+    def delete(self) -> None:
         """Deletes an experiment.
 
         Example::
@@ -368,7 +370,7 @@ class Experiment:
         """
         self._sal.experiment.experiment_delete(self._workspace_id, self._exp_id)
 
-    def set_label(self, label: str):
+    def set_label(self, label: str) -> None:
         """Sets a label (string) for an experiment to distinguish it.
 
         Example::

--- a/modelon/impact/client/entities/external_result.py
+++ b/modelon/impact/client/entities/external_result.py
@@ -38,10 +38,10 @@ class ExternalResult:
         self._result_id = result_id
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Result id '{self._result_id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return isinstance(obj, ExternalResult) and obj._result_id == self._result_id
 
     @property
@@ -61,5 +61,5 @@ class ExternalResult:
         workspace_id = upload_meta.get("workspaceId")
         return _ExternalResultMetaData(id, name, description, workspace_id)
 
-    def delete(self):
+    def delete(self) -> None:
         self._sal.external_result.delete_uploaded_result(self._result_id)

--- a/modelon/impact/client/entities/log.py
+++ b/modelon/impact/client/entities/log.py
@@ -1,6 +1,6 @@
 class Log(str):
     """Log class inheriting from string object."""
 
-    def show(self):
+    def show(self) -> None:
         """Prints the formatted log."""
         print(self)

--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -25,7 +25,10 @@ SimulationOptionsOrDict = Union[SimulationOptions, Dict[str, Any]]
 SolverOptionsOrDict = Union[SolverOptions, Dict[str, Any]]
 
 
-def _assert_valid_compilation_options(compiler_options=None, runtime_options=None):
+def _assert_valid_compilation_options(
+    compiler_options: Optional[CompilerOptionsOrDict] = None,
+    runtime_options: Optional[RuntimeOptionsOrDict] = None,
+) -> None:
     if compiler_options is not None and not isinstance(
         compiler_options, (CompilerOptions, dict)
     ):
@@ -53,10 +56,10 @@ class Model:
         self._project_id = project_id
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Class name '{self._class_name}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return isinstance(obj, Model) and obj._class_name == self._class_name
 
     @property
@@ -196,7 +199,7 @@ class Model:
         solver_options: Optional[SolverOptionsOrDict] = None,
         simulation_options: Optional[SimulationOptionsOrDict] = None,
         simulation_log_level: str = "WARNING",
-    ):
+    ) -> base.SimpleModelicaExperimentDefinition:
         """Returns a new experiment definition using this Model.
 
         Args:
@@ -269,17 +272,17 @@ class Model:
         options = self._sal.project.project_options_get(
             self._project_id, self._workspace_id, custom_function=custom_function.name
         )
-        options = ProjectExecutionOptions(options, custom_function.name)
+        project_options = ProjectExecutionOptions(options, custom_function.name)
         return base.SimpleModelicaExperimentDefinition(
             model=self,
             custom_function=custom_function,
-            compiler_options=compiler_options or options.compiler_options,
+            compiler_options=compiler_options or project_options.compiler_options,
             fmi_target=fmi_target,
             fmi_version=fmi_version,
             platform=platform,
             compiler_log_level=compiler_log_level,
-            runtime_options=runtime_options or options.runtime_options,
-            solver_options=solver_options or options.solver_options,
-            simulation_options=simulation_options or options.simulation_options,
+            runtime_options=runtime_options or project_options.runtime_options,
+            solver_options=solver_options or project_options.solver_options,
+            simulation_options=simulation_options or project_options.simulation_options,
             simulation_log_level=simulation_log_level,
         )

--- a/modelon/impact/client/entities/model_executable.py
+++ b/modelon/impact/client/entities/model_executable.py
@@ -18,7 +18,9 @@ SimulationOptionsOrDict = Union[SimulationOptions, Dict[str, Any]]
 SolverOptionsOrDict = Union[SolverOptions, Dict[str, Any]]
 
 
-def _assert_compilation_is_complete(status, operation_name="Operation"):
+def _assert_compilation_is_complete(
+    status: ModelExecutableStatus, operation_name: str = "Operation"
+) -> None:
     if status == ModelExecutableStatus.NOTSTARTED:
         raise exceptions.OperationNotCompleteError.for_operation(operation_name, status)
     elif status == ModelExecutableStatus.CANCELLED:
@@ -31,12 +33,12 @@ class _ModelExecutableRunInfo:
         self._errors = errors
 
     @property
-    def status(self):
+    def status(self) -> ModelExecutableStatus:
         """Status info for a Model-Executable."""
         return self._status
 
     @property
-    def errors(self):
+    def errors(self) -> List[str]:
         """A list of errors.
 
         Is empty unless 'status' attribute is 'FAILED'
@@ -62,10 +64,10 @@ class ModelExecutable:
         self._info = info
         self._modifiers = modifiers
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"FMU with id '{self._fmu_id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return isinstance(obj, ModelExecutable) and obj._fmu_id == self._fmu_id
 
     def __hash__(self) -> int:
@@ -154,7 +156,7 @@ class ModelExecutable:
             self._sal.model_executable.compile_log(self._workspace_id, self._fmu_id)
         )
 
-    def delete(self):
+    def delete(self) -> None:
         """Deletes an FMU.
 
         Example::
@@ -193,7 +195,7 @@ class ModelExecutable:
         solver_options: Optional[SolverOptionsOrDict] = None,
         simulation_options: Optional[SimulationOptionsOrDict] = None,
         simulation_log_level: str = "WARNING",
-    ):
+    ) -> base.SimpleFMUExperimentDefinition:
         """Returns a new experiment definition using this FMU.
 
         Args:
@@ -231,7 +233,7 @@ class ModelExecutable:
             simulation_log_level,
         )
 
-    def download(self, path: Optional[str] = None):
+    def download(self, path: Optional[str] = None) -> str:
         """Downloads an FMU binary that is compiled. Returns the local path to
         the downloaded FMU archive.
 

--- a/modelon/impact/client/entities/project.py
+++ b/modelon/impact/client/entities/project.py
@@ -3,7 +3,7 @@ import enum
 import logging
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Optional, Union, List, Dict, Any
+from typing import Optional, Union, List, Dict, Any, Iterable
 from modelon.impact.client.options import ProjectExecutionOptions
 from modelon.impact.client.entities.content import ContentType, ProjectContent
 from modelon.impact.client.operations.content_import import ContentImportOperation
@@ -253,7 +253,7 @@ class Project:
     def _get_project_content(self, content: Dict[str, str]) -> ProjectContent:
         return ProjectContent(content, self._project_id, self._sal)
 
-    def get_contents(self) -> List[ProjectContent]:
+    def get_contents(self) -> Iterable[ProjectContent]:
         """Get project contents.
 
         Example::

--- a/modelon/impact/client/entities/result.py
+++ b/modelon/impact/client/entities/result.py
@@ -60,5 +60,5 @@ class Result(Mapping):
     def __len__(self) -> int:
         return self._variables.__len__()
 
-    def keys(self):
+    def keys(self):  # type: ignore
         return self._variables

--- a/modelon/impact/client/entities/result.py
+++ b/modelon/impact/client/entities/result.py
@@ -1,10 +1,20 @@
+from __future__ import annotations
 from collections.abc import Mapping
-from typing import List
-from modelon.impact.client.sal.service import Service
+from typing import Dict, List, Any, Iterator, TYPE_CHECKING
 from modelon.impact.client.entities.asserts import assert_variable_in_result
 
+if TYPE_CHECKING:
+    from modelon.impact.client.sal.service import Service
+    from modelon.impact.client.sal.experiment import ExperimentService
 
-def _create_result_dict(variables, workspace_id, exp_id, case_id, exp_sal):
+
+def _create_result_dict(
+    variables: List[str],
+    workspace_id: str,
+    exp_id: str,
+    case_id: str,
+    exp_sal: ExperimentService,
+) -> Dict[str, Any]:
     response = exp_sal.trajectories_get(workspace_id, exp_id, variables)
     case_index = int(case_id.split("_")[1])
     data = {
@@ -30,14 +40,14 @@ class Result(Mapping):
         self._sal = service
         self._variables = variables
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         assert_variable_in_result([key], self._variables)
         response = self._sal.experiment.case_trajectories_get(
             self._workspace_id, self._exp_id, self._case_id, [key]
         )
         return response[0]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         data = _create_result_dict(
             self._variables,
             self._workspace_id,
@@ -47,7 +57,7 @@ class Result(Mapping):
         )
         return data.__iter__()
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._variables.__len__()
 
     def keys(self):

--- a/modelon/impact/client/exceptions.py
+++ b/modelon/impact/client/exceptions.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+from typing import Any
+
+
 class Error(Exception):
     pass
 
@@ -16,7 +20,7 @@ class OperationTimeOutError(Error):
 
 class OperationFailureError(Error):
     @classmethod
-    def for_operation(cls, operation_name: str):
+    def for_operation(cls, operation_name: str) -> OperationFailureError:
         return cls(
             f"{operation_name} was cancelled before completion! "
             f"Log file generated for cancelled {operation_name} is empty!"
@@ -25,7 +29,9 @@ class OperationFailureError(Error):
 
 class OperationNotCompleteError(Error):
     @classmethod
-    def for_operation(cls, operation_name: str, status):
+    def for_operation(
+        cls, operation_name: str, status: Any
+    ) -> OperationNotCompleteError:
         return cls(
             f"{operation_name} is still in progress! Status : {status}."
             f" Please call the wait() method on the {operation_name} operation"

--- a/modelon/impact/client/experiment_definition/asserts.py
+++ b/modelon/impact/client/experiment_definition/asserts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+from typing import Optional, Dict, Union, Any, TYPE_CHECKING
 from modelon.impact.client.entities.external_result import ExternalResult
 from modelon.impact.client.entities.case import Case
 from modelon.impact.client.entities.experiment import Experiment
@@ -7,15 +9,34 @@ from modelon.impact.client.options import (
     RuntimeOptions,
     CompilerOptions,
 )
-
-import modelon.impact.client.entities.model
-
 from modelon.impact.client.entities.custom_function import CustomFunction
-
+import modelon.impact.client.entities.model
 import modelon.impact.client.entities.model_executable
+import modelon.impact.client.experiment_definition.extension
+
+CaseOrExperimentOrExternalResult = Union[Case, Experiment, ExternalResult]
+RuntimeOptionsOrDict = Union[RuntimeOptions, Dict[str, Any]]
+SimulationOptionsOrDict = Union[SimulationOptions, Dict[str, Any]]
+SolverOptionsOrDict = Union[SolverOptions, Dict[str, Any]]
+CompilerOptionsOrDict = Union[CompilerOptions, Dict[str, Any]]
+
+if TYPE_CHECKING:
+    from modelon.impact.client.entities.model import Model
+    from modelon.impact.client.entities.model_executable import ModelExecutable
+    from modelon.impact.client.experiment_definition.base import (
+        SimpleFMUExperimentDefinition,
+        SimpleModelicaExperimentDefinition,
+    )
 
 
-def validate_and_set_initialize_from(entity, definition):
+def validate_and_set_initialize_from(
+    entity: CaseOrExperimentOrExternalResult,
+    definition: Union[
+        SimpleFMUExperimentDefinition,
+        SimpleModelicaExperimentDefinition,
+        modelon.impact.client.experiment_definition.extension.SimpleExperimentExtension,
+    ],
+) -> None:
     if isinstance(entity, Experiment):
         if len(entity.get_cases()) > 1:
             raise ValueError(
@@ -25,7 +46,10 @@ def validate_and_set_initialize_from(entity, definition):
         definition._initialize_from_experiment = entity
     elif isinstance(entity, Case):
         definition._initialize_from_case = entity
-    elif isinstance(entity, ExternalResult):
+    elif isinstance(entity, ExternalResult) and not isinstance(
+        definition,
+        modelon.impact.client.experiment_definition.extension.SimpleExperimentExtension,
+    ):
         definition._initialize_from_external_result = entity
     else:
         raise TypeError(
@@ -36,24 +60,24 @@ def validate_and_set_initialize_from(entity, definition):
         )
 
 
-def assert_unique_exp_initialization(*initializing_from):
-    initializing_from = [entity for entity in initializing_from if entity is not None]
-    if len(initializing_from) > 1:
+def assert_unique_exp_initialization(*initializing_from: Any) -> None:
+    entities = [entity for entity in initializing_from if entity is not None]
+    if len(entities) > 1:
         raise ValueError(
             "An experiment can only be initialized from one entity. Experiment is "
-            f"configured to initialize from {' and '.join(map(str, initializing_from))}"
+            f"configured to initialize from {' and '.join(map(str, entities))}"
         )
 
 
 def assert_valid_args(
-    model=None,
-    fmu=None,
-    custom_function=None,
-    solver_options=None,
-    simulation_options=None,
-    compiler_options=None,
-    runtime_options=None,
-):
+    model: Optional[Model] = None,
+    fmu: Optional[ModelExecutable] = None,
+    custom_function: Optional[CustomFunction] = None,
+    solver_options: Optional[SolverOptionsOrDict] = None,
+    simulation_options: Optional[SimulationOptionsOrDict] = None,
+    compiler_options: Optional[CompilerOptionsOrDict] = None,
+    runtime_options: Optional[RuntimeOptionsOrDict] = None,
+) -> None:
     if fmu and not isinstance(
         fmu, modelon.impact.client.entities.model_executable.ModelExecutable
     ):

--- a/modelon/impact/client/experiment_definition/expansion.py
+++ b/modelon/impact/client/experiment_definition/expansion.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, asdict
 from abc import abstractmethod, ABC
-from typing import Optional
+from typing import Optional, Dict, Any
 import logging
 
 
@@ -11,11 +11,11 @@ class ExpansionAlgorithm(ABC):
     """Base class for an expansion algorithm."""
 
     @abstractmethod
-    def __str__(self):
+    def __str__(self) -> str:
         "Returns a string representation of the expansion algorithm"
 
     @abstractmethod
-    def get_parameters_as_dict(self):
+    def get_parameters_as_dict(self) -> Optional[Dict[str, Any]]:
         "Returns parameters as a dictionary"
 
 
@@ -41,10 +41,10 @@ class LatinHypercube(ExpansionAlgorithm):
     samples: int
     seed: Optional[int] = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "LATINHYPERCUBE"
 
-    def get_parameters_as_dict(self):
+    def get_parameters_as_dict(self) -> Optional[Dict[str, Any]]:
         return asdict(self)
 
 
@@ -65,10 +65,10 @@ class FullFactorial(ExpansionAlgorithm):
 
     """
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "FULLFACTORIAL"
 
-    def get_parameters_as_dict(self):
+    def get_parameters_as_dict(self) -> Optional[Dict[str, Any]]:
         return None
 
 
@@ -96,8 +96,8 @@ class Sobol(ExpansionAlgorithm):
 
     samples: int
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "SOBOL"
 
-    def get_parameters_as_dict(self):
+    def get_parameters_as_dict(self) -> Optional[Dict[str, Any]]:
         return asdict(self)

--- a/modelon/impact/client/experiment_definition/extension.py
+++ b/modelon/impact/client/experiment_definition/extension.py
@@ -237,7 +237,8 @@ class SimpleExperimentExtension(BaseExperimentExtension):
         """
         ext_dict: Dict[str, Any] = {}
         if self._variable_modifiers:
-            ext_dict["modifiers"] = {"variables": self._variable_modifiers}
+            ext_dict.setdefault("modifiers", {})
+            ext_dict["modifiers"]["variables"] = self._variable_modifiers
 
         if self._parameter_modifiers:
             ext_dict.setdefault("analysis", {})
@@ -256,6 +257,7 @@ class SimpleExperimentExtension(BaseExperimentExtension):
             ext_dict["analysis"]["simulationLogLevel"] = self._simulation_log_level
 
         if self._initialize_from_experiment:
+            ext_dict.setdefault("modifiers", {})
             ext_dict["modifiers"][
                 "initializeFrom"
             ] = self._initialize_from_experiment.id
@@ -264,6 +266,7 @@ class SimpleExperimentExtension(BaseExperimentExtension):
             ext_dict["modifiers"]["initializeFromCase"] = case_to_identifier_dict(
                 self._initialize_from_case
             )
+
         if self._case_label:
             ext_dict["caseData"] = [{"label": self._case_label}]
 

--- a/modelon/impact/client/experiment_definition/extension.py
+++ b/modelon/impact/client/experiment_definition/extension.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
 import logging
 from abc import ABC
+from typing import Optional, Dict, Any, Union
 
 from modelon.impact.client.experiment_definition.operators import Operator
 from modelon.impact.client.entities.external_result import ExternalResult
+from modelon.impact.client.entities.experiment import Experiment
+from modelon.impact.client.entities.case import Case
 from modelon.impact.client.experiment_definition.util import (
     get_options,
     case_to_identifier_dict,
@@ -69,10 +73,10 @@ class SimpleExperimentExtension(BaseExperimentExtension):
 
     def __init__(
         self,
-        parameter_modifiers=None,
-        solver_options=None,
-        simulation_options=None,
-        simulation_log_level=None,
+        parameter_modifiers: Optional[Dict[str, Any]] = None,
+        solver_options: Optional[Dict[str, Any]] = None,
+        simulation_options: Optional[Dict[str, Any]] = None,
+        simulation_log_level: Optional[str] = None,
     ):
         self._parameter_modifiers = (
             {} if parameter_modifiers is None else parameter_modifiers
@@ -80,18 +84,19 @@ class SimpleExperimentExtension(BaseExperimentExtension):
         self._solver_options = get_options(dict, solver_options)
         self._simulation_options = get_options(dict, simulation_options)
         self._simulation_log_level = simulation_log_level
-        self._variable_modifiers = {}
-        self._initialize_from_experiment = None
-        self._initialize_from_case = None
-        self._case_label = None
+        self._variable_modifiers: Dict[str, Any] = {}
+        self._initialize_from_experiment: Optional[Experiment] = None
+        self._initialize_from_case: Optional[Case] = None
+        self._case_label: Optional[str] = None
 
-    def with_modifiers(self, modifiers=None, **modifiers_kwargs):
+    def with_modifiers(
+        self, modifiers: Optional[Dict[str, Any]] = None, **modifiers_kwargs: Any
+    ) -> SimpleExperimentExtension:
         """Sets the modifiers variables for an experiment extension.
 
         Args:
 
-            modifiers:
-                A dictionary of variable modifiers.
+            modifiers: A dictionary of variable modifiers.
 
         Example::
 
@@ -132,13 +137,12 @@ class SimpleExperimentExtension(BaseExperimentExtension):
             new._variable_modifiers[variable] = value
         return new
 
-    def with_case_label(self, case_label):
+    def with_case_label(self, case_label: str) -> SimpleExperimentExtension:
         """Sets the case label for an experiment extension.
 
         Args:
 
-            case_label:
-                A case label string.
+            case_label (str): A case label string.
 
         Example::
 
@@ -167,15 +171,16 @@ class SimpleExperimentExtension(BaseExperimentExtension):
 
         return new
 
-    def initialize_from(self, entity):
+    def initialize_from(
+        self, entity: Union[Experiment, Case]
+    ) -> SimpleExperimentExtension:
         """Sets the experiment or case to initialize from for an experiment
         extension.
 
         Args:
 
-            entity:
-                "An instance of modelon.impact.client.entities.case.Case or "
-                "modelon.impact.client.entities.experiment.Experiment."
+            entity: An instance of modelon.impact.client.entities.case.Case or
+                modelon.impact.client.entities.experiment.Experiment.
 
         Example::
             experiment = workspace.get_experiment(experiment_id)
@@ -209,13 +214,12 @@ class SimpleExperimentExtension(BaseExperimentExtension):
         new._case_label = self._case_label
         return new
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         """Returns the experiment extensions as a dictionary.
 
         Returns:
 
-            extensions_dict:
-                A dictionary containing the experiment extensions.
+            extensions_dict (dict): A dictionary containing the experiment extensions.
 
         Example::
 
@@ -231,7 +235,7 @@ class SimpleExperimentExtension(BaseExperimentExtension):
             simulate_ext.to_dict()
 
         """
-        ext_dict = {}
+        ext_dict: Dict[str, Any] = {}
         if self._variable_modifiers:
             ext_dict["modifiers"] = {"variables": self._variable_modifiers}
 

--- a/modelon/impact/client/experiment_definition/operators.py
+++ b/modelon/impact/client/experiment_definition/operators.py
@@ -1,5 +1,5 @@
 """This module contains operators for parametrizing batch runs."""
-
+from typing import Any
 from abc import abstractmethod
 from dataclasses import dataclass
 
@@ -8,7 +8,7 @@ class Operator:
     """Base class for an Operator."""
 
     @abstractmethod
-    def __str__(self):
+    def __str__(self) -> str:
         "Returns a string representation of the operator"
 
 
@@ -43,7 +43,7 @@ class Range(Operator):
     end_value: float
     no_of_steps: int
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"range({self.start_value},{self.end_value},{self.no_of_steps})"
 
 
@@ -66,10 +66,10 @@ class Choices(Operator):
 
     """
 
-    def __init__(self, *values):
+    def __init__(self, *values: Any):
         self.values = values
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"choices({', '.join(map(str, self.values))})"
 
 
@@ -101,7 +101,7 @@ class Uniform(Operator):
     start: float
     end: float
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"uniform({self.start},{self.end})"
 
 
@@ -132,7 +132,7 @@ class Beta(Operator):
     alpha: float
     beta: float
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"beta({self.alpha},{self.alpha})"
 
 
@@ -175,5 +175,5 @@ class Normal(Operator):
     start: float = float('-inf')
     end: float = float('inf')
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"normal({self.mean},{self.variance},{self.start},{self.end})"

--- a/modelon/impact/client/experiment_definition/util.py
+++ b/modelon/impact/client/experiment_definition/util.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+from typing import Dict, Any, TYPE_CHECKING, Optional
 from modelon.impact.client.options import BaseExecutionOptions
 
+if TYPE_CHECKING:
+    from modelon.impact.client.entities.case import Case
 
-def get_options(default_options, options):
+
+def get_options(default_options: Any, options: Optional[Any]) -> Dict[str, Any]:
     return (
         dict(default_options())
         if options is None
@@ -11,7 +16,7 @@ def get_options(default_options, options):
     )
 
 
-def case_to_identifier_dict(case):
+def case_to_identifier_dict(case: Case) -> Dict[str, Any]:
     return {
         "caseId": case.id,
         "experimentId": case.experiment_id,

--- a/modelon/impact/client/jupyterhub/authorize.py
+++ b/modelon/impact/client/jupyterhub/authorize.py
@@ -9,9 +9,7 @@ from modelon.impact.client.sal.uri import URI
 logger = logging.getLogger(__name__)
 
 
-def _get_jupyter_token(
-    credential_manager: CredentialManager, interactive: bool
-) -> Optional[str]:
+def _get_jupyter_token(credential_manager: CredentialManager, interactive: bool) -> str:
     jupyter_token = credential_manager.get_key(interactive=interactive)
     if not jupyter_token:
         raise exceptions.NoJupyterHubTokenError("No JupyterHub API token is given")
@@ -52,8 +50,9 @@ def authorize(
         else:
             raise
 
-    if interactive and jupyter_context.token:
-        credential_manager.write_key_to_file(jupyter_context.token)
+    jupyter_token = jupyter_context.token
+    if interactive and jupyter_token:
+        credential_manager.write_key_to_file(jupyter_token)
 
     if not user.server_running():
         uri_to_start_server = uri / 'hub/home'

--- a/modelon/impact/client/jupyterhub/authorize.py
+++ b/modelon/impact/client/jupyterhub/authorize.py
@@ -1,14 +1,17 @@
 import logging
-
+from typing import Optional, Tuple
 from modelon.impact.client.credential_manager import CredentialManager
 from modelon.impact.client.jupyterhub import exceptions
 from modelon.impact.client.jupyterhub import sal
-
+from modelon.impact.client.sal.context import Context
+from modelon.impact.client.sal.uri import URI
 
 logger = logging.getLogger(__name__)
 
 
-def _get_jupyter_token(credential_manager, interactive, context=None):
+def _get_jupyter_token(
+    credential_manager: CredentialManager, interactive: bool
+) -> Optional[str]:
     jupyter_token = credential_manager.get_key(interactive=interactive)
     if not jupyter_token:
         raise exceptions.NoJupyterHubTokenError("No JupyterHub API token is given")
@@ -16,7 +19,13 @@ def _get_jupyter_token(credential_manager, interactive, context=None):
     return jupyter_token
 
 
-def authorize(uri, interactive, context=None, credential_manager=None, service=None):
+def authorize(
+    uri: URI,
+    interactive: bool,
+    context: Optional[Context] = None,
+    credential_manager: Optional[CredentialManager] = None,
+    service: Optional[sal.JupyterHubService] = None,
+) -> Tuple[URI, sal.JupyterContext]:
     help_text = f"Enter JupyterHub API token (can be generated at {uri / 'token'}):"
     credential_manager = credential_manager or CredentialManager(
         file_id="jupyterhub-api.key",
@@ -26,25 +35,25 @@ def authorize(uri, interactive, context=None, credential_manager=None, service=N
         ],
         interactive_help_text=help_text,
     )
-    context = sal.JupyterContext(base=context)
+    jupyter_context = sal.JupyterContext(base=context)
     service = service or sal.JupyterHubService()
 
     try:
-        context.token = _get_jupyter_token(credential_manager, interactive)
-        user = service.get_user_data(uri, context)
+        jupyter_context.token = _get_jupyter_token(credential_manager, interactive)
+        user = service.get_user_data(uri, jupyter_context)
     except exceptions.JupyterHubAuthrizationError:
         if interactive:
             logger.warning(
                 "Could not authorize with the provided JupyterHub API token, "
                 "please enter a new token"
             )
-            context.token = credential_manager.get_key_from_prompt()
-            user = service.get_user_data(uri, context)
+            jupyter_context.token = credential_manager.get_key_from_prompt()
+            user = service.get_user_data(uri, jupyter_context)
         else:
             raise
 
-    if interactive:
-        credential_manager.write_key_to_file(context.token)
+    if interactive and jupyter_context.token:
+        credential_manager.write_key_to_file(jupyter_context.token)
 
     if not user.server_running():
         uri_to_start_server = uri / 'hub/home'
@@ -53,4 +62,4 @@ def authorize(uri, interactive, context=None, credential_manager=None, service=N
             f"Go to {uri_to_start_server} and start a server."
         )
 
-    return user.impact_server_uri(uri), context
+    return user.impact_server_uri(uri), jupyter_context

--- a/modelon/impact/client/jupyterhub/sal.py
+++ b/modelon/impact/client/jupyterhub/sal.py
@@ -1,64 +1,65 @@
 import json.decoder
-
+from typing import Optional
 import requests
 
 from modelon.impact.client.jupyterhub import exceptions
 from modelon.impact.client.sal.context import Context
+from modelon.impact.client.sal.uri import URI
 
 
 class JupyterContext:
     __slots__ = ['_base', '_token']
 
-    def __init__(self, base=None):
+    def __init__(self, base: Optional[Context] = None):
         self._base = base if base else Context()
-        self._token = None
+        self._token: Optional[str] = None
 
     @property
-    def session(self):
+    def session(self) -> requests.Session:
         return self._base.session
 
     @property
-    def token(self):
+    def token(self) -> Optional[str]:
         return self._token
 
     @token.setter
-    def token(self, token):
+    def token(self, token: str) -> None:
         self._token = token
         self.session.headers.update({'Authorization': 'token %s' % token})
 
 
 class JupyterUser:
-    def __init__(self, user_id, server):
+    def __init__(self, user_id: str, server: str):
         self.id = user_id
         self._server = server
 
-    def server_running(self):
+    def server_running(self) -> bool:
         return self._server is not None
 
-    def impact_server_uri(self, jupyterhub_uri):
+    def impact_server_uri(self, jupyterhub_uri: URI) -> URI:
         return jupyterhub_uri / f'user/{self.id}/impact'
 
 
 class JupyterHubService:
     @classmethod
-    def get_user_data(cls, uri, context):
+    def get_user_data(cls, uri: URI, context: JupyterContext) -> JupyterUser:
         auth_token_url = (
             uri / f'hub/api/authorizations/token/{context.token}'
         ).resolve()
 
         try:
-            user_respons = context.session.get(auth_token_url)
+            user_response = context.session.get(auth_token_url)
         except requests.exceptions.RequestException as e:
             raise exceptions.NotAJupyterHubUrl(
                 f"Did not get a response from {uri}, is the URL correct?"
             ) from e
 
-        if not user_respons.ok:
-            if user_respons.status_code == 403:
+        if not user_response.ok:
+            if user_response.status_code == 403:
                 raise exceptions.JupyterHubAuthrizationError(
                     "Could not authorize against JupyterHub, is the token correct?"
                 )
-            elif user_respons.status_code == 404:
+            elif user_response.status_code == 404:
                 raise exceptions.NotAJupyterHubUrl(
                     f"Missing resource '{auth_token_url}'. Possible errors are "
                     f"that the URL '{uri}' don't points to a JupyterHub or "
@@ -67,11 +68,11 @@ class JupyterHubService:
             else:
                 raise exceptions.UnknownJupyterHubError(
                     "Something went wrong calling JupyterHub. Got the response "
-                    f"'{user_respons}' with content '{user_respons.content}'"
+                    f"'{user_response}' with content '{str(user_response.content)}'"
                 )
 
         try:
-            user_data = user_respons.json()
+            user_data = user_response.json()
             return JupyterUser(user_data['name'], user_data['server'])
         except (KeyError, json.decoder.JSONDecodeError) as e:
             raise exceptions.NotAJupyterHubUrl(

--- a/modelon/impact/client/operations/base.py
+++ b/modelon/impact/client/operations/base.py
@@ -28,7 +28,7 @@ class AsyncOperationStatus(enum.Enum):
     READY = 'ready'
     ERROR = 'error'
 
-    def done(self):
+    def done(self) -> bool:
         return self in [AsyncOperationStatus.READY, AsyncOperationStatus.ERROR]
 
 
@@ -36,17 +36,17 @@ class BaseOperation(ABC):
     """Abstract base operation class."""
 
     @abstractmethod
-    def data(self):
+    def data(self) -> Any:
         """Returns the operation class."""
         pass
 
     @abstractmethod
-    def status(self):
+    def status(self) -> Any:
         """Returns the operation status as an enumeration."""
         pass
 
     @abstractmethod
-    def cancel(self):
+    def cancel(self) -> Any:
         """Terminates the operation."""
         pass
 
@@ -57,7 +57,7 @@ class BaseOperation(ABC):
         pass
 
     @abstractmethod
-    def wait(self, timeout):
+    def wait(self, timeout: Optional[float]) -> Any:
         """Waits for the operation to finish."""
         pass
 
@@ -105,7 +105,7 @@ class AsyncOperation(BaseOperation):
 
             time.sleep(0.5)
 
-    def cancel(self):
+    def cancel(self) -> None:
         raise NotImplementedError('Cancel is not supported for this operation')
 
 
@@ -128,7 +128,9 @@ class ExecutionOperation(BaseOperation):
         """
         return self.status() == Status.DONE
 
-    def wait(self, timeout: Optional[float] = None, status: Status = Status.DONE):
+    def wait(
+        self, timeout: Optional[float] = None, status: Status = Status.DONE
+    ) -> Any:
         """Waits until the operation achieves the set status. Returns the
         operation class instance if the set status is achieved.
 

--- a/modelon/impact/client/operations/case.py
+++ b/modelon/impact/client/operations/case.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from modelon.impact.client.entities import case
 from modelon.impact.client.operations.base import ExecutionOperation, Status
 from modelon.impact.client.sal.service import Service
@@ -6,30 +7,30 @@ from modelon.impact.client.sal.service import Service
 class CaseOperation(ExecutionOperation):
     """An operation class for the modelon.impact.client.entities.Case class."""
 
-    def __init__(self, workspace_id, exp_id, case_id, service: Service):
+    def __init__(self, workspace_id: str, exp_id: str, case_id: str, service: Service):
         super().__init__()
         self._workspace_id = workspace_id
         self._exp_id = exp_id
         self._case_id = case_id
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Case operation for id '{self._case_id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return isinstance(obj, CaseOperation) and obj._case_id == self._case_id
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Case id."""
         return self._case_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Execution"
 
-    def data(self):
+    def data(self) -> case.Case:
         """Returns a new Case class instance.
 
         Returns:
@@ -45,7 +46,7 @@ class CaseOperation(ExecutionOperation):
             self._case_id, self._workspace_id, self._exp_id, self._sal, case_data
         )
 
-    def status(self):
+    def status(self) -> Status:
         """Returns the execution status as an enumeration.
 
         Returns:
@@ -66,7 +67,7 @@ class CaseOperation(ExecutionOperation):
             ]
         )
 
-    def cancel(self):
+    def cancel(self) -> None:
         """Terminates the execution process.
 
         Example::

--- a/modelon/impact/client/operations/content_import.py
+++ b/modelon/impact/client/operations/content_import.py
@@ -1,3 +1,4 @@
+from typing import Dict, Any
 from modelon.impact.client.sal.service import Service
 from modelon.impact.client.operations.base import AsyncOperation, AsyncOperationStatus
 from modelon.impact.client import exceptions
@@ -13,28 +14,28 @@ class ContentImportOperation(AsyncOperation):
         self._location = location
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Content import operations for id '{self.id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return (
             isinstance(obj, ContentImportOperation) and obj._location == self._location
         )
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Content import id."""
         return self._location.split('/')[-1]
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Content import"
 
-    def _info(self):
+    def _info(self) -> Dict[str, Any]:
         return self._sal.imports.get_import_status(self._location)["data"]
 
-    def data(self):
+    def data(self) -> ProjectContent:
         """Returns a new Workspace class instance.
 
         Returns:
@@ -53,7 +54,7 @@ class ContentImportOperation(AsyncOperation):
         resp = self._sal.project.project_content_get(project_id, content_id)
         return ProjectContent(resp, project_id, self._sal)
 
-    def status(self):
+    def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
         Returns:

--- a/modelon/impact/client/operations/experiment.py
+++ b/modelon/impact/client/operations/experiment.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from modelon.impact.client.operations import base
 import modelon.impact.client.entities.experiment
 from modelon.impact.client.sal.service import Service
@@ -13,23 +14,23 @@ class ExperimentOperation(base.ExecutionOperation):
         self._exp_id = exp_id
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Experiment operation for id '{self._exp_id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return isinstance(obj, ExperimentOperation) and obj._exp_id == self._exp_id
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Experiment id."""
         return self._exp_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Execution"
 
-    def data(self):
+    def data(self) -> modelon.impact.client.entities.experiment.Experiment:
         """Returns a new Experiment class instance.
 
         Returns:
@@ -42,7 +43,7 @@ class ExperimentOperation(base.ExecutionOperation):
             self._workspace_id, self._exp_id, self._sal
         )
 
-    def status(self):
+    def status(self) -> base.Status:
         """Returns the execution status as an enumeration.
 
         Returns:
@@ -63,7 +64,7 @@ class ExperimentOperation(base.ExecutionOperation):
             ]
         )
 
-    def cancel(self):
+    def cancel(self) -> None:
         """Terminates the execution process.
 
         Example::

--- a/modelon/impact/client/operations/external_result_import.py
+++ b/modelon/impact/client/operations/external_result_import.py
@@ -1,3 +1,4 @@
+from typing import Dict, Any
 from modelon.impact.client import exceptions
 from modelon.impact.client.entities.external_result import ExternalResult
 from modelon.impact.client.sal.service import Service
@@ -16,29 +17,29 @@ class ExternalResultImportOperation(AsyncOperation):
         self._location = location
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Result import operations for id '{self.id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return (
             isinstance(obj, ExternalResultImportOperation)
             and obj._location == self._location
         )
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Result import id."""
         return self._location.split('/')[-1]
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Result import"
 
-    def _info(self):
+    def _info(self) -> Dict[str, Any]:
         return self._sal.imports.get_import_status(self._location)["data"]
 
-    def data(self):
+    def data(self) -> ExternalResult:
         """Returns a new ExternalResult class instance.
 
         Returns:
@@ -55,7 +56,7 @@ class ExternalResultImportOperation(AsyncOperation):
         resp = self._sal.external_result.get_uploaded_result(self.id)
         return ExternalResult(resp['data']['id'], self._sal)
 
-    def status(self):
+    def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
         Returns:

--- a/modelon/impact/client/operations/model_executable.py
+++ b/modelon/impact/client/operations/model_executable.py
@@ -30,26 +30,26 @@ class CachedModelExecutableOperation(ExecutionOperation):
         self._info = info
         self._modifiers = modifiers
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Cached model executable operations for id '{self._fmu_id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return (
             isinstance(obj, CachedModelExecutableOperation)
             and obj._fmu_id == self._fmu_id
         )
 
     @property
-    def id(self):
+    def id(self) -> str:
         """FMU id."""
         return self._fmu_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Looking for cached FMU"
 
-    def data(self):
+    def data(self) -> ModelExecutable:
         """Returns a new ModelExecutable class instance.
 
         Returns:
@@ -62,7 +62,7 @@ class CachedModelExecutableOperation(ExecutionOperation):
             self._workspace_id, self._fmu_id, self._sal, self._info, self._modifiers
         )
 
-    def status(self):
+    def status(self) -> Status:
         """Returns the compilation status as an enumeration.
 
         Returns:
@@ -79,12 +79,14 @@ class CachedModelExecutableOperation(ExecutionOperation):
         """
         return Status.DONE
 
-    def cancel(self):
+    def cancel(self) -> None:
         raise NotImplementedError(
             "Cancel is not supported for CachedModelExecutableOperation class"
         )
 
-    def wait(self, timeout=None, status=Status.DONE):
+    def wait(
+        self, timeout: Optional[float] = None, status: Status = Status.DONE
+    ) -> ModelExecutable:
         """Waits until the operation achieves the set status. Returns the
         operation class instance if the set status is achieved.
 
@@ -137,23 +139,23 @@ class ModelExecutableOperation(ExecutionOperation):
         self._fmu_id = fmu_id
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Model executable operations for id '{self._fmu_id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return isinstance(obj, ModelExecutableOperation) and obj._fmu_id == self._fmu_id
 
     @property
-    def id(self):
+    def id(self) -> str:
         """FMU id."""
         return self._fmu_id
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Compilation"
 
-    def data(self):
+    def data(self) -> ModelExecutable:
         """Returns a new ModelExecutable class instance.
 
         Returns:
@@ -164,7 +166,7 @@ class ModelExecutableOperation(ExecutionOperation):
         """
         return ModelExecutable(self._workspace_id, self._fmu_id, self._sal)
 
-    def status(self):
+    def status(self) -> Status:
         """Returns the compilation status as an enumeration.
 
         Returns:
@@ -185,7 +187,7 @@ class ModelExecutableOperation(ExecutionOperation):
             ]
         )
 
-    def cancel(self):
+    def cancel(self) -> None:
         """Terminates the compilation process.
 
         Example::

--- a/modelon/impact/client/operations/project_import.py
+++ b/modelon/impact/client/operations/project_import.py
@@ -1,3 +1,4 @@
+from typing import Dict, Any
 from modelon.impact.client.entities.project import Project, ProjectDefinition
 from modelon.impact.client.sal.service import Service
 from modelon.impact.client.operations.base import AsyncOperation, AsyncOperationStatus
@@ -21,28 +22,28 @@ class ProjectImportOperation(AsyncOperation):
         self._location = location
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Project import operations for id '{self.id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return (
             isinstance(obj, ProjectImportOperation) and obj._location == self._location
         )
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Project import id."""
         return self._location.split('/')[-1]
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Project import"
 
-    def _info(self):
+    def _info(self) -> Dict[str, Any]:
         return self._sal.imports.get_import_status(self._location)["data"]
 
-    def data(self):
+    def data(self) -> Project:
         """Returns a new Project class instance.
 
         Returns:
@@ -66,7 +67,7 @@ class ProjectImportOperation(AsyncOperation):
             self._sal,
         )
 
-    def status(self):
+    def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
         Returns:

--- a/modelon/impact/client/operations/workspace/conversion.py
+++ b/modelon/impact/client/operations/workspace/conversion.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+from typing import Dict, Any
 from modelon.impact.client import exceptions
 from modelon.impact.client.entities.workspace import Workspace, WorkspaceDefinition
 from modelon.impact.client.operations.base import AsyncOperation, AsyncOperationStatus
@@ -17,31 +19,31 @@ class WorkspaceConversionOperation(AsyncOperation):
         self._location = location
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Workspace conversion operations for id '{self.id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return (
             isinstance(obj, WorkspaceConversionOperation)
             and obj._location == self._location
         )
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Workspace conversion id."""
         return self._location.split('/')[-1]
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Workspace conversion"
 
-    def _info(self):
+    def _info(self) -> Dict[str, Any]:
         return self._sal.workspace.get_workspace_conversion_status(self._location)[
             "data"
         ]
 
-    def data(self):
+    def data(self) -> Workspace:
         """Returns a Workspace class instance of the converted workspace.
 
         Returns:
@@ -59,7 +61,7 @@ class WorkspaceConversionOperation(AsyncOperation):
         resp = self._sal.workspace.workspace_get(workspace_id)
         return Workspace(resp["id"], WorkspaceDefinition(resp["definition"]), self._sal)
 
-    def status(self):
+    def status(self) -> AsyncOperationStatus:
         """Returns the conversion status as an enumeration.
 
         Returns:

--- a/modelon/impact/client/operations/workspace/exports.py
+++ b/modelon/impact/client/operations/workspace/exports.py
@@ -1,15 +1,20 @@
+from __future__ import annotations
 import os
+from typing import Dict, Any, TYPE_CHECKING
 from modelon.impact.client.sal.service import Service
 from modelon.impact.client.operations.base import AsyncOperation, AsyncOperationStatus
 from modelon.impact.client import exceptions
 
+if TYPE_CHECKING:
+    from modelon.impact.client.sal.exports import ExportService
+
 
 class Export:
-    def __init__(self, export_service, download_uri):
+    def __init__(self, export_service: ExportService, download_uri: str):
         self._export_sal = export_service
         self._download_uri = download_uri
 
-    def download_as(self, path_to_download):
+    def download_as(self, path_to_download: str) -> str:
         """Writes the binary archive to a file. Returns the path to downloaded
         archive.
 
@@ -49,29 +54,29 @@ class WorkspaceExportOperation(AsyncOperation):
         self._location = location
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Workspace export operations for id '{self.id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return (
             isinstance(obj, WorkspaceExportOperation)
             and obj._location == self._location
         )
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Workspace export id."""
         return self._location.split('/')[-1]
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Workspace export"
 
-    def _info(self):
+    def _info(self) -> Dict[str, Any]:
         return self._sal.exports.get_export_status(self._location)["data"]
 
-    def data(self):
+    def data(self) -> Export:
         """Returns a Export class instance.
 
         Returns:
@@ -86,7 +91,7 @@ class WorkspaceExportOperation(AsyncOperation):
             )
         return Export(self._sal.exports, info["data"]["downloadUri"])
 
-    def status(self):
+    def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
         Returns:

--- a/modelon/impact/client/operations/workspace/imports.py
+++ b/modelon/impact/client/operations/workspace/imports.py
@@ -1,3 +1,4 @@
+from typing import Dict, Any
 from modelon.impact.client.entities.workspace import Workspace, WorkspaceDefinition
 from modelon.impact.client.sal.service import Service
 from modelon.impact.client.operations.base import AsyncOperation, AsyncOperationStatus
@@ -21,29 +22,29 @@ class WorkspaceImportOperation(AsyncOperation):
         self._location = location
         self._sal = service
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Workspace import operations for id '{self.id}'"
 
-    def __eq__(self, obj):
+    def __eq__(self, obj: object) -> bool:
         return (
             isinstance(obj, WorkspaceImportOperation)
             and obj._location == self._location
         )
 
     @property
-    def id(self):
+    def id(self) -> str:
         """Workspace import id."""
         return self._location.split('/')[-1]
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of operation."""
         return "Workspace import"
 
-    def _info(self):
+    def _info(self) -> Dict[str, Any]:
         return self._sal.imports.get_import_status(self._location)["data"]
 
-    def data(self):
+    def data(self) -> Workspace:
         """Returns a new Workspace class instance.
 
         Returns:
@@ -61,7 +62,7 @@ class WorkspaceImportOperation(AsyncOperation):
         resp = self._sal.workspace.workspace_get(workspace_id)
         return Workspace(resp["id"], WorkspaceDefinition(resp["definition"]), self._sal)
 
-    def status(self):
+    def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
         Returns:

--- a/modelon/impact/client/options.py
+++ b/modelon/impact/client/options.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
 from copy import deepcopy
 from collections.abc import Mapping
-from typing import Union, List, Dict, Any
+from typing import Union, List, Dict, Any, Iterator
 from abc import ABC
 
 
-def _set_options(options, **modified):
+def _set_options(options: Dict[str, Any], **modified: Any) -> Dict[str, Any]:
     opts = deepcopy(options)
     for name, value in modified.items():
         opts[name] = value
@@ -19,25 +20,24 @@ class BaseExecutionOptions(Mapping, ABC):
         self._values = values
         self._custom_function_name = custom_function_name
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{type(self).__name__} for '{self._custom_function_name}'"
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         return self._values[key]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         return self._values.__iter__()
 
-    def __len__(self):
+    def __len__(self) -> int:
         return self._values.__len__()
 
-    def with_values(self, **modified):
+    def with_values(self, **modified: Any) -> Any:
         """Sets/updates the options.
 
         Args:
 
-            parameters:
-                A keyworded, variable-length argument list of options.
+            parameters: A keyworded, variable-length argument list of options.
 
         Example::
 
@@ -66,7 +66,7 @@ class SolverOptions(BaseExecutionOptions):
 
 
 class SimulationOptions(BaseExecutionOptions):
-    def with_result_filter(self, pattern: Union[str, List[str]]):
+    def with_result_filter(self, pattern: Union[str, List[str]]) -> SimulationOptions:
         """Sets the variable filter for results.
 
         Args:
@@ -95,24 +95,24 @@ class ProjectExecutionOptions:
         self._name = name
 
     @property
-    def custom_function(self):
+    def custom_function(self) -> str:
         return self._name
 
     @property
-    def compiler_options(self):
+    def compiler_options(self) -> CompilerOptions:
         return CompilerOptions(self._data.get("compiler", {}), self.custom_function)
 
     @property
-    def runtime_options(self):
+    def runtime_options(self) -> RuntimeOptions:
         return RuntimeOptions(self._data.get("runtime", {}), self.custom_function)
 
     @property
-    def simulation_options(self):
+    def simulation_options(self) -> SimulationOptions:
         return SimulationOptions(self._data.get("simulation", {}), self.custom_function)
 
     @property
-    def solver_options(self):
+    def solver_options(self) -> SolverOptions:
         return SolverOptions(self._data.get("solver", {}), self.custom_function)
 
-    def to_dict(self):
+    def to_dict(self) -> Dict[str, Any]:
         return {"customFunction": self._name, **self._data}

--- a/modelon/impact/client/sal/context.py
+++ b/modelon/impact/client/sal/context.py
@@ -3,5 +3,5 @@ from requests import Session
 
 
 class Context:
-    def __init__(self):
+    def __init__(self) -> None:
         self.session = Session()

--- a/modelon/impact/client/sal/custom_function.py
+++ b/modelon/impact/client/sal/custom_function.py
@@ -1,4 +1,5 @@
 """Custom function service module."""
+from typing import Dict, Any
 from modelon.impact.client.sal.http import HTTPClient
 from modelon.impact.client.sal.uri import URI
 
@@ -8,14 +9,16 @@ class CustomFunctionService:
         self._base_uri = uri
         self._http_client = http_client
 
-    def custom_function_get(self, workspace_id: str, custom_function: str):
+    def custom_function_get(
+        self, workspace_id: str, custom_function: str
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/custom-functions/{custom_function}"
         ).resolve()
         return self._http_client.get_json(url)
 
-    def custom_functions_get(self, workspace_id: str):
+    def custom_functions_get(self, workspace_id: str) -> Dict[str, Any]:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/custom-functions"
         ).resolve()
@@ -23,7 +26,7 @@ class CustomFunctionService:
 
     def custom_function_default_options_get(
         self, workspace_id: str, custom_function: str
-    ):
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/custom-functions/{custom_function}"
@@ -31,7 +34,9 @@ class CustomFunctionService:
         ).resolve()
         return self._http_client.get_json(url)
 
-    def custom_function_options_get(self, workspace_id: str, custom_function: str):
+    def custom_function_options_get(
+        self, workspace_id: str, custom_function: str
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/custom-functions/{custom_function}"

--- a/modelon/impact/client/sal/exceptions.py
+++ b/modelon/impact/client/sal/exceptions.py
@@ -22,7 +22,7 @@ class UnauthorizedError(ServiceAccessError):
 
 
 class HTTPError(ServiceAccessError):
-    def __init__(self, message, status_code):
+    def __init__(self, message: str, status_code: int):
         self.status_code = status_code
         super().__init__(message)
 

--- a/modelon/impact/client/sal/experiment.py
+++ b/modelon/impact/client/sal/experiment.py
@@ -1,6 +1,7 @@
 """Experiment service module."""
+from __future__ import annotations
 import enum
-from typing import Any, Optional, List, Dict
+from typing import Any, Optional, List, Dict, Union, Text, Tuple
 from modelon.impact.client.sal.http import HTTPClient
 from modelon.impact.client.sal.uri import URI
 
@@ -14,7 +15,7 @@ class ResultFormat(enum.Enum):
     CSV = "csv"
 
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, value: Any) -> Any:
         if cls not in ['mat', 'csv']:
             raise ValueError(
                 "Invalid result format! Allowed formats are 'mat' and 'csv."
@@ -38,33 +39,33 @@ class ExperimentService:
         self._http_client.post_json_no_response_body(url, body=body)
         return exp_id
 
-    def experiment_delete(self, workspace_id: str, exp_id: str):
+    def experiment_delete(self, workspace_id: str, exp_id: str) -> None:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/experiments/{exp_id}"
         ).resolve()
         self._http_client.delete_json(url)
 
-    def experiment_set_label(self, workspace_id: str, exp_id: str, label: str):
+    def experiment_set_label(self, workspace_id: str, exp_id: str, label: str) -> None:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/experiments/{exp_id}"
         ).resolve()
         return self._http_client.put_json_no_response_body(url, body={"label": label})
 
-    def execute_status(self, workspace_id: str, experiment_id: str):
+    def execute_status(self, workspace_id: str, experiment_id: str) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/execution"
         ).resolve()
         return self._http_client.get_json(url)
 
-    def execute_cancel(self, workspace_id: str, experiment_id: str):
+    def execute_cancel(self, workspace_id: str, experiment_id: str) -> None:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/execution"
         ).resolve()
         return self._http_client.delete_json(url)
 
-    def result_variables_get(self, workspace_id: str, experiment_id: str):
+    def result_variables_get(self, workspace_id: str, experiment_id: str) -> List[str]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/variables"
@@ -73,7 +74,7 @@ class ExperimentService:
 
     def trajectories_get(
         self, workspace_id: str, experiment_id: str, variables: List[str]
-    ):
+    ) -> List[str]:
         body = {"variable_names": variables}
         url = (
             self._base_uri
@@ -81,14 +82,16 @@ class ExperimentService:
         ).resolve()
         return self._http_client.post_json(url, body=body)
 
-    def cases_get(self, workspace_id: str, experiment_id: str):
+    def cases_get(self, workspace_id: str, experiment_id: str) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases"
         ).resolve()
         return self._http_client.get_json(url)
 
-    def case_get(self, workspace_id: str, experiment_id: str, case_id: str):
+    def case_get(
+        self, workspace_id: str, experiment_id: str, case_id: str
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"
@@ -102,7 +105,7 @@ class ExperimentService:
         experiment_id: str,
         case_id: str,
         case_data: Dict[str, Any],
-    ):
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"
@@ -110,7 +113,7 @@ class ExperimentService:
         ).resolve()
         return self._http_client.put_json(url, body=case_data)
 
-    def case_get_log(self, workspace_id: str, experiment_id: str, case_id: str):
+    def case_get_log(self, workspace_id: str, experiment_id: str, case_id: str) -> str:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"
@@ -124,7 +127,7 @@ class ExperimentService:
         experiment_id: str,
         case_id: str,
         result_format: ResultFormat = ResultFormat.MAT,
-    ):
+    ) -> Tuple[Union[Text, bytes], str]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"
@@ -140,7 +143,7 @@ class ExperimentService:
 
     def case_trajectories_get(
         self, workspace_id: str, experiment_id: str, case_id: str, variables: List[str]
-    ):
+    ) -> List[str]:
         body = {"variable_names": variables}
         url = (
             self._base_uri
@@ -151,7 +154,7 @@ class ExperimentService:
 
     def case_artifact_get(
         self, workspace_id: str, experiment_id: str, case_id: str, artifact_id: str
-    ):
+    ) -> Tuple[bytes, str]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"
@@ -162,7 +165,7 @@ class ExperimentService:
 
     def case_artifacts_meta_get(
         self, workspace_id: str, experiment_id: str, case_id: str
-    ):
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"

--- a/modelon/impact/client/sal/exports.py
+++ b/modelon/impact/client/sal/exports.py
@@ -1,4 +1,5 @@
 """Export service module."""
+from typing import Dict, Any
 from modelon.impact.client.sal.http import HTTPClient
 from modelon.impact.client.sal.uri import URI
 
@@ -8,10 +9,10 @@ class ExportService:
         self._base_uri = uri
         self._http_client = http_client
 
-    def export_download(self, location):
+    def export_download(self, location: str) -> bytes:
         url = (self._base_uri / location).resolve()
         return self._http_client.get_zip(url)
 
-    def get_export_status(self, location):
+    def get_export_status(self, location: str) -> Dict[str, Any]:
         url = (self._base_uri / location).resolve()
         return self._http_client.get_json(url)

--- a/modelon/impact/client/sal/external_result.py
+++ b/modelon/impact/client/sal/external_result.py
@@ -16,7 +16,7 @@ class ExternalResultService:
         path_to_result: str,
         label: Optional[str] = None,
         description: Optional[str] = None,
-    ):
+    ) -> Dict[str, Any]:
         url = (self._base_uri / "api/uploads/results").resolve()
         options: Dict[str, Any] = {
             "context": {"workspaceId": workspace_id},
@@ -32,10 +32,10 @@ class ExternalResultService:
             }
             return self._http_client.post_json(url, files=multipart_form_data)
 
-    def get_uploaded_result(self, result_id: str):
+    def get_uploaded_result(self, result_id: str) -> Dict[str, Any]:
         url = (self._base_uri / f"api/external-result/{result_id}").resolve()
         return self._http_client.get_json(url)
 
-    def delete_uploaded_result(self, result_id: str):
+    def delete_uploaded_result(self, result_id: str) -> None:
         url = (self._base_uri / f"api/external-result/{result_id}").resolve()
         return self._http_client.delete_json(url)

--- a/modelon/impact/client/sal/http.py
+++ b/modelon/impact/client/sal/http.py
@@ -1,5 +1,5 @@
 """HTTP client class."""
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Union
 from modelon.impact.client.sal.request import (
     RequestCSV,
     RequestJSON,
@@ -15,13 +15,14 @@ from modelon.impact.client.sal.response import (
     OctetStreamResponse,
 )
 from modelon.impact.client.sal.context import Context
+from modelon.impact.client.jupyterhub.sal import JupyterContext
 
 
 class HTTPClient:
-    def __init__(self, context: Optional[Context] = None):
+    def __init__(self, context: Optional[Union[Context, JupyterContext]] = None):
         self._context = context if context else Context()
 
-    def get_json(self, url: str, headers: Optional[Dict[str, Any]] = None):
+    def get_json(self, url: str, headers: Optional[Dict[str, Any]] = None) -> Any:
         return self.get_json_response(url, headers=headers).data
 
     def get_json_response(
@@ -30,7 +31,7 @@ class HTTPClient:
         request = RequestJSON(self._context, "GET", url, headers=headers)
         return request.execute()
 
-    def get_text(self, url: str) -> Dict[str, Any]:
+    def get_text(self, url: str) -> str:
         request = RequestText(self._context, "GET", url)
         return request.execute().data
 
@@ -55,26 +56,27 @@ class HTTPClient:
         return request.execute().data
 
     def post_json(
-        self, url: str, body: Optional[Dict[str, Any]] = None, files=None
-    ) -> Dict[str, Any]:
+        self,
+        url: str,
+        body: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+    ) -> Any:
         request = RequestJSON(self._context, "POST", url, body, files)
         return request.execute().data
 
     def post_json_no_response_body(
         self, url: str, body: Optional[Dict[str, Any]] = None
-    ):
+    ) -> None:
         RequestJSON(self._context, "POST", url, body).execute()
 
-    def delete_json(self, url: str, body: Optional[Dict[str, Any]] = None):
+    def delete_json(self, url: str, body: Optional[Dict[str, Any]] = None) -> None:
         RequestJSON(self._context, "DELETE", url, body).execute()
 
     def put_json_no_response_body(
         self, url: str, body: Optional[Dict[str, Any]] = None
-    ):
+    ) -> None:
         RequestJSON(self._context, "PUT", url, body).execute()
 
-    def put_json(
-        self, url: str, body: Optional[Dict[str, Any]] = None
-    ) -> Dict[str, Any]:
+    def put_json(self, url: str, body: Optional[Dict[str, Any]] = None) -> Any:
         request = RequestJSON(self._context, "PUT", url, body)
         return request.execute().data

--- a/modelon/impact/client/sal/imports.py
+++ b/modelon/impact/client/sal/imports.py
@@ -1,4 +1,5 @@
 """Import service module."""
+from typing import Dict, Any
 from modelon.impact.client.sal.http import HTTPClient
 from modelon.impact.client.sal.uri import URI
 
@@ -8,6 +9,6 @@ class ImportService:
         self._base_uri = uri
         self._http_client = http_client
 
-    def get_import_status(self, location):
+    def get_import_status(self, location: str) -> Dict[str, Any]:
         url = (self._base_uri / location).resolve()
         return self._http_client.get_json(url)

--- a/modelon/impact/client/sal/model_executable.py
+++ b/modelon/impact/client/sal/model_executable.py
@@ -1,5 +1,5 @@
 """Model executable service module."""
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List
 from modelon.impact.client.sal.http import HTTPClient
 from modelon.impact.client.sal.uri import URI
 
@@ -19,7 +19,7 @@ class ModelExecutableService:
         resp = self._http_client.post_json(url, body=options)
         return resp["id"], resp["parameters"]
 
-    def compile_model(self, workspace_id, fmu_id: str) -> str:
+    def compile_model(self, workspace_id: str, fmu_id: str) -> str:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}/compilation"
@@ -27,7 +27,7 @@ class ModelExecutableService:
         self._http_client.post_json_no_response_body(url)
         return fmu_id
 
-    def compile_log(self, workspace_id: str, fmu_id: str):
+    def compile_log(self, workspace_id: str, fmu_id: str) -> str:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}/compilation/"
@@ -35,27 +35,27 @@ class ModelExecutableService:
         ).resolve()
         return self._http_client.get_text(url)
 
-    def fmu_delete(self, workspace_id: str, fmu_id: str):
+    def fmu_delete(self, workspace_id: str, fmu_id: str) -> None:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}"
         ).resolve()
         self._http_client.delete_json(url)
 
-    def compile_status(self, workspace_id: str, fmu_id: str):
+    def compile_status(self, workspace_id: str, fmu_id: str) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}/compilation"
         ).resolve()
         return self._http_client.get_json(url)
 
-    def compile_cancel(self, workspace_id: str, fmu_id: str):
+    def compile_cancel(self, workspace_id: str, fmu_id: str) -> None:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}/compilation"
         ).resolve()
         return self._http_client.delete_json(url)
 
-    def settable_parameters_get(self, workspace_id: str, fmu_id: str):
+    def settable_parameters_get(self, workspace_id: str, fmu_id: str) -> List[str]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}/"
@@ -65,7 +65,7 @@ class ModelExecutableService:
 
     def ss_fmu_metadata_get(
         self, workspace_id: str, fmu_id: str, parameter_state: Dict[str, Any]
-    ):
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}"
             "/steady-state-metadata"

--- a/modelon/impact/client/sal/project.py
+++ b/modelon/impact/client/sal/project.py
@@ -10,27 +10,27 @@ class ProjectService:
         self._base_uri = uri
         self._http_client = http_client
 
-    def projects_get(self, vcs_info: bool):
+    def projects_get(self, vcs_info: bool) -> Dict[str, Any]:
         url = (self._base_uri / f"api/projects?vcsInfo={vcs_info}").resolve()
         return self._http_client.get_json(url)
 
-    def project_get(self, project_id: str, vcs_info: bool):
+    def project_get(self, project_id: str, vcs_info: bool) -> Dict[str, Any]:
         url = (
             self._base_uri / f"api/projects/{project_id}?vcsInfo={vcs_info}"
         ).resolve()
         return self._http_client.get_json(url)
 
-    def project_delete(self, project_id: str):
+    def project_delete(self, project_id: str) -> None:
         url = (self._base_uri / f"api/projects/{project_id}").resolve()
         self._http_client.delete_json(url)
 
-    def project_put(self, project_id: str, project_data: Dict[str, Any]):
+    def project_put(self, project_id: str, project_data: Dict[str, Any]) -> None:
         url = (self._base_uri / f"api/projects/{project_id}").resolve()
         self._http_client.put_json(url, body=project_data)
 
     def project_options_get(
         self, project_id: str, workspace_id: str, custom_function: str
-    ):
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/projects/{project_id}/custom-functions/"
@@ -38,7 +38,9 @@ class ProjectService:
         ).resolve()
         return self._http_client.get_json(url)
 
-    def project_default_options_get(self, workspace_id: str, custom_function: str):
+    def project_default_options_get(
+        self, workspace_id: str, custom_function: str
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/custom-functions/{custom_function}"
@@ -46,7 +48,7 @@ class ProjectService:
         ).resolve()
         return self._http_client.get_json(url)
 
-    def project_content_delete(self, project_id: str, content_id: str):
+    def project_content_delete(self, project_id: str, content_id: str) -> None:
         url = (
             self._base_uri / f"api/projects/{project_id}/content/{content_id}"
         ).resolve()
@@ -54,7 +56,7 @@ class ProjectService:
 
     def project_content_upload(
         self, path_to_result: str, project_id: str, content_type: str
-    ):
+    ) -> Dict[str, Any]:
         url = (self._base_uri / f"/api/projects/{project_id}/content-imports").resolve()
         with open(path_to_result, "rb") as f:
             multipart_form_data = {
@@ -63,7 +65,7 @@ class ProjectService:
             }
             return self._http_client.post_json(url, files=multipart_form_data)
 
-    def project_content_get(self, project_id: str, content_id: str):
+    def project_content_get(self, project_id: str, content_id: str) -> Dict[str, Any]:
         url = (
             self._base_uri / f"/api/projects/{project_id}/content/{content_id}"
         ).resolve()
@@ -81,7 +83,7 @@ class ProjectService:
         exclude_patterns: Optional[Union[str, List[str]]] = None,
         top_level_inputs: Optional[Union[str, List[str]]] = None,
         step_size: float = 0.0,
-    ):
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/projects/{project_id}/content/"
@@ -107,7 +109,7 @@ class ProjectService:
             }
             return self._http_client.post_json(url, files=multipart_form_data)
 
-    def import_from_zip(self, path_to_project: str):
+    def import_from_zip(self, path_to_project: str) -> Dict[str, Any]:
         url = (self._base_uri / "api/project-imports").resolve()
         with open(path_to_project, "rb") as f:
             return self._http_client.post_json(url, files={"file": f})

--- a/modelon/impact/client/sal/request.py
+++ b/modelon/impact/client/sal/request.py
@@ -11,7 +11,6 @@ from modelon.impact.client.sal.response import (
     OctetStreamResponse,
     MatStreamResponse,
 )
-from modelon.impact.client.sal.context import Context
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ logger = logging.getLogger(__name__)
 class Request:
     def __init__(
         self,
-        context: Context,
+        context: Any,
         method: str,
         url: str,
         request_type: Callable,
@@ -35,7 +34,7 @@ class Request:
         self.request_type = request_type
         self.headers = headers
 
-    def execute(self, check_return: bool = True):
+    def execute(self, check_return: bool = True) -> Any:
         try:
             if self.method == "POST":
                 logger.debug("POST with JSON body: {}".format(self.body))
@@ -70,32 +69,80 @@ class Request:
 
 
 class RequestJSON(Request):
-    def __init__(self, context, method, url, body=None, files=None, headers=None):
+    def __init__(
+        self,
+        context: Any,
+        method: str,
+        url: str,
+        body: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ):
         super().__init__(context, method, url, JSONResponse, body, files, headers)
 
 
 class RequestZip(Request):
-    def __init__(self, context, method, url, body=None, files=None, headers=None):
+    def __init__(
+        self,
+        context: Any,
+        method: str,
+        url: str,
+        body: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ):
         super().__init__(context, method, url, ZIPResponse, body, files, headers)
 
 
 class RequestText(Request):
-    def __init__(self, context, method, url, body=None, files=None, headers=None):
+    def __init__(
+        self,
+        context: Any,
+        method: str,
+        url: str,
+        body: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ):
         super().__init__(context, method, url, TextResponse, body, files, headers)
 
 
 class RequestCSV(Request):
-    def __init__(self, context, method, url, body=None, files=None, headers=None):
+    def __init__(
+        self,
+        context: Any,
+        method: str,
+        url: str,
+        body: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ):
         super().__init__(context, method, url, CSVResponse, body, files, headers)
 
 
 class RequestOctetStream(Request):
-    def __init__(self, context, method, url, body=None, files=None, headers=None):
+    def __init__(
+        self,
+        context: Any,
+        method: str,
+        url: str,
+        body: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ):
         super().__init__(
             context, method, url, OctetStreamResponse, body, files, headers
         )
 
 
 class RequestMatStream(Request):
-    def __init__(self, context, method, url, body=None, files=None, headers=None):
+    def __init__(
+        self,
+        context: Any,
+        method: str,
+        url: str,
+        body: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ):
         super().__init__(context, method, url, MatStreamResponse, body, files, headers)

--- a/modelon/impact/client/sal/response.py
+++ b/modelon/impact/client/sal/response.py
@@ -1,6 +1,6 @@
 """Response class."""
 import re
-from typing import Text, Union, Dict, Any
+from typing import Text, Dict, Any
 from modelon.impact.client.sal import exceptions
 
 
@@ -11,7 +11,7 @@ class ResponseError:
 
 
 class Response:
-    def __init__(self, resp_obj):
+    def __init__(self, resp_obj: Any):
         self._resp_obj = resp_obj
 
     def _is_json(self) -> bool:
@@ -46,7 +46,7 @@ class Response:
 
 
 class JSONResponse(Response):
-    def __init__(self, resp_obj):
+    def __init__(self, resp_obj: Any):
         super().__init__(resp_obj)
 
     @property
@@ -67,7 +67,7 @@ class JSONResponse(Response):
 
 
 class TextResponse(Response):
-    def __init__(self, resp_obj):
+    def __init__(self, resp_obj: Any):
         super().__init__(resp_obj)
 
     def _is_txt(self) -> bool:
@@ -87,7 +87,7 @@ class TextResponse(Response):
 
 
 class ZIPResponse(Response):
-    def __init__(self, resp_obj):
+    def __init__(self, resp_obj: Any):
         super().__init__(resp_obj)
 
     def _is_zip(self) -> bool:
@@ -108,7 +108,7 @@ class ZIPResponse(Response):
 
 
 class FileResponse(Response):
-    def __init__(self, resp_obj, content_type: str):
+    def __init__(self, resp_obj: Any, content_type: str):
         super().__init__(resp_obj)
         self.content_type = content_type
 
@@ -116,7 +116,7 @@ class FileResponse(Response):
         return self.content_type in self._resp_obj.headers.get("content-type")
 
     @property
-    def stream(self) -> Union[Text, bytes]:
+    def stream(self) -> bytes:
         if not self._resp_obj.ok:
             raise exceptions.HTTPError(self.error.message, self._resp_obj.status_code)
 
@@ -142,15 +142,15 @@ class FileResponse(Response):
 
 
 class CSVResponse(FileResponse):
-    def __init__(self, resp_obj):
+    def __init__(self, resp_obj: Any):
         super().__init__(resp_obj, "text/csv")
 
 
 class OctetStreamResponse(FileResponse):
-    def __init__(self, resp_obj):
+    def __init__(self, resp_obj: Any):
         super().__init__(resp_obj, "application/octet-stream")
 
 
 class MatStreamResponse(FileResponse):
-    def __init__(self, resp_obj):
+    def __init__(self, resp_obj: Any):
         super().__init__(resp_obj, "application/vnd.impact.mat.v1+octet-stream")

--- a/modelon/impact/client/sal/uri.py
+++ b/modelon/impact/client/sal/uri.py
@@ -1,4 +1,6 @@
 """URI class."""
+from __future__ import annotations
+from typing import Any
 import sys
 import urllib.parse
 
@@ -11,17 +13,17 @@ class URI:
 
         self.content = content
 
-    def resolve(self, **kwargs):
+    def resolve(self, **kwargs: Any) -> str:
         return self.content.format(**kwargs)
 
-    def _with_path(self, path):
+    def _with_path(self, path: str) -> URI:
         return URI(urllib.parse.urljoin(self.content + "/", path.lstrip('/')))
 
-    def __floordiv__(self, other):
+    def __floordiv__(self, other: str) -> URI:
         return self._with_path(other)
 
-    def __truediv__(self, other):
+    def __truediv__(self, other: str) -> URI:
         return self._with_path(other)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.content

--- a/modelon/impact/client/sal/users.py
+++ b/modelon/impact/client/sal/users.py
@@ -1,4 +1,5 @@
 """Users service module."""
+from typing import Dict, Any
 from modelon.impact.client.sal.http import HTTPClient
 from modelon.impact.client.sal.uri import URI
 
@@ -8,6 +9,6 @@ class UsersService:
         self._base_uri = uri
         self._http_client = http_client
 
-    def get_me(self):
+    def get_me(self) -> Dict[str, Any]:
         url = (self._base_uri / "api/users/me").resolve()
         return self._http_client.get_json(url)

--- a/modelon/impact/client/sal/workspace.py
+++ b/modelon/impact/client/sal/workspace.py
@@ -9,19 +9,21 @@ class WorkspaceService:
         self._base_uri = uri
         self._http_client = http_client
 
-    def workspace_create(self, name: str):
+    def workspace_create(self, name: str) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspaces").resolve()
         return self._http_client.post_json(url, body={"new": {"name": name}})
 
-    def workspace_delete(self, workspace_id: str):
+    def workspace_delete(self, workspace_id: str) -> None:
         url = (self._base_uri / f"api/workspaces/{workspace_id}").resolve()
         self._http_client.delete_json(url)
 
-    def workspaces_get(self):
+    def workspaces_get(self) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspaces").resolve()
         return self._http_client.get_json(url)
 
-    def projects_get(self, workspace_id: str, vcs_info: bool, include_disabled: bool):
+    def projects_get(
+        self, workspace_id: str, vcs_info: bool, include_disabled: bool
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/projects?vcsInfo={vcs_info}"
@@ -29,13 +31,13 @@ class WorkspaceService:
         ).resolve()
         return self._http_client.get_json(url)
 
-    def project_create(self, workspace_id: str, name: str):
+    def project_create(self, workspace_id: str, name: str) -> Dict[str, Any]:
         url = (self._base_uri / f"api/workspaces/{workspace_id}/projects").resolve()
         return self._http_client.post_json(url, body={"new": {"name": name}})
 
     def dependencies_get(
         self, workspace_id: str, vcs_info: bool, include_disabled: bool
-    ):
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/dependencies?vcsInfo={vcs_info}"
@@ -43,55 +45,59 @@ class WorkspaceService:
         ).resolve()
         return self._http_client.get_json(url)
 
-    def workspace_get(self, workspace_id: str):
+    def workspace_get(self, workspace_id: str) -> Dict[str, Any]:
         url = (self._base_uri / f"api/workspaces/{workspace_id}").resolve()
         return self._http_client.get_json(url)
 
-    def workspace_export_setup(self, workspace_id: str, options: Dict[str, Any]):
+    def workspace_export_setup(
+        self, workspace_id: str, options: Dict[str, Any]
+    ) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspace-exports").resolve()
         options["workspaceId"] = workspace_id
         return self._http_client.post_json(url, body=options)
 
-    def workspace_conversion_setup(self, workspace_id: str, backup_name: Optional[str]):
+    def workspace_conversion_setup(
+        self, workspace_id: str, backup_name: Optional[str]
+    ) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspace-conversions").resolve()
         backup_data = {'backup': {'name': backup_name}} if backup_name else {}
         body: Dict[str, Any] = {'data': {'workspaceId': workspace_id, **backup_data}}
         return self._http_client.post_json(url, body=body)
 
-    def get_workspace_conversion_status(self, location: str):
+    def get_workspace_conversion_status(self, location: str) -> Dict[str, Any]:
         url = (self._base_uri / location).resolve()
         return self._http_client.get_json(url)
 
-    def workspace_clone(self, workspace_id: str):
+    def workspace_clone(self, workspace_id: str) -> Dict[str, Any]:
         url = (self._base_uri / f"api/workspaces/{workspace_id}/clone").resolve()
         return self._http_client.post_json(url)
 
-    def fmus_get(self, workspace_id: str):
+    def fmus_get(self, workspace_id: str) -> Dict[str, Any]:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/model-executables"
         ).resolve()
         return self._http_client.get_json(url)
 
-    def fmu_get(self, workspace_id: str, fmu_id: str):
+    def fmu_get(self, workspace_id: str, fmu_id: str) -> Dict[str, Any]:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}"
         ).resolve()
         return self._http_client.get_json(url)
 
-    def fmu_download(self, workspace_id: str, fmu_id: str):
+    def fmu_download(self, workspace_id: str, fmu_id: str) -> bytes:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/model-executables/{fmu_id}/binary"
         ).resolve()
         return self._http_client.get_zip(url)
 
-    def experiments_get(self, workspace_id: str):
+    def experiments_get(self, workspace_id: str) -> Dict[str, Any]:
         url = (self._base_uri / f"api/workspaces/{workspace_id}/experiments").resolve()
         return self._http_client.get_json(
             url, headers={"Accept": "application/vnd.impact.experiment.v2+json"}
         )
 
-    def experiment_get(self, workspace_id: str, experiment_id: str):
+    def experiment_get(self, workspace_id: str, experiment_id: str) -> Dict[str, Any]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}"
@@ -105,7 +111,7 @@ class WorkspaceService:
         workspace_id: str,
         definition: Dict[str, Any],
         user_data: Optional[Dict[str, Any]] = None,
-    ):
+    ) -> Dict[str, Any]:
         url = (self._base_uri / f"api/workspaces/{workspace_id}/experiments").resolve()
         body = {
             **definition,
@@ -113,14 +119,16 @@ class WorkspaceService:
         }
         return self._http_client.post_json(url, body=body)
 
-    def shared_definition_get(self, workspace_id: str, strict: bool = False):
+    def shared_definition_get(
+        self, workspace_id: str, strict: bool = False
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/"
             f"sharing-definition?strict={'true' if strict else 'false'}"
         ).resolve()
         return self._http_client.get_json(url)
 
-    def import_from_zip(self, path_to_workspace: str):
+    def import_from_zip(self, path_to_workspace: str) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspace-imports").resolve()
         with open(path_to_workspace, "rb") as f:
             return self._http_client.post_json(url, files={"file": f})
@@ -129,7 +137,7 @@ class WorkspaceService:
         self,
         shared_definition: Dict[str, Any],
         selected_matchings: Optional[List[Dict[str, Any]]] = None,
-    ):
+    ) -> Dict[str, Any]:
         if selected_matchings:
             shared_definition = {
                 **shared_definition,
@@ -138,18 +146,24 @@ class WorkspaceService:
         url = (self._base_uri / "api/workspace-imports").resolve()
         return self._http_client.post_json(url, body=shared_definition)
 
-    def get_project_matchings(self, shared_definition: Dict[str, Any]):
+    def get_project_matchings(
+        self, shared_definition: Dict[str, Any]
+    ) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspace-imports-matchings").resolve()
         return self._http_client.post_json(url, body=shared_definition)
 
-    def import_project_from_zip(self, workspace_id: str, path_to_project: str):
+    def import_project_from_zip(
+        self, workspace_id: str, path_to_project: str
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/project-imports"
         ).resolve()
         with open(path_to_project, "rb") as f:
             return self._http_client.post_json(url, files={"file": f})
 
-    def import_dependency_from_zip(self, workspace_id: str, path_to_project: str):
+    def import_dependency_from_zip(
+        self, workspace_id: str, path_to_project: str
+    ) -> Dict[str, Any]:
         url = (
             self._base_uri / f"api/workspaces/{workspace_id}/dependency-imports"
         ).resolve()

--- a/tests/impact/client/entities/test_case.py
+++ b/tests/impact/client/entities/test_case.py
@@ -47,7 +47,9 @@ class TestCase:
         result, name = case.get_result()
         assert (result, name) == (b'\x00\x00\x00\x00', IDs.RESULT_MAT)
         assert case.is_successful()
-        assert case.get_trajectories()['inertia.I'] == [14, 4, 4, 74]
+        result = case.get_trajectories()
+        assert result.keys() == ['inertia.I', 'time']
+        assert result['inertia.I'] == [14, 4, 4, 74]
 
     def test_failed_case(self, experiment_with_failed_case):
         failed_case = experiment_with_failed_case.get_case("case_2")


### PR DESCRIPTION
This PR helps resolves circular imports when specifying type hints for methods. The TYPE_CHECKING flag used is set to True by mypy  while performing type check.
Also fixed the devcontainer based on Emil's cookie cutter template to fix the python interpreter selection issues.