### PR TITLE
fix: only call PUT /case/{case_id} when client state differs from server state

### DIFF
--- a/tests/impact/client/fixtures/fixtures.py
+++ b/tests/impact/client/fixtures/fixtures.py
@@ -1497,18 +1497,8 @@ def experiment():
     exp_service.execute_status.return_value = {"status": "done"}
     exp_service.result_variables_get.return_value = ["inertia.I", "time"]
     exp_service.cases_get.return_value = {"data": {"items": [{"id": IDs.CASE_PRIMARY}]}}
-    case_get_data = get_test_get_case()
-    exp_service.case_get.return_value = case_get_data
-    exp_service.case_get_log.return_value = "Successful Log"
-    exp_service.case_result_get.return_value = (bytes(4), IDs.RESULT_MAT)
-    exp_service.case_artifacts_meta_get.return_value = {
-        "data": {
-            "items": [{"id": IDs.CUSTOM_ARTIFACT_ID, "downloadAs": IDs.RESULT_MAT}]
-        }
-    }
-    exp_service.case_artifact_get.return_value = (bytes(4), IDs.RESULT_MAT)
+    exp_service.case_get.return_value = get_test_get_case()
     exp_service.trajectories_get.return_value = [[[1, 2, 3, 4]], [[5, 2, 9, 4]]]
-    exp_service.case_trajectories_get.return_value = [[1, 2, 3, 4], [5, 2, 9, 4]]
     return ExperimentMock(
         create_experiment_entity(
             IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY, service=service
@@ -1526,6 +1516,15 @@ def case():
     exp_service.result_variables_get.return_value = ["inertia.I", "time"]
     case_get_data = get_test_get_case()
     exp_service.case_get.return_value = case_get_data
+    exp_service.case_get_log.return_value = "Successful Log"
+    exp_service.case_result_get.return_value = (bytes(4), IDs.RESULT_MAT)
+    exp_service.case_artifacts_meta_get.return_value = {
+        "data": {
+            "items": [{"id": IDs.CUSTOM_ARTIFACT_ID, "downloadAs": IDs.RESULT_MAT}]
+        }
+    }
+    exp_service.case_artifact_get.return_value = (bytes(4), IDs.RESULT_MAT)
+    exp_service.case_trajectories_get.return_value = [[1, 2, 3, 4], [5, 2, 9, 4]]
     return CaseMock(
         create_case_entity(
             IDs.CASE_PRIMARY,
@@ -1561,7 +1560,7 @@ def experiment_running():
     service = MagicMock()
     exp_service = service.experiment
     exp_service.experiment_execute.return_value = IDs.EXPERIMENT_PRIMARY
-    exp_service.case_get.return_value = {"id": IDs.CASE_PRIMARY}
+    exp_service.case_get.return_value = get_test_get_case()
     exp_service.execute_status.return_value = {"status": "running"}
     return create_experiment_entity(
         IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY, service
@@ -1573,7 +1572,7 @@ def experiment_cancelled():
     service = MagicMock()
     exp_service = service.experiment
     exp_service.experiment_execute.return_value = IDs.EXPERIMENT_PRIMARY
-    exp_service.case_get.return_value = {"id": IDs.CASE_PRIMARY}
+    exp_service.case_get.return_value = get_test_get_case()
     exp_service.execute_status.return_value = {"status": "cancelled"}
     return create_experiment_entity(
         IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY, service=service
@@ -1606,16 +1605,7 @@ def batch_experiment_with_case_filter():
             ]
         }
     }
-    exp_service.case_get.return_value = {
-        "id": "case_3",
-        "run_info": {
-            "status": "successful",
-            "consistent": True,
-            "datetime_started": 1662964956945,
-            "datetime_finished": 1662964957990,
-        },
-        "input": {"fmu_id": IDs.FMU_PRIMARY},
-    }
+    exp_service.case_get.return_value = get_test_get_case("case_3")
     return ExperimentMock(
         create_experiment_entity(
             IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY, service
@@ -1635,17 +1625,9 @@ def batch_experiment():
     exp_service.execute_status.return_value = {"status": "done"}
     exp_service.result_variables_get.return_value = ["inertia.I", "time"]
     exp_service.cases_get.return_value = {
-        "data": {"items": [{"id": IDs.CASE_PRIMARY}, {"id": "case_2"}]}
+        "data": {"items": [{"id": IDs.CASE_PRIMARY}, {"id": IDs.CASE_SECONDARY}]}
     }
-    exp_service.case_get.return_value = {
-        "id": "case_2",
-        "run_info": {
-            "status": "successful",
-            "consistent": True,
-            "datetime_started": 1662964956945,
-            "datetime_finished": 1662964957990,
-        },
-    }
+    exp_service.case_get.return_value = get_test_get_case(case_id=IDs.CASE_SECONDARY)
     exp_service.case_get_log.return_value = "Successful Log"
     exp_service.case_result_get.return_value = (bytes(4), IDs.RESULT_MAT)
     exp_service.case_artifact_get.return_value = (bytes(4), IDs.RESULT_MAT)
@@ -1712,15 +1694,7 @@ def experiment_with_failed_case():
     }
     exp_service.execute_status.return_value = {"status": "done"}
     exp_service.cases_get.return_value = {"data": {"items": [{"id": IDs.CASE_PRIMARY}]}}
-    exp_service.case_get.return_value = {
-        "id": IDs.CASE_PRIMARY,
-        "run_info": {
-            "status": "failed",
-            "consistent": True,
-            "datetime_started": 1662964956945,
-            "datetime_finished": 1662964957990,
-        },
-    }
+    exp_service.case_get.return_value = get_test_get_case(status="failed")
     exp_service.result_variables_get.return_value = ["inertia.I", "time"]
     exp_service.trajectories_get.return_value = [[[1, 2, 3, 4]], [[5, 2, 9, 4]]]
     exp_service.case_trajectories_get.return_value = [[1, 2, 3, 4], [5, 2, 9, 4]]
@@ -1745,7 +1719,6 @@ def failed_experiment():
     }
     exp_service.execute_status.return_value = {"status": "done"}
     exp_service.cases_get.return_value = {"data": {"items": []}}
-    exp_service.case_get.return_value = {}
     return create_experiment_entity(
         IDs.WORKSPACE_PRIMARY, IDs.EXPERIMENT_PRIMARY, service=service
     )
@@ -1764,8 +1737,8 @@ def cancelled_experiment():
             "cancelled": 1,
         }
     }
-    exp_service.cases_get.return_value = {"data": {"items": [{"id": IDs.CASE_PRIMARY}]}}
-    exp_service.case_get.return_value = {"id": IDs.CASE_PRIMARY}
+    exp_service.cases_get.return_value = {"data": {"items": [get_test_get_case()]}}
+    exp_service.case_get.return_value = get_test_get_case()
     exp_service.execute_status.return_value = {
         "status": "cancelled",
         "consistent": True,

--- a/tests/impact/client/helpers.py
+++ b/tests/impact/client/helpers.py
@@ -470,6 +470,34 @@ def get_test_workspace_definition(name=None):
     }
 
 
+def get_test_get_case():
+    return {
+        "id": IDs.CASE_PRIMARY,
+        "run_info": {
+            "status": "successful",
+            "consistent": True,
+            "datetime_started": 1662964956945,
+            "datetime_finished": 1662964957990,
+        },
+        "input": {
+            "fmu_id": IDs.FMU_PRIMARY,
+            "analysis": {
+                "analysis_function": "dynamic",
+                "parameters": {"start_time": 0, "final_time": 1},
+                "simulation_options": {},
+                "solver_options": {},
+                "simulation_log_level": "NOTHING",
+            },
+            "parametrization": {},
+            "structural_parametrization": {},
+            "fmu_base_parametrization": {},
+            "initialize_from_case": None,
+            "initialize_from_external_result": None,
+        },
+        "meta": {"label": "Cruise operating point"},
+    }
+
+
 def create_workspace_entity(name, definition=None, service=None):
     definition = definition or get_test_workspace_definition(name)
     return Workspace(name, definition, service or MagicMock())

--- a/tests/impact/client/helpers.py
+++ b/tests/impact/client/helpers.py
@@ -174,6 +174,7 @@ class IDs:
     EXPERIMENT_PRIMARY = 'pid_20090615_134'
     EXPERIMENT_SECONDARY = 'filter_20090615_135'
     CASE_PRIMARY = 'case_1'
+    CASE_SECONDARY = 'case_2'
     IMPORT = '9a8fg798a7g'
     EXPORT = '79sd8-3n2a4-e3t24'
     CONVERSION = 't24e3-a43n2-d879s'
@@ -470,11 +471,22 @@ def get_test_workspace_definition(name=None):
     }
 
 
