### PR TITLE
Docs build fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,20 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.9"
+  jobs:
+    post_create_environment:
+      # Install poetry
+      # https://python-poetry.org/docs/#installing-manually
+      - pip install poetry
+      # Tell poetry to not use a virtual environment
+      - poetry config virtualenvs.create false
+    post_install:
+      # Install dependencies with 'docs' dependency group
+      # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+      - poetry install --with docs
+
 sphinx:
   configuration: docs/source/conf.py
-
-python:
-  version: 3.7
-  install:
-    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-sphinx_copybutton
-semantic-version

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.napoleon',
     'sphinxcontrib.spelling',
+    'sphinx_search.extension',
 ]
 
 add_module_names = False
@@ -66,9 +67,9 @@ html_theme_options = {
 
 # The wordlist with known words, like Jupyterlab
 spelling_word_list_filename = "spelling_wordlist.txt"
-spelling_show_suggestions=True
-spelling_ignore_acronyms=True
-spelling_exclude_patterns=['modelon.*']
+spelling_show_suggestions = True
+spelling_ignore_acronyms = True
+spelling_exclude_patterns = ['modelon.*']
 
 # Enable google style docstrings
 napoleon_google_docstring = True
@@ -79,6 +80,6 @@ napoleon_google_docstring = True
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
 
-suppress_warnings = ['autosectionlabel.*'] # See https://github.com/sphinx-doc/sphinx/issues/7697
-
-
+suppress_warnings = [
+    'autosectionlabel.*'
+]  # See https://github.com/sphinx-doc/sphinx/issues/7697

--- a/poetry.lock
+++ b/poetry.lock
@@ -814,6 +814,18 @@ files = [
 ]
 
 [[package]]
+name = "readthedocs-sphinx-search"
+version = "0.3.1"
+description = "Sphinx extension to enable search as you type for docs hosted on Read the Docs."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "readthedocs-sphinx-search-0.3.1.tar.gz", hash = "sha256:32c1ed5b129691adfb7e40effcecf887c5ebd525a06d96b9df11afb9461c9e33"},
+    {file = "readthedocs_sphinx_search-0.3.1-py3-none-any.whl", hash = "sha256:6ee204bf66a78684f370ac8b0f47eeccffbe507586d0826958365463ab2becbf"},
+]
+
+[[package]]
 name = "requests"
 version = "2.28.2"
 description = "Python HTTP for Humans."
@@ -1390,4 +1402,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.0"
-content-hash = "589d58f2f9c4b30f816303e1781b8b03b56b97e06681b2668699791b7faa052f"
+content-hash = "f820cfff353b3f09a1c1a222f9166253458a544519c02e513cb261dcb4c42a3d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -803,14 +803,14 @@ watchdog = ">=0.6.0"
 
 [[package]]
 name = "pytz"
-version = "2023.2"
+version = "2023.3"
 description = "World timezone definitions, modern and historical"
 category = "dev"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2023.2-py2.py3-none-any.whl", hash = "sha256:8a8baaf1e237175b02f5c751eea67168043a749c843989e2b3015aa1ad9db68b"},
-    {file = "pytz-2023.2.tar.gz", hash = "sha256:a27dcf612c05d2ebde626f7d506555f10dfc815b3eddccfaadfc7d99b11c9a07"},
+    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
+    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
 ]
 
 [[package]]
@@ -873,14 +873,14 @@ doc = ["Sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "setuptools"
-version = "67.6.0"
+version = "67.6.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.6.0-py3-none-any.whl", hash = "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"},
-    {file = "setuptools-67.6.0.tar.gz", hash = "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077"},
+    {file = "setuptools-67.6.1-py3-none-any.whl", hash = "sha256:e728ca814a823bf7bf60162daf9db95b93d532948c4c0bea762ce62f60189078"},
+    {file = "setuptools-67.6.1.tar.gz", hash = "sha256:257de92a9d50a60b8e22abfcbb771571fde0dbf3ec234463212027a4eeecbe9a"},
 ]
 
 [package.extras]
@@ -1181,14 +1181,14 @@ files = [
 
 [[package]]
 name = "types-requests"
-version = "2.28.11.16"
+version = "2.28.11.17"
 description = "Typing stubs for requests"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-requests-2.28.11.16.tar.gz", hash = "sha256:9d4002056df7ebc4ec1f28fd701fba82c5c22549c4477116cb2656aa30ace6db"},
-    {file = "types_requests-2.28.11.16-py3-none-any.whl", hash = "sha256:a86921028335fdcc3aaf676c9d3463f867db6af2303fc65aa309b13ae1e6dd53"},
+    {file = "types-requests-2.28.11.17.tar.gz", hash = "sha256:0d580652ce903f643f8c3b494dd01d29367ea57cea0c7ad7f65cf3169092edb0"},
+    {file = "types_requests-2.28.11.17-py3-none-any.whl", hash = "sha256:cc1aba862575019306b2ed134eb1ea994cab1c887a22e18d3383e6dd42e9789b"},
 ]
 
 [package.dependencies]
@@ -1196,14 +1196,14 @@ types-urllib3 = "<1.27"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.25.8"
+version = "1.26.25.10"
 description = "Typing stubs for urllib3"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-urllib3-1.26.25.8.tar.gz", hash = "sha256:ecf43c42d8ee439d732a1110b4901e9017a79a38daca26f08e42c8460069392c"},
-    {file = "types_urllib3-1.26.25.8-py3-none-any.whl", hash = "sha256:95ea847fbf0bf675f50c8ae19a665baedcf07e6b4641662c4c3c72e7b2edf1a9"},
+    {file = "types-urllib3-1.26.25.10.tar.gz", hash = "sha256:c44881cde9fc8256d05ad6b21f50c4681eb20092552351570ab0a8a0653286d6"},
+    {file = "types_urllib3-1.26.25.10-py3-none-any.whl", hash = "sha256:12c744609d588340a07e45d333bf870069fc8793bcf96bae7a96d4712a42591d"},
 ]
 
 [[package]]
@@ -1390,4 +1390,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.0"
-content-hash = "89b3c04b33e4d9c24a47f1a8ba4e75a59a9a905eababb31241e3484b76a8910f"
+content-hash = "589d58f2f9c4b30f816303e1781b8b03b56b97e06681b2668699791b7faa052f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ sphinx-rtd-theme = "^1.1.1"
 sphinx-copybutton = "^0.5.1"
 sphinxcontrib-napoleon = "^0.7"
 sphinxcontrib-spelling = "^7.7.0"
+readthedocs-sphinx-search = "^0.3.1"
 
 [tool.docformatter]
 recursive = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,14 @@ pytest-watch = "^4.2.0"
 black = "^22.10.0"
 click = "^8.1.3"
 requests_mock = "^1.10"
-sphinx = "^4.0.0"
-sphinx-rtd-theme = "^1.1.1"
-sphinx-copybutton = "^0.5.1"
 pytest-cov = "^4.0.0"
 pylint = "^2.13.4"
 docformatter = {extras = ["tomli"], version = "^1.5.1"}
+
+[tool.poetry.group.docs.dependencies]
+sphinx = "^4.0.0"
+sphinx-rtd-theme = "^1.1.1"
+sphinx-copybutton = "^0.5.1"
 sphinxcontrib-napoleon = "^0.7"
 sphinxcontrib-spelling = "^7.7.0"
 


### PR DESCRIPTION
This PR fixes the build issues with RTD caused by having a different requirements file for docs. I have now standardized it to use the PyProject.toml.
Also while debugging this, I found a cool extension which allows you to search as you type (see https://readthedocs-sphinx-search.readthedocs.io/en/latest/) which I have now added to the client.
I have temporarily enabled viewing of  https://modelon-impact-client.readthedocs.io/en/docs-build-fix/ to help with this PR review. Thanks!