### PR TITLE
fix: the Status method in Operations class is now a property

### DIFF
--- a/modelon/impact/client/entities/case.py
+++ b/modelon/impact/client/entities/case.py
@@ -631,7 +631,7 @@ class Case(CaseInterface):
             case.sync()
             case_ops = case.execute()
             case_ops.cancel()
-            case_ops.status()
+            case_ops.status
             case_ops.wait()
 
         """

--- a/modelon/impact/client/entities/experiment.py
+++ b/modelon/impact/client/entities/experiment.py
@@ -212,7 +212,7 @@ class Experiment(ExperimentInterface):
             experiment = workspace.create_experiment(experiment_definition)
             experiment_ops = experiment.execute()
             experiment_ops.cancel()
-            experiment_ops.status()
+            experiment_ops.status
             experiment_ops.wait()
 
             generate_cases = experiment.execute(with_cases=[]).wait()

--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -133,7 +133,7 @@ class Model(ModelInterface):
 
             compile_ops=model.compile(compiler_options)
             compile_ops.cancel()
-            compile_ops.status()
+            compile_ops.status
             compiler_options=custom_function.get_compiler_options().with_values(c_compiler='gcc')
             runtime_options={'cs_solver':0}
             model.compile(compiler_options, runtime_options).wait()

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -467,7 +467,7 @@ class Workspace(WorkspaceInterface):
 
             experiment_ops = workspace.execute(definition)
             experiment_ops.cancel()
-            experiment_ops.status()
+            experiment_ops.status
             experiment_ops.wait()
 
         """

--- a/modelon/impact/client/operations/base.py
+++ b/modelon/impact/client/operations/base.py
@@ -50,6 +50,7 @@ class BaseOperation(Generic[Entity]):
         """Returns the Entity class."""
         pass
 
+    @property
     @abstractmethod
     def status(self) -> Any:
         """Returns the operation status as an enumeration."""
@@ -98,16 +99,16 @@ class AsyncOperation(BaseOperation[Entity]):
         """
         start_t = time.time()
         while True:
-            logger.info(f"{self.name} in progress! Status : {self.status().name}")
-            if self.status().done():
-                logger.info(f"{self.name} completed! Status : {self.status().name}")
+            logger.info(f"{self.name} in progress! Status : {self.status.name}")
+            if self.status.done():
+                logger.info(f"{self.name} completed! Status : {self.status.name}")
                 return self.data()
 
             current_t = time.time()
             if timeout and current_t - start_t > timeout:
                 raise exceptions.OperationTimeOutError(
                     f"Time exceeded the set timeout - {timeout}s! "
-                    f"Present status of operation is {self.status().name}!"
+                    f"Present status of operation is {self.status.name}!"
                 )
 
             time.sleep(0.5)
@@ -132,7 +133,7 @@ class ExecutionOperation(BaseOperation[Entity]):
            workspace.execute(definition).is_complete()
 
         """
-        return self.status() == Status.DONE
+        return self.status == Status.DONE
 
     def wait(
         self, timeout: Optional[float] = None, status: Status = Status.DONE
@@ -167,16 +168,16 @@ class ExecutionOperation(BaseOperation[Entity]):
         """
         start_t = time.time()
         while True:
-            logger.info(f"{self.name} in progress! Status : {self.status().name}")
-            if self.status() == status:
-                logger.info(f"{self.name} completed! Status : {self.status().name}")
+            logger.info(f"{self.name} in progress! Status : {self.status.name}")
+            if self.status == status:
+                logger.info(f"{self.name} completed! Status : {self.status.name}")
                 return self.data()
 
             current_t = time.time()
             if timeout and current_t - start_t > timeout:
                 raise exceptions.OperationTimeOutError(
                     f"Time exceeded the set timeout - {timeout}s! "
-                    f"Present status of operation is {self.status().name}!"
+                    f"Present status of operation is {self.status.name}!"
                 )
 
             time.sleep(0.5)

--- a/modelon/impact/client/operations/case.py
+++ b/modelon/impact/client/operations/case.py
@@ -60,6 +60,7 @@ class CaseOperation(ExecutionOperation[Entity]):
             info=case_data,
         )
 
+    @property
     def status(self) -> Status:
         """Returns the execution status as an enumeration.
 
@@ -70,7 +71,7 @@ class CaseOperation(ExecutionOperation[Entity]):
 
         Example::
 
-            case.execute().status()
+            case.execute().status
 
         """
         return Status(

--- a/modelon/impact/client/operations/content_import.py
+++ b/modelon/impact/client/operations/content_import.py
@@ -62,6 +62,7 @@ class ContentImportOperation(AsyncOperation[Entity]):
         resp = self._sal.project.project_content_get(project_id, content_id)
         return self._create_entity(self, content=resp, project_id=project_id)
 
+    @property
     def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
@@ -72,7 +73,7 @@ class ContentImportOperation(AsyncOperation[Entity]):
 
         Example::
 
-            project.import_content('path/to/model.mo').status()
+            project.import_content('path/to/model.mo').status
 
         """
         return AsyncOperationStatus(self._info()["status"])

--- a/modelon/impact/client/operations/experiment.py
+++ b/modelon/impact/client/operations/experiment.py
@@ -50,6 +50,7 @@ class ExperimentOperation(ExecutionOperation[Entity]):
             self, workspace_id=self._workspace_id, exp_id=self._exp_id
         )
 
