### PR TITLE
fix: updating the import_to_userspace api to use the backend api when performing an update operation

### DIFF
--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -274,8 +274,9 @@ class PublishedWorkspace:
                     )
                     return local_workspace
                 logger.info('Updating the workspace to the latest published workspace.')
-                updated_workspace = self._import_to_userspace()
-                local_workspace.delete()
+                updated_workspace = self._import_to_userspace(
+                    overwrite_workspace_id=local_workspace.id
+                )
                 return updated_workspace
             else:
                 logger.info(
@@ -289,8 +290,10 @@ class PublishedWorkspace:
         )
         return self._import_to_userspace()
 
-    def _import_to_userspace(self) -> Workspace:
-        resp = self._sal.workspace.import_from_cloud(self._id)
+    def _import_to_userspace(
+        self, overwrite_workspace_id: Optional[str] = None
+    ) -> Workspace:
+        resp = self._sal.workspace.import_from_cloud(self._id, overwrite_workspace_id)
         return WorkspaceImportOperation[Workspace](
             resp["data"]["location"], self._sal, Workspace.from_import_operation
         ).wait()

--- a/modelon/impact/client/sal/workspace.py
+++ b/modelon/impact/client/sal/workspace.py
@@ -166,14 +166,19 @@ class WorkspaceService:
         url = (self._base_uri / "api/workspace-imports").resolve()
         return self._http_client.post_json(url, body=shared_definition)
 
-    def import_from_cloud(self, sharing_id: str) -> Dict[str, Any]:
+    def import_from_cloud(
+        self, sharing_id: str, overwrite_workspace_id: Optional[str] = None
+    ) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspace-imports").resolve()
+        payload: Dict[str, Any] = {"id": sharing_id}
+        if overwrite_workspace_id:
+            payload["update"] = {"workspaceId": overwrite_workspace_id}
         return self._http_client.post_json(
             url,
             headers={
                 "Content-type": "application/vnd.impact.published-workspace.v1+json"
             },
-            body={"id": sharing_id},
+            body=payload,
         )
 
     def get_project_matchings(


### PR DESCRIPTION
Jira - https://modelonproducts.atlassian.net/browse/FLOW-293

Code to test: -

```
import os

os.environ["IMPACT_PYTHON_CLIENT_EXPERIMENTAL"] = "true"
from modelon.impact.client import Client

client = Client(url="https://jhmi-staging.modelon.com", interactive=True)
pub_ws_client = client.get_published_workspaces_client()
pub_workspaces = pub_ws_client.find(owner_username="abhilash.kumar@modelon.com")
workspace = pub_workspaces[0].import_to_userspace(update_if_available=True)
```
