### PR TITLE
feat: added support to fetch only last point for a result trajectory

### DIFF
--- a/modelon/impact/client/entities/result.py
+++ b/modelon/impact/client/entities/result.py
@@ -14,8 +14,11 @@ def _create_result_dict(
     exp_id: str,
     case_id: str,
     exp_sal: ExperimentService,
+    last_point_only: bool,
 ) -> Dict[str, Any]:
-    response = exp_sal.trajectories_get(workspace_id, exp_id, variables)
+    response = exp_sal.trajectories_get(
+        workspace_id, exp_id, variables, last_point_only
+    )
     case_index = int(case_id.split("_")[1])
     data = {
         variable: response[i][case_index - 1] for i, variable in enumerate(variables)
@@ -42,8 +45,9 @@ class Result(Mapping):
 
     def __getitem__(self, key: str) -> Any:
         assert_variable_in_result([key], self._variables)
+        # TODO: Implement support for last point only
         response = self._sal.experiment.case_trajectories_get(
-            self._workspace_id, self._exp_id, self._case_id, [key]
+            self._workspace_id, self._exp_id, self._case_id, [key], False
         )
         return response[0]
 
@@ -54,6 +58,7 @@ class Result(Mapping):
             self._exp_id,
             self._case_id,
             self._sal.experiment,
+            False,
         )
         return data.__iter__()
 

--- a/modelon/impact/client/sal/experiment.py
+++ b/modelon/impact/client/sal/experiment.py
@@ -73,14 +73,23 @@ class ExperimentService:
         return self._http_client.get_json(url)
 
     def trajectories_get(
-        self, workspace_id: str, experiment_id: str, variables: List[str]
-    ) -> List[str]:
-        body = {"variable_names": variables}
+        self,
+        workspace_id: str,
+        experiment_id: str,
+        variables: List[str],
+        last_point_only: bool,
+        format: Optional[str] = None,
+    ) -> Any:
+        body = {
+            "variable_names": variables,
+            "filter": {"lastPointOnly": last_point_only},
+        }
+        headers = {"Accept": format or "application/vnd.impact.trajectories.v1+json"}
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/trajectories"
         ).resolve()
-        return self._http_client.post_json(url, body=body)
+        return self._http_client.post_json(url, body=body, headers=headers)
 
     def cases_get(self, workspace_id: str, experiment_id: str) -> Dict[str, Any]:
         url = (
@@ -142,9 +151,17 @@ class ExperimentService:
         return mat_resp.stream, mat_resp.file_name
 
     def case_trajectories_get(
-        self, workspace_id: str, experiment_id: str, case_id: str, variables: List[str]
+        self,
+        workspace_id: str,
+        experiment_id: str,
+        case_id: str,
+        variables: List[str],
+        last_point_only: bool,
     ) -> List[str]:
-        body = {"variable_names": variables}
+        body = {
+            "variable_names": variables,
+            "filter": {"lastPointOnly": last_point_only},
+        }
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"

--- a/modelon/impact/client/sal/http.py
+++ b/modelon/impact/client/sal/http.py
@@ -65,8 +65,9 @@ class HTTPClient:
         url: str,
         body: Optional[Dict[str, Any]] = None,
         files: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        request = RequestJSON(self._context, "POST", url, body, files)
+        request = RequestJSON(self._context, "POST", url, body, files, headers=headers)
         return request.execute().data
 
     def post_json_no_response_body(

--- a/modelon/impact/client/sal/request.py
+++ b/modelon/impact/client/sal/request.py
@@ -40,7 +40,7 @@ class Request:
             if self.method == "POST":
                 logger.debug("POST with JSON body: {}".format(self.body))
                 resp = self.context.session.post(
-                    self.url, json=self.body, files=self.files
+                    self.url, json=self.body, files=self.files, headers=self.headers
                 )
             elif self.method == "GET":
                 resp = self.context.session.get(self.url, headers=self.headers)

--- a/tests/impact/client/entities/test_experiment.py
+++ b/tests/impact/client/entities/test_experiment.py
@@ -2,7 +2,10 @@ import pytest
 import unittest.mock as mock
 from modelon.impact.client import exceptions
 
-from modelon.impact.client.entities.experiment import ExperimentStatus
+from modelon.impact.client.entities.experiment import (
+    ExperimentStatus,
+    ExperimentResultPoint,
+)
 from tests.impact.client.helpers import (
     create_case_entity,
     create_experiment_operation,
@@ -64,6 +67,24 @@ class TestExperiment:
             [mock.call(IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY, ["case_3"])]
         )
         exp_sal.case_put.assert_not_called()
+
+    def test_experiment_get_last_time_point(self, experiment_last_time_point):
+        experiment = experiment_last_time_point.entity
+        exp = experiment.get_last_point(['inertia.I', 'time'])
+        assert isinstance(exp, ExperimentResultPoint)
+        assert exp.cases == ['case_1', 'case_2', 'case_3']
+        assert exp.variables == ['inertia.I', 'time']
+        assert exp.as_lists() == [[1.0, 1.0], [1.0, 2.0], [1.0, None]]
+
+    def test_experiment_get_last_time_point_all_variables(
+        self, experiment_last_time_point
+    ):
+        experiment = experiment_last_time_point.entity
+        exp = experiment.get_last_point()
+        assert isinstance(exp, ExperimentResultPoint)
+        assert exp.cases == ['case_1', 'case_2', 'case_3']
+        assert exp.variables == ['inertia.I', 'time']
+        assert exp.as_lists() == [[1.0, 1.0], [1.0, 2.0], [1.0, None]]
 
     def test_execute_successful(self, experiment):
         experiment = experiment.entity

--- a/tests/impact/client/helpers.py
+++ b/tests/impact/client/helpers.py
@@ -87,6 +87,7 @@ def with_text_route(mock_server_base, method, url, text_response, status_code=20
     )
     return mock_server_base
 
+
 def with_xml_route(mock_server_base, method, url, xml_response, status_code=200):
     xml = xml_response
     xml_header = {'content-type': 'application/xml'}
@@ -98,6 +99,7 @@ def with_xml_route(mock_server_base, method, url, xml_response, status_code=200)
         status_code=status_code,
     )
     return mock_server_base
+
 
 def with_csv_route(
     mock_server_base, method, url, text_response, status_code=200, content_header=None
@@ -255,6 +257,35 @@ MODEL_DESCRIPTION_XML = """<?xml version="1.0" encoding="UTF-8"?>
 	</ModelVariables>
 </fmiModelDescription>
 """
+
+LAST_POINT_TRAJECTORY = {
+    "data": {
+        "items": [
+            {
+                "caseId": "case_1",
+                "items": [
+                    {"fixed": True, "trajectory": [1.0]},
+                    {"fixed": False, "trajectory": [1.0]},
+                ],
+            },
+            {
+                "caseId": "case_2",
+                "items": [
+                    {"fixed": True, "trajectory": [1.0]},
+                    {"fixed": False, "trajectory": [2.0]},
+                ],
+            },
+            {
+                "caseId": "case_3",
+                "items": [
+                    {"fixed": True, "trajectory": [1.0]},
+                    None,
+                ],
+            },
+        ]
+    }
+}
+
 
 def get_test_get_fmu():
     return {

--- a/tests/impact/client/sal/test_experiment_service.py
+++ b/tests/impact/client/sal/test_experiment_service.py
@@ -1,7 +1,7 @@
 from modelon.impact.client.sal.uri import URI
 import modelon.impact.client.sal.service
 from modelon.impact.client.sal.experiment import ResultFormat
-from tests.impact.client.helpers import IDs
+from tests.impact.client.helpers import IDs, LAST_POINT_TRAJECTORY
 
 
 class TestExperimentService:
@@ -90,9 +90,26 @@ class TestExperimentService:
             uri=uri, context=get_trajectories.context
         )
         data = service.experiment.trajectories_get(
-            IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY, ["variable1", "variable2"]
+            IDs.WORKSPACE_PRIMARY,
+            IDs.EXPERIMENT_PRIMARY,
+            ["variable1", "variable2"],
+            False,
         )
         assert data == [[[1.0, 1.0], [3.0, 3.0], [5.0, 5.0]]]
+
+    def test_get_last_time_point(self, get_last_point):
+        uri = URI(get_last_point.url)
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri, context=get_last_point.context
+        )
+        data = service.experiment.trajectories_get(
+            IDs.WORKSPACE_PRIMARY,
+            IDs.EXPERIMENT_PRIMARY,
+            ["variable1", "variable2"],
+            True,
+            "application/vnd.impact.trajectories.v2+json",
+        )
+        assert data == LAST_POINT_TRAJECTORY
 
     def test_get_cases(self, get_cases):
         uri = URI(get_cases.url)
@@ -202,5 +219,6 @@ class TestExperimentService:
             IDs.EXPERIMENT_PRIMARY,
             IDs.CASE_PRIMARY,
             ["variable1", "variable2"],
+            False,
         )
         assert data == [[1.0, 2.0, 7.0], [2.0, 3.0, 5.0]]


### PR DESCRIPTION
Jira - https://modelonproducts.atlassian.net/browse/FLOW-36

How to test 
```
from modelon.impact.client import Client, Range
import pandas as pd

client = Client(
    url="https://jhmi-staging.modelon.com/user/abhilash.kumar@modelon.com/impact",
    interactive=True,
)
ws = client.get_workspace("tpl")
model = ws.get_model('Unnamed.Structural')
cf = ws.get_custom_function('dynamic')
exp_def = model.new_experiment_definition(cf).with_modifiers({'b': Range(1, 5, 5)})
exp = ws.execute(exp_def).wait()
traj = exp.get_last_time_point(["a", "b", "c"])
print(traj.as_lists())
# Outputs
# [[1.0, 1.0, 1.0], [1.0, 2.0, 2.0], [1.0, 3.0, 3.0], [1.0, 4.0, None], [1.0, 5.0, None]]
print(traj.cases)
# Outputs
# ['case_1', 'case_2', 'case_3', 'case_4', 'case_5']
print(traj.variables)
# Outputs
# ['a', 'b', 'c']
df = pd.DataFrame(data=traj.as_lists(), columns=traj.variables, index=traj.cases)
df.index.name = "Cases"
print(df)
# Outputs
#           a    b    c
# Cases
# case_1  1.0  1.0  1.0
# case_2  1.0  2.0  2.0
# case_3  1.0  3.0  3.0
# case_4  1.0  4.0  NaN
# case_5  1.0  5.0  NaN

```