### PR TITLE
feat: Add logic in python client for published workspace update

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -361,7 +361,12 @@ class Client:
             if item['definition']['name'] == workspace_name
         ]
 
-    def get_workspaces(self) -> List[Workspace]:
+    def get_workspaces(
+        self,
+        only_app_mode: bool = False,
+        name: Optional[str] = None,
+        sharing_id: Optional[str] = None,
+    ) -> List[Workspace]:
         """Returns a list of Workspace class object.
 
         Returns:
@@ -372,7 +377,7 @@ class Client:
             workspaces = client.get_workspaces()
 
         """
-        resp = self._sal.workspace.workspaces_get()
+        resp = self._sal.workspace.workspaces_get(only_app_mode, name, sharing_id)
         return [
             Workspace(item["id"], item["definition"], self._sal)
             for item in resp["data"]["items"]

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -238,8 +238,9 @@ class PublishedWorkspace:
             The workspace class object.
 
         Example::
-
-            published_workspace.import_to_userspace()
+            published_workspace = client.get_published_workspaces(owner="username",
+                name="A Workspace")[0]
+            workspace = published_workspace.import_to_userspace()
 
         """
         local_workspace = self._get_latest_local_workspace()

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -208,7 +208,7 @@ class PublishedWorkspace:
         """
         self._sal.workspace.request_published_workspace_access(self._id)
 
-    def _get_latest_local_workspace(self):
+    def _get_latest_local_workspace(self) -> Optional[Workspace]:
         resp = self._sal.workspace.workspaces_get(sharing_id=self._id)
         workspaces = [
             Workspace(item["id"], item["definition"], self._sal)
@@ -223,7 +223,7 @@ class PublishedWorkspace:
             )
             return sorted(
                 workspaces,
-                key=lambda x: x.definition.received_from.created_at,
+                key=lambda x: x.definition.received_from.created_at,  # type: ignore
             )[-1]
         return workspaces[0]
 
@@ -244,7 +244,9 @@ class PublishedWorkspace:
         """
         local_workspace = self._get_latest_local_workspace()
         if local_workspace:
-            if self.created_at != local_workspace.definition.received_from.created_at:
+            local_ws_recieved_from = local_workspace.definition.received_from
+            local_ws_created_at = local_ws_recieved_from.created_at  # type: ignore
+            if self.created_at != local_ws_created_at:
                 if not update_if_available:
                     logger.warning(
                         'A new update is available for the workspace with ID '
@@ -265,7 +267,7 @@ class PublishedWorkspace:
         )
         return self._import_to_userspace()
 
-    def _import_to_userspace(self):
+    def _import_to_userspace(self) -> Workspace:
         resp = self._sal.workspace.import_from_cloud(self._id)
         return WorkspaceImportOperation[Workspace](
             resp["data"]["location"], self._sal, Workspace.from_import_operation
@@ -277,11 +279,11 @@ class OwnerData:
         self._data = data
 
     @property
-    def username(self):
+    def username(self) -> str:
         return self._data['username']
 
     @property
-    def tenant(self):
+    def tenant(self) -> str:
         return self._data['tenant']
 
 
@@ -290,19 +292,19 @@ class ReceivedFrom:
         self._data = data
 
     @property
-    def sharing_id(self):
+    def sharing_id(self) -> str:
         return self._data['sharingId']
 
     @property
-    def workspace_name(self):
+    def workspace_name(self) -> str:
         return self._data['workspaceName']
 
     @property
-    def owner(self):
+    def owner(self) -> OwnerData:
         return OwnerData(self._data['owner'])
 
     @property
-    def created_at(self):
+    def created_at(self) -> int:
         return self._data['createdAt']
 
 

--- a/modelon/impact/client/sal/workspace.py
+++ b/modelon/impact/client/sal/workspace.py
@@ -36,7 +36,7 @@ class WorkspaceService:
         if sharing_id:
             query["sharingId"] = sharing_id
         if only_app_mode:
-            query["onlyAppMode"] = only_app_mode
+            query["onlyAppMode"] = str(only_app_mode)
         query_args = '&'.join(f'{key}={value}' for key, value in query.items())
         url = (self._base_uri / f"api/workspaces?{query_args}").resolve()
         return self._http_client.get_json(url)

--- a/modelon/impact/client/sal/workspace.py
+++ b/modelon/impact/client/sal/workspace.py
@@ -24,8 +24,21 @@ class WorkspaceService:
         ).resolve()
         return self._http_client.get_json(url)
 
-    def workspaces_get(self) -> Dict[str, Any]:
-        url = (self._base_uri / "api/workspaces").resolve()
+    def workspaces_get(
+        self,
+        only_app_mode: bool = False,
+        name: Optional[str] = None,
+        sharing_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        query = {}
+        if name:
+            query["name"] = name
+        if sharing_id:
+            query["sharingId"] = sharing_id
+        if only_app_mode:
+            query["onlyAppMode"] = only_app_mode
+        query_args = '&'.join(f'{key}={value}' for key, value in query.items())
+        url = (self._base_uri / f"api/workspaces?{query_args}").resolve()
         return self._http_client.get_json(url)
 
     def projects_get(

--- a/tests/impact/client/entities/test_workspace.py
+++ b/tests/impact/client/entities/test_workspace.py
@@ -5,11 +5,11 @@ import unittest.mock as mock
 from tests.files.paths import TEST_WORKSPACE_PATH
 from tests.impact.client.helpers import (
     IDs,
+    create_experiment_operation,
     create_model_entity,
     create_model_exe_entity,
-    create_published_workspace_entity,
-    create_experiment_operation,
     create_project_entity,
+    create_published_workspace_entity,
     create_workspace_entity,
     create_workspace_export_operation,
 )
@@ -52,7 +52,7 @@ class TestPublishedWorkspace:
         )
 
     def test_import_published_workspace(self, publish_workspace):
-        workspace = publish_workspace.entity.import_to_userspace().wait()
+        workspace = publish_workspace.entity.import_to_userspace()
         assert workspace.id == IDs.WORKSPACE_PRIMARY
 
 


### PR DESCRIPTION
Jira - https://modelonproducts.atlassian.net/browse/FLOW-248

```
from modelon.impact.client import Client

# Publish a local workspace
client = Client(url="https://jhmi-staging.modelon.com/", interactive=True)
workspaces =  client.get_workspace_by_name('SyncPubTest')
if not workspaces:
    local_workspace = client.create_workspace('SyncPubTest')
else:
    local_workspace = workspaces[0]
# Check if already published to avoid republishing 
published_workspaces = client.get_published_workspaces(owner_username='abhilash.kumar@modelon.com', name='SyncPubTest')
if not published_workspaces:
    sharing_id = local_workspace.export(publish=True).wait().id
else:
    sharing_id = published_workspaces[0].id

# Get the owner_name and workspace name from the published workspace entity
published_workspace = client.get_published_workspace(sharing_id)
owner_name = published_workspace.definition.owner_username
name = published_workspace.name
print(owner_name, name)

# Import the published workspace
shared_workspace = published_workspace.import_to_userspace(update_if_available=False)

# Update workflow
# Make updates and republish the workspace
local_workspace.export(publish=True).wait().id
published_workspace = client.get_published_workspaces(owner_username=owner_name, name=name)[0]

# Importing raises a warning about updates available
local_workspace = published_workspace.import_to_userspace(update_if_available=False)

# Update the workspace with the latest changes on cloud
local_workspace = published_workspace.import_to_userspace(update_if_available=True)
```