-def get_test_get_case():
+def get_test_get_case(
+    case_id=IDs.CASE_PRIMARY,
+    status="successful",
+    initialize_from_external_result=None,
+    initialize_from_case=None,
+    parameters=None,
+    meta=None,
+    simulation_options=None,
+    solver_options=None,
+    parametrization=None,
+    simulation_log_level="NOTHING",
+):
     return {
-        "id": IDs.CASE_PRIMARY,
+        "id": case_id,
         "run_info": {
-            "status": "successful",
+            "status": status,
             "consistent": True,
             "datetime_started": 1662964956945,
             "datetime_finished": 1662964957990,
@@ -483,18 +495,18 @@ def get_test_get_case():
             "fmu_id": IDs.FMU_PRIMARY,
             "analysis": {
                 "analysis_function": "dynamic",
-                "parameters": {"start_time": 0, "final_time": 1},
-                "simulation_options": {},
-                "solver_options": {},
-                "simulation_log_level": "NOTHING",
+                "parameters": parameters or {},
+                "simulation_options": simulation_options or {},
+                "solver_options": solver_options or {},
+                "simulation_log_level": simulation_log_level,
             },
-            "parametrization": {},
+            "parametrization": parametrization or {},
             "structural_parametrization": {},
             "fmu_base_parametrization": {},
-            "initialize_from_case": None,
-            "initialize_from_external_result": None,
+            "initialize_from_case": initialize_from_case,
+            "initialize_from_external_result": initialize_from_external_result,
         },
-        "meta": {"label": "Cruise operating point"},
+        "meta": meta or {},
     }
 
 


### PR DESCRIPTION
```
from modelon.impact.client import Client

c = Client(url="https://jhmi-staging.modelon.com/", interactive=True)
w = c.get_workspace("test")


m = w.get_model("Unnamed.PID_Controller_1")
ed = m.new_experiment_definition(w.get_custom_function('dynamic'))
e = w.create_experiment(ed)
r = e.execute(with_cases=[]).wait()
cc = e.get_cases()
# print(cc[0]._get_info(cached=False), cc[0].info)
cc[0].meta.label = "bla"
print(cc[0].meta.label)
cc = e.get_cases()
# print(cc[0]._get_info(cached=False))
cc[0].meta.label = "bla"
print(cc[0].meta.label)
print("execute 1")
cc[0].execute().wait()
print("execute 1 done")
cc[0].get_result("csv")[1]
print("execute 2")
cc[0].meta.label = "blah2"
cc[0].execute().wait()
print(cc[0].meta.label)
print("execute 2 done")
print(cc[0].meta)
print("execute 3")
cc[0].execute().wait()

```