+    @property
     def status(self) -> Status:
         """Returns the execution status as an enumeration.
 
@@ -60,7 +61,7 @@ class ExperimentOperation(ExecutionOperation[Entity]):
 
         Example::
 
-            workspace.execute(definition).status()
+            workspace.execute(definition).status
 
         """
         return Status(

--- a/modelon/impact/client/operations/external_result_import.py
+++ b/modelon/impact/client/operations/external_result_import.py
@@ -61,6 +61,7 @@ class ExternalResultImportOperation(AsyncOperation[Entity]):
         resp = self._sal.external_result.get_uploaded_result(self.id)
         return self._create_entity(self, result_id=resp['data']['id'])
 
+    @property
     def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
@@ -71,7 +72,7 @@ class ExternalResultImportOperation(AsyncOperation[Entity]):
 
         Example::
 
-            workspace.upload_result('A.mat').status()
+            workspace.upload_result('A.mat').status
 
         """
         return AsyncOperationStatus(self._info()["status"])

--- a/modelon/impact/client/operations/fmu_import.py
+++ b/modelon/impact/client/operations/fmu_import.py
@@ -76,6 +76,7 @@ class FMUImportOperation(AsyncOperation[Entity]):
             project_id=self._project_id,
         )
 
+    @property
     def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
@@ -86,7 +87,7 @@ class FMUImportOperation(AsyncOperation[Entity]):
 
         Example::
 
-            model.import_fmu('test.fmu').status()
+            model.import_fmu('test.fmu').status
 
         """
         return AsyncOperationStatus(self._info()["status"])

--- a/modelon/impact/client/operations/model_executable.py
+++ b/modelon/impact/client/operations/model_executable.py
@@ -66,6 +66,7 @@ class CachedModelExecutableOperation(ExecutionOperation[Entity]):
             modifiers=self._modifiers,
         )
 
+    @property
     def status(self) -> Status:
         """Returns the compilation status as an enumeration.
 
@@ -76,7 +77,7 @@ class CachedModelExecutableOperation(ExecutionOperation[Entity]):
 
         Example::
 
-            model.compile(options).status()
+            model.compile(options).status
 
         """
         return Status.DONE
@@ -116,9 +117,9 @@ class CachedModelExecutableOperation(ExecutionOperation[Entity]):
 
         """
 
-        if self.status() != status:
+        if self.status != status:
             raise exceptions.OperationTimeOutError(
-                f"The operation '{self.name}' has the status '{self.status().name}'"
+                f"The operation '{self.name}' has the status '{self.status.name}'"
                 f", it will never get the status '{status.name}'!"
             )
 
@@ -169,6 +170,7 @@ class ModelExecutableOperation(ExecutionOperation[Entity]):
             self, workspace_id=self._workspace_id, fmu_id=self._fmu_id
         )
 
+    @property
     def status(self) -> Status:
         """Returns the compilation status as an enumeration.
 
@@ -179,7 +181,7 @@ class ModelExecutableOperation(ExecutionOperation[Entity]):
 
         Example::
 
-            model.compile(options).status()
+            model.compile(options).status
 
         """
         return Status(

--- a/modelon/impact/client/operations/project_import.py
+++ b/modelon/impact/client/operations/project_import.py
@@ -65,6 +65,7 @@ class ProjectImportOperation(AsyncOperation[Entity]):
             project_type=resp["projectType"],
         )
 
+    @property
     def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
@@ -75,8 +76,8 @@ class ProjectImportOperation(AsyncOperation[Entity]):
 
         Example::
 
-            status = client.import_project_from_zip(path_to_project).status()
-            status = workspace.import_project_from_zip(path_to_project).status()
+            status = client.import_project_from_zip(path_to_project).status
+            status = workspace.import_project_from_zip(path_to_project).status
 
         """
         return AsyncOperationStatus(self._info()["status"])

--- a/modelon/impact/client/operations/workspace/conversion.py
+++ b/modelon/impact/client/operations/workspace/conversion.py
@@ -67,6 +67,7 @@ class WorkspaceConversionOperation(AsyncOperation[Entity]):
             self, workspace_id=resp["id"], workspace_definition=resp["definition"]
         )
 
+    @property
     def status(self) -> AsyncOperationStatus:
         """Returns the conversion status as an enumeration.
 
@@ -77,7 +78,7 @@ class WorkspaceConversionOperation(AsyncOperation[Entity]):
 
         Example::
 
-            client.convert_workspace(workspace_id).status()
+            client.convert_workspace(workspace_id).status
 
         """
         return AsyncOperationStatus(self._info()["status"])

--- a/modelon/impact/client/operations/workspace/exports.py
+++ b/modelon/impact/client/operations/workspace/exports.py
@@ -94,6 +94,7 @@ class WorkspaceExportOperation(AsyncOperation[Entity]):
             )
         return self._create_entity(self, download_uri=info["data"]["downloadUri"])
 
+    @property
     def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
@@ -104,7 +105,7 @@ class WorkspaceExportOperation(AsyncOperation[Entity]):
 
         Example::
 
-            workspace.download().status()
+            workspace.download().status
 
         """
         return AsyncOperationStatus(self._info()["status"])

--- a/modelon/impact/client/operations/workspace/imports.py
+++ b/modelon/impact/client/operations/workspace/imports.py
@@ -64,6 +64,7 @@ class WorkspaceImportOperation(AsyncOperation[Entity]):
             self, workspace_id=resp["id"], workspace_definition=resp["definition"]
         )
 
+    @property
     def status(self) -> AsyncOperationStatus:
         """Returns the upload status as an enumeration.
 
@@ -74,7 +75,7 @@ class WorkspaceImportOperation(AsyncOperation[Entity]):
 
         Example::
 
-            client.import_workspace_from_shared_definition(definition, False).status()
+            client.import_workspace_from_shared_definition(definition, False).status
 
         """
         return AsyncOperationStatus(self._info()["status"])

--- a/tests/impact/client/entities/test_project.py
+++ b/tests/impact/client/entities/test_project.py
@@ -96,7 +96,7 @@ class TestProject:
         content_operation = project.entity.import_content(
             SINGLE_FILE_LIBRARY_PATH, content_type=ContentType.MODELICA
         )
-        assert content_operation.status() == AsyncOperationStatus.READY
+        assert content_operation.status == AsyncOperationStatus.READY
         content = content_operation.data()
 
         assert content.id == IDs.PROJECT_CONTENT_SECONDARY
@@ -109,7 +109,7 @@ class TestProject:
         content_operation = project.entity.import_modelica_library(
             SINGLE_FILE_LIBRARY_PATH
         )
-        assert content_operation.status() == AsyncOperationStatus.READY
+        assert content_operation.status == AsyncOperationStatus.READY
 
         content = content_operation.data()
         assert content.id == IDs.PROJECT_CONTENT_SECONDARY

--- a/tests/impact/client/operations/imports/test_external_result.py
+++ b/tests/impact/client/operations/imports/test_external_result.py
@@ -50,8 +50,8 @@ class TestExternalResultImportOperation:
         # Then
         assert isinstance(upload_op, ExternalResultImportOperation)
         assert upload_op.id == IDs.IMPORT
-        assert upload_op.status() == AsyncOperationStatus.READY
-        assert upload_op.status().done()
+        assert upload_op.status == AsyncOperationStatus.READY
+        assert upload_op.status.done()
         assert result == create_external_result_entity(IDs.EXTERNAL_RESULT)
         meta = result.metadata
         assert meta.id == IDs.EXTERNAL_RESULT

--- a/tests/impact/client/operations/test_case.py
+++ b/tests/impact/client/operations/test_case.py
@@ -9,7 +9,7 @@ class TestCaseOperation:
         case = experiment.entity.get_case(IDs.CASE_PRIMARY)
         case_ops = case.execute()
         assert case_ops.id == IDs.CASE_PRIMARY
-        assert case_ops.status() == Status.DONE
+        assert case_ops.status == Status.DONE
         assert case_ops.is_complete()
         assert case_ops.wait() == create_case_entity(
             IDs.CASE_PRIMARY, IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY
@@ -19,7 +19,7 @@ class TestCaseOperation:
         case = experiment.entity.get_case(IDs.CASE_PRIMARY)
         case_ops = case.execute()
         assert case_ops.id == IDs.CASE_PRIMARY
-        assert case_ops.status() == Status.DONE
+        assert case_ops.status == Status.DONE
         assert case_ops.is_complete()
         pytest.raises(
             exceptions.OperationTimeOutError, case_ops.wait, 1e-10, Status.CANCELLED
@@ -29,7 +29,7 @@ class TestCaseOperation:
         case = experiment_running.get_case(IDs.CASE_PRIMARY)
         case_ops = case.execute()
         assert case_ops.id == IDs.CASE_PRIMARY
-        assert case_ops.status() == Status.RUNNING
+        assert case_ops.status == Status.RUNNING
         assert not case_ops.is_complete()
         assert case_ops.wait(status=Status.RUNNING) == create_case_entity(
             IDs.CASE_PRIMARY,
@@ -41,7 +41,7 @@ class TestCaseOperation:
         case = experiment_cancelled.get_case(IDs.CASE_PRIMARY)
         case = case.execute()
         assert case.id == IDs.CASE_PRIMARY
-        assert case.status() == Status.CANCELLED
+        assert case.status == Status.CANCELLED
         assert case.wait(status=Status.CANCELLED) == create_case_entity(
             IDs.CASE_PRIMARY,
             IDs.WORKSPACE_PRIMARY,
@@ -52,5 +52,5 @@ class TestCaseOperation:
         case = experiment_cancelled.get_case(IDs.CASE_PRIMARY)
         case = case.execute()
         assert case.id == IDs.CASE_PRIMARY
-        assert case.status() == Status.CANCELLED
+        assert case.status == Status.CANCELLED
         pytest.raises(exceptions.OperationTimeOutError, case.wait, 1e-10, Status.DONE)

--- a/tests/impact/client/operations/test_experiment.py
+++ b/tests/impact/client/operations/test_experiment.py
@@ -8,7 +8,7 @@ class TestExperimentOperation:
     def test_execute_wait_done(self, workspace):
         exp = workspace.entity.execute({})
         assert exp.id == IDs.EXPERIMENT_PRIMARY
-        assert exp.status() == Status.DONE
+        assert exp.status == Status.DONE
         assert exp.is_complete()
         assert exp.wait() == create_experiment_entity(
             IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY
@@ -17,7 +17,7 @@ class TestExperimentOperation:
     def test_execute_wait_cancel_timeout(self, workspace):
         exp = workspace.entity.execute({})
         assert exp.id == IDs.EXPERIMENT_PRIMARY
-        assert exp.status() == Status.DONE
+        assert exp.status == Status.DONE
         assert exp.is_complete()
         pytest.raises(
             exceptions.OperationTimeOutError, exp.wait, 1e-10, Status.CANCELLED
@@ -26,7 +26,7 @@ class TestExperimentOperation:
     def test_execute_wait_running(self, workspace_execute_running):
         exp = workspace_execute_running.execute({})
         assert exp.id == IDs.EXPERIMENT_PRIMARY
-        assert exp.status() == Status.RUNNING
+        assert exp.status == Status.RUNNING
         assert not exp.is_complete()
         assert exp.wait(status=Status.RUNNING) == create_experiment_entity(
             IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY
@@ -35,7 +35,7 @@ class TestExperimentOperation:
     def test_execute_wait_cancelled(self, workspace_execute_cancelled):
         exp = workspace_execute_cancelled.execute({})
         assert exp.id == IDs.EXPERIMENT_PRIMARY
-        assert exp.status() == Status.CANCELLED
+        assert exp.status == Status.CANCELLED
         assert exp.wait(status=Status.CANCELLED) == create_experiment_entity(
             IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY
         )
@@ -43,5 +43,5 @@ class TestExperimentOperation:
     def test_execute_wait_timeout(self, workspace_execute_cancelled):
         exp = workspace_execute_cancelled.execute({})
         assert exp.id == IDs.EXPERIMENT_PRIMARY
-        assert exp.status() == Status.CANCELLED
+        assert exp.status == Status.CANCELLED
         pytest.raises(exceptions.OperationTimeOutError, exp.wait, 1e-10, Status.DONE)

--- a/tests/impact/client/operations/test_model_exe.py
+++ b/tests/impact/client/operations/test_model_exe.py
@@ -14,7 +14,7 @@ class TestModelExecutableOperation:
         fmu = model_compiled.compile(compiler_options, force_compilation=True)
         assert fmu == create_model_exe_operation(IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY)
         assert fmu.id == IDs.FMU_PRIMARY
-        assert fmu.status() == Status.DONE
+        assert fmu.status == Status.DONE
         assert fmu.is_complete()
         assert fmu.wait() == create_model_exe_entity(
             IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY
@@ -24,7 +24,7 @@ class TestModelExecutableOperation:
         fmu = model_compiled.compile(compiler_options, force_compilation=True)
         assert fmu == create_model_exe_operation(IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY)
         assert fmu.id == IDs.FMU_PRIMARY
-        assert fmu.status() == Status.DONE
+        assert fmu.status == Status.DONE
         assert fmu.is_complete()
         pytest.raises(
             exceptions.OperationTimeOutError, fmu.wait, 1e-10, Status.CANCELLED
@@ -34,7 +34,7 @@ class TestModelExecutableOperation:
         fmu = model_compiling.compile(compiler_options, force_compilation=True)
         assert fmu == create_model_exe_operation(IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY)
         assert fmu.id == IDs.FMU_PRIMARY
-        assert fmu.status() == Status.RUNNING
+        assert fmu.status == Status.RUNNING
         assert not fmu.is_complete()
         assert fmu.wait(status=Status.RUNNING) == create_model_exe_entity(
             IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY
@@ -44,7 +44,7 @@ class TestModelExecutableOperation:
         fmu = model_compile_cancelled.compile(compiler_options, force_compilation=True)
         assert fmu == create_model_exe_operation(IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY)
         assert fmu.id == IDs.FMU_PRIMARY
-        assert fmu.status() == Status.CANCELLED
+        assert fmu.status == Status.CANCELLED
         assert fmu.wait(status=Status.CANCELLED) == create_model_exe_entity(
             IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY
         )
@@ -53,7 +53,7 @@ class TestModelExecutableOperation:
         fmu = model_compile_cancelled.compile(compiler_options, force_compilation=True)
         assert fmu == create_model_exe_operation(IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY)
         assert fmu.id == IDs.FMU_PRIMARY
-        assert fmu.status() == Status.CANCELLED
+        assert fmu.status == Status.CANCELLED
         pytest.raises(exceptions.OperationTimeOutError, fmu.wait, 1e-10, Status.DONE)
 
 
@@ -65,7 +65,7 @@ class TestCachedModelExecutableOperation:
         )
         assert fmu.id == IDs.FMU_PRIMARY
         assert fmu.name == "Looking for cached FMU"
-        assert fmu.status() == Status.DONE
+        assert fmu.status == Status.DONE
         assert fmu.is_complete()
         assert fmu.wait() == create_model_exe_entity(
             IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY
@@ -77,7 +77,7 @@ class TestCachedModelExecutableOperation:
             IDs.WORKSPACE_PRIMARY, IDs.FMU_PRIMARY
         )
         assert fmu.id == IDs.FMU_PRIMARY
-        assert fmu.status() == Status.DONE
+        assert fmu.status == Status.DONE
         pytest.raises(
             exceptions.OperationTimeOutError, fmu.wait, status=Status.CANCELLED
         )


### PR DESCRIPTION
BREAKING CHANGE: the status method in all operations class inheriting BaseOperation class is now a property