### PR TITLE
fix: refactored login workflow to distinguish if python client is run…

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -149,9 +149,11 @@ class Client:
         self._uri = URI(url)
         self._sal = modelon.impact.client.sal.service.Service(self._uri, context)
 
-        try:
-            self._validate_compatible_api_version()
-        except modelon.impact.client.sal.exceptions.AccessingJupyterHubError:
+        if self._sal.is_jupyterhub_url():
+            logger.info(
+                "API response indicates that the URL '%s' hosts a JupyterHub.",
+                str(self._uri),
+            )
             self._uri, jupyter_context = modelon.impact.client.jupyterhub.authorize(
                 self._uri,
                 interactive,
@@ -161,7 +163,8 @@ class Client:
             self._sal = modelon.impact.client.sal.service.Service(
                 self._uri, jupyter_context
             )
-            self._validate_compatible_api_version()
+
+        self._validate_compatible_api_version()
 
         if credential_manager is None:
             help_hint = f"can be generated at {self._uri / 'admin/keys'}"

--- a/modelon/impact/client/jupyterhub/sal.py
+++ b/modelon/impact/client/jupyterhub/sal.py
@@ -29,7 +29,7 @@ class JupyterContext:
 
 
 class JupyterUser:
-    def __init__(self, user_id: str, server: str):
+    def __init__(self, user_id: str, server: Optional[str]):
         self.id = user_id
         self._server = server
 
@@ -42,7 +42,9 @@ class JupyterUser:
 
 class JupyterHubService:
     @classmethod
-    def get_user_data(cls, uri: URI, context: JupyterContext) -> JupyterUser:
+    def get_user_data(
+        cls, uri: URI, context: JupyterContext, server: Optional[str] = None
+    ) -> JupyterUser:
         auth_token_url = (
             uri / f'hub/api/authorizations/token/{context.token}'
         ).resolve()
@@ -73,7 +75,7 @@ class JupyterHubService:
 
         try:
             user_data = user_response.json()
-            return JupyterUser(user_data['name'], user_data['server'])
+            return JupyterUser(user_data['name'], user_data.get('server', server))
         except (KeyError, json.decoder.JSONDecodeError) as e:
             raise exceptions.NotAJupyterHubUrl(
                 "User response data is not correct, "

--- a/modelon/impact/client/sal/exceptions.py
+++ b/modelon/impact/client/sal/exceptions.py
@@ -37,7 +37,3 @@ class ErrorJSONInvalidFormatError(ServiceAccessError):
 
 class NoResponseFetchVersionError(ServiceAccessError):
     pass
-
-
-class AccessingJupyterHubError(ServiceAccessError):
-    pass

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -82,14 +82,22 @@ class Service:
             self.external_result, retry_with_login_decorator
         )
 
+    def is_jupyterhub_url(self) -> bool:
+        url = (self._base_uri / "hub/api/").resolve()
+
+        try:
+            response = self._http_client.get_json_response(url)
+        except (
+            exceptions.CommunicationError,
+            exceptions.SSLError,
+            exceptions.HTTPError,
+        ):
+            return False
+        return self._JUPYTERHUB_VERSION_HEADER in response.headers
+
     def api_get_metadata(self) -> Dict[str, Any]:
         url = (self._base_uri / "api/").resolve()
         response = self._http_client.get_json_response(url)
-        if self._JUPYTERHUB_VERSION_HEADER in response.headers:
-            raise exceptions.AccessingJupyterHubError(
-                f"API response indicates that the URL '{self._base_uri}' "
-                "hosts a JupyterHub."
-            )
 
         return response.data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,5 +35,12 @@ def mock_server_base():
     mock_url = 'http://mock-impact.com'
 
     mock_server_base = MockedServer(mock_url, MockContex(session), adapter)
-
-    return with_json_route(mock_server_base, 'POST', 'api/login', {})
+    mock_server = with_json_route(mock_server_base, 'POST', 'api/login', {})
+    mock_server = with_json_route(
+        mock_server,
+        'GET',
+        'hub/api/',
+        {},
+        extra_headers={},
+    )
+    return mock_server

--- a/tests/impact/client/fixtures/fixtures.py
+++ b/tests/impact/client/fixtures/fixtures.py
@@ -104,7 +104,7 @@ def jupyterhub_api(mock_server_base):
     mock_server = with_json_route(
         mock_server_base,
         'GET',
-        'api/',
+        'hub/api/',
         jupyter_api_json,
         extra_headers={'x-jupyterhub-version': '1.3.0'},
     )

--- a/tests/impact/client/test_client.py
+++ b/tests/impact/client/test_client.py
@@ -60,7 +60,7 @@ def test_semantic_version_error(semantic_version_error):
 
 
 def assert_login_called(*, adapter, body):
-    login_call = adapter.request_history[1]
+    login_call = adapter.request_history[2]
     assert 'http://mock-impact.com/api/login' == login_call.url
     assert 'POST' == login_call.method
     assert body == login_call.json()


### PR DESCRIPTION
As discussed in chat, I have now simplified the workflows to distinguish user using the python client inside vs outside the JH environment. Also made sure server key is always present -  For with JH we rely on env variable JUPYTERHUB_SERVICE_PREFIX else we rely on the response.  