### PR TITLE
Upload import

### DIFF
--- a/modelon/impact/client/entities/project.py
+++ b/modelon/impact/client/entities/project.py
@@ -365,7 +365,7 @@ class Project:
             resp['data']['location'], self._sal, ProjectContent.from_operation
         )
 
-    def upload_modelica_library(self, path_to_lib: str) -> ContentImportOperation:
+    def import_modelica_library(self, path_to_lib: str) -> ContentImportOperation:
         """Uploads/adds a non-encrypted Modelica library or a Modelica model to
         the project.
 
@@ -376,8 +376,8 @@ class Project:
 
         Example::
 
-            project.upload_model_library('C:/A.mo')
-            project.upload_model_library('C:/B.zip')
+            project.import_modelica_library('C:/A.mo')
+            project.import_modelica_library('C:/B.zip')
 
         """
         if Path(path_to_lib).suffix.lower() not in ['.mo', '.zip']:

--- a/modelon/impact/client/entities/project.py
+++ b/modelon/impact/client/entities/project.py
@@ -340,7 +340,7 @@ class Project:
         """
         return self.get_content_by_name(name, ContentType.MODELICA)
 
-    def upload_content(
+    def import_content(
         self, path_to_content: str, content_type: ContentType
     ) -> ContentImportOperation:
         """Upload content to a project.
@@ -355,7 +355,7 @@ class Project:
 
             from modelon.impact.client import ContentType
 
-            project.upload_content('/home/test.mo', ContentType.MODELICA).wait()
+            project.import_content('/home/test.mo', ContentType.MODELICA).wait()
 
         """
         resp = self._sal.project.project_content_upload(
@@ -385,7 +385,7 @@ class Project:
                 "Only '.mo' or '.zip' file extension are supported for uploading "
                 "Modelica content into project."
             )
-        return self.upload_content(path_to_lib, ContentType.MODELICA)
+        return self.import_content(path_to_lib, ContentType.MODELICA)
 
     def get_options(
         self, custom_function: CustomFunction, use_defaults: Optional[bool] = False

--- a/modelon/impact/client/operations/content_import.py
+++ b/modelon/impact/client/operations/content_import.py
@@ -72,7 +72,7 @@ class ContentImportOperation(AsyncOperation[Entity]):
 
         Example::
 
-            project.upload_content('path/to/model.mo').status()
+            project.import_content('path/to/model.mo').status()
 
         """
         return AsyncOperationStatus(self._info()["status"])

--- a/tests/impact/client/entities/test_project.py
+++ b/tests/impact/client/entities/test_project.py
@@ -105,8 +105,8 @@ class TestProject:
         assert content.name == 'test'
         assert not content.default_disabled
 
-    def test_upload_modelica_library(self, project):
-        content_operation = project.entity.upload_modelica_library(
+    def test_import_modelica_library(self, project):
+        content_operation = project.entity.import_modelica_library(
             SINGLE_FILE_LIBRARY_PATH
         )
         assert content_operation.status() == AsyncOperationStatus.READY

--- a/tests/impact/client/entities/test_project.py
+++ b/tests/impact/client/entities/test_project.py
@@ -92,8 +92,8 @@ class TestProject:
         project.delete()
         service.project.project_delete.assert_called_with(IDs.PROJECT_PRIMARY)
 
-    def test_upload_project_content(self, project):
-        content_operation = project.entity.upload_content(
+    def test_import_content(self, project):
+        content_operation = project.entity.import_content(
             SINGLE_FILE_LIBRARY_PATH, content_type=ContentType.MODELICA
         )
         assert content_operation.status() == AsyncOperationStatus.READY


### PR DESCRIPTION
Renamed newly added methods to use "import_" instead of "upload_". NOTE:- I have not updated the old ones using 'upload' terminology to not do any breaking change.