### PR TITLE
fix: default to https://impact.modelon.cloud/ if no url is provided by user or no environmental variable is set

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -96,7 +96,7 @@ class Client:
         url:
             The URL for Modelon Impact client host. Defaults to the value specified
             by env variable 'MODELON_IMPACT_CLIENT_URL' if set else uses the URL
-            'http://localhost:8080/'.
+            'https://impact.modelon.cloud/'.
         interactive:
             If True the client will prompt for an API key if no other login information
             can be found. An API key entered for this prompt will be saved to disk

--- a/modelon/impact/client/configuration.py
+++ b/modelon/impact/client/configuration.py
@@ -14,7 +14,7 @@ def get_client_url() -> str:
     """
     url = os.environ.get("MODELON_IMPACT_CLIENT_URL")
     if url is None:
-        url = "http://localhost:8080/"
+        url = "https://impact.modelon.cloud/"
         logger.warning("No URL for client was specified, will use: {}".format(url))
     return url
 

--- a/tests/impact/client/test_configuration.py
+++ b/tests/impact/client/test_configuration.py
@@ -2,7 +2,7 @@ import modelon.impact.client.configuration as configuration
 
 
 def test_get_client_url_default():
-    assert "http://localhost:8080/" == configuration.get_client_url()
+    assert "https://impact.modelon.cloud/" == configuration.get_client_url()
 
 
 def test_get_client_url_env(monkeypatch):


### PR DESCRIPTION
This PR changes the default url to https://impact.modelon.cloud/ if no url is provided by user or no environmental variable is set