### PR TITLE
chore: added workspace publishing docs

### DIFF
--- a/docs/source/modelon.impact.client.rst
+++ b/docs/source/modelon.impact.client.rst
@@ -56,6 +56,14 @@ modelon.impact.client.options module
    :undoc-members:
    :show-inheritance:
 
+modelon.impact.client.published\_workspace\_client module
+---------------------------------------------------------
+
+.. automodule:: modelon.impact.client.published_workspace_client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/source/working_with_workspaces.rst
+++ b/docs/source/working_with_workspaces.rst
@@ -57,11 +57,55 @@ would result in multiple workspaces being created with same name.
 Workspace sharing
 *****************
 
-A workspace in Modelon Impact can be shared as a zipped artifact(snapshot) or as workspace definition referring to version controlled 
-projects and preinstalled libraries. 
+A workspace in Modelon Impact can be shared as a zipped artifact (snapshot) or as a workspace configuration.
+A snapshot can be either stored in a cloud storage or downloaded as a zip file to the client system. 
 
-Zipped(snapshot) export
-#######################
+A snapshot in cloud storage can be shared with the other users of the same Modelon Impact same website,
+e.g., https://impact.modelon.cloud. By default read access is granted to all users 
+within the same tenant group as setup by site administrators. On https://impact.modelon.cloud this 
+corresponds to same organization.
+
+Workspace configuration is a JSON-serializable structure containing links to version
+controlled projects and preinstalled libraries. 
+
+Published Workspaces
+####################
+
+Publishing a workspace to cloud storage bundles all Projects with Modelica packages including resources,
+results and FMUs. Publishing specifying a model will publish an app mode workspace::
+
+   # Create an example workspace containing experiment result
+   from modelon.impact.client import Client
+
+   client = Client()
+   workspace = client.create_workspace("PublishDemo")
+   model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")
+   dynamic_cf = workspace.get_custom_function("dynamic")
+   exp_def = model.new_experiment_definition(dynamic_cf)
+   experiment = workspace.create_experiment(exp_def).execute().wait()
+
+   # Publish the workspace to cloud storage in app mode
+   workspace.export(publish=True, class_path="Modelica.Blocks.Examples.PID_Controller").wait()
+
+A published workspace can be found and imported by a user who has appropriate access rights::
+
+   pwc = client.get_published_workspaces_client()
+   published_workspace = pwc.find(name="PublishDemo")[0]
+   imported_workspace = published_workspace.import_to_userspace()
+
+The imported workspace will contain results that were bundled and experiment IDs will be kept intact::
+
+   imported_experiment = imported_workspace.get_experiments()[0]
+   assert imported_experiment.id == experiment.id
+
+Repeated imports of the same workspace do not update the workspace in userspace. However,
+if an update was published the receiver can get his copy overwritten by the update::
+
+   updated_workspace = published_workspace.import_to_userspace(update_if_available=True)
+   assert imported_workspace.id == updated_workspace.id    
+
+Zipped (snapshot) export
+########################
 
 A zipped archive export of the workspace bundles all Projects (with Modelica packages including resources, and also results and FMUs). 
 This ZIP file can then be uploaded at another point. The below code snippet exports an existing workspace::

--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -450,11 +450,18 @@ class Client:
             A list of Project class objects.
 
         Example::
-            from modelon.impact.client import ProjectType, StorageLocation
+
+            # Get all projects and then get projects with filtering.
+            from modelon.impact.client import (
+                ProjectType,
+                StorageLocation
+            )
 
             client.get_projects()
-            client.get_projects(project_type=ProjectType.LOCAL,
-                storage_location=StorageLocation.USERSPACE)
+            client.get_projects(
+                project_type=ProjectType.LOCAL,
+                storage_location=StorageLocation.USERSPACE
+            )
 
         """
         resp = self._sal.project.projects_get(

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -68,15 +68,15 @@ def _get_project_entry_reference(
 ) -> Union[ReleasedProjectReference, VcsReference, Reference]:
     if "name" in reference:
         return ReleasedProjectReference(
-            id=reference.get('id'),
-            name=reference.get('name'),
-            version=reference.get('version'),
-            build=reference.get('build'),
+            id=reference.get("id"),
+            name=reference.get("name"),
+            version=reference.get("version"),
+            build=reference.get("build"),
         )
     elif "vcsUri" in reference:
-        return VcsReference(id=reference.get('id'), vcs_uri=reference.get('vcsUri'))
+        return VcsReference(id=reference.get("id"), vcs_uri=reference.get("vcsUri"))
     else:
-        return Reference(id=reference.get('id'))
+        return Reference(id=reference.get("id"))
 
 
 class ProjectEntry:
@@ -85,7 +85,7 @@ class ProjectEntry:
 
     @property
     def reference(self) -> Union[ReleasedProjectReference, VcsReference, Reference]:
-        return _get_project_entry_reference(self._data.get('reference'))
+        return _get_project_entry_reference(self._data.get("reference"))
 
     @property
     def id(self) -> str:
@@ -93,24 +93,24 @@ class ProjectEntry:
 
     @property
     def disabled(self) -> bool:
-        return self._data.get('disabled')
+        return self._data.get("disabled")
 
     @property
     def disabled_content(self) -> bool:
-        return self._data.get('disabledContent')
+        return self._data.get("disabledContent")
 
 
 @enum.unique
 class PublishedWorkspaceType(enum.Enum):
-    APP_MODE = 'APP_MODE'
-    ARCHIVE = 'ARCHIVE'
+    APP_MODE = "APP_MODE"
+    ARCHIVE = "ARCHIVE"
 
 
 @enum.unique
 class PublishedWorkspaceUploadStatus(enum.Enum):
-    INITIALIZING = 'initializing'
-    CREATED = 'created'
-    DELETING = 'deleting'
+    INITIALIZING = "initializing"
+    CREATED = "created"
+    DELETING = "deleting"
 
 
 @dataclass
@@ -125,12 +125,12 @@ class PublishedWorkspaceDefinition:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> PublishedWorkspaceDefinition:
         return cls(
-            name=data['workspaceName'],
-            tenant_id=data['tenantId'],
-            size=data['size'],
-            status=PublishedWorkspaceUploadStatus(data['status']),
-            owner_username=data['ownerUsername'],
-            created_at=data['createdAt'],
+            name=data["workspaceName"],
+            tenant_id=data["tenantId"],
+            size=data["size"],
+            status=PublishedWorkspaceUploadStatus(data["status"]),
+            owner_username=data["ownerUsername"],
+            created_at=data["createdAt"],
         )
 
 
@@ -307,8 +307,8 @@ class PublishedWorkspace:
             return None
         if len(workspaces) > 1:
             logger.warning(
-                'Multiple local copies of workspace with the same '
-                'sharing ID exist. Picking the latest.'
+                "Multiple local copies of workspace with the same "
+                "sharing ID exist. Picking the latest."
             )
             return sorted(
                 workspaces,
@@ -327,6 +327,7 @@ class PublishedWorkspace:
             The workspace class object.
 
         Example::
+
             published_workspace = client.get_published_workspaces(owner="username",
                 name="A Workspace")[0]
             workspace = published_workspace.import_to_userspace()
@@ -335,32 +336,32 @@ class PublishedWorkspace:
         local_workspace = self._get_latest_local_workspace()
         if local_workspace:
             logger.info(
-                f'Local imports of workspace with sharing ID {self._id} exists.'
+                f"Local imports of workspace with sharing ID {self._id} exists."
             )
             local_ws_recieved_from = local_workspace.definition.received_from
             local_ws_created_at = local_ws_recieved_from.created_at  # type: ignore
             if self.created_at != local_ws_created_at:
                 if not update_if_available:
                     logger.warning(
-                        'A new update is available for the workspace with ID '
+                        "A new update is available for the workspace with ID "
                         f'{local_workspace.id}. Set "update_if_available" to True '
-                        'if you wish to update the workspace!'
+                        "if you wish to update the workspace!"
                     )
                     return local_workspace
-                logger.info('Updating the workspace to the latest published workspace.')
+                logger.info("Updating the workspace to the latest published workspace.")
                 updated_workspace = self._import_to_userspace(
                     overwrite_workspace_id=local_workspace.id
                 )
                 return updated_workspace
             else:
                 logger.info(
-                    f'Returning the local workspace with ID {local_workspace.id}.'
+                    f"Returning the local workspace with ID {local_workspace.id}."
                 )
                 return local_workspace
 
         logger.info(
-            f'No local imports of workspace with sharing ID {self._id} exist.'
-            'Importing the published workspace to userspace.'
+            f"No local imports of workspace with sharing ID {self._id} exist."
+            "Importing the published workspace to userspace."
         )
         return self._import_to_userspace()
 
@@ -380,6 +381,7 @@ class PublishedWorkspace:
             The PublishedWorkspaceACL class object.
 
         Example::
+
             published_workspace = client.get_published_workspaces(owner="username",
                 name="A Workspace")[0]
             published_workspace_acl = published_workspace.get_access_control_list()
@@ -398,11 +400,11 @@ class OwnerData:
 
     @property
     def username(self) -> str:
-        return self._data['username']
+        return self._data["username"]
 
     @property
     def tenant_id(self) -> str:
-        return self._data['tenantId']
+        return self._data["tenantId"]
 
 
 class ReceivedFrom:
@@ -411,19 +413,19 @@ class ReceivedFrom:
 
     @property
     def sharing_id(self) -> str:
-        return self._data['sharingId']
+        return self._data["sharingId"]
 
     @property
     def workspace_name(self) -> str:
-        return self._data['workspaceName']
+        return self._data["workspaceName"]
 
     @property
     def owner(self) -> OwnerData:
-        return OwnerData(self._data['owner'])
+        return OwnerData(self._data["owner"])
 
     @property
     def created_at(self) -> int:
-        return self._data['createdAt']
+        return self._data["createdAt"]
 
 
 class WorkspaceDefinition:
@@ -433,47 +435,47 @@ class WorkspaceDefinition:
     @property
     def name(self) -> str:
         """Workspace name."""
-        return self._data.get('name')
+        return self._data.get("name")
 
     @property
     def format(self) -> str:
         """Workspace definition format."""
-        return self._data.get('format')
+        return self._data.get("format")
 
     @property
     def description(self) -> str:
         """Workspace description."""
-        return self._data.get('description')
+        return self._data.get("description")
 
     @property
     def created_by(self) -> str:
         """User ID of the workspace creator."""
-        return self._data.get('createdBy')
+        return self._data.get("createdBy")
 
     @property
     def default_project_id(self) -> str:
         """Project ID of the default workspace project."""
-        return self._data.get('defaultProjectId')
+        return self._data.get("defaultProjectId")
 
     @property
     def received_from(self) -> Optional[ReceivedFrom]:
         """Received from information for the workspace, if imported from cloud."""
         return (
-            ReceivedFrom(self._data.get('receivedFrom'))
-            if self._data.get('receivedFrom')
+            ReceivedFrom(self._data.get("receivedFrom"))
+            if self._data.get("receivedFrom")
             else None
         )
 
     @property
     def projects(self) -> List[ProjectEntry]:
         """List of workspace projects."""
-        projects = self._data.get('projects', [])
+        projects = self._data.get("projects", [])
         return [ProjectEntry(project) for project in projects]
 
     @property
     def dependencies(self) -> List[ProjectEntry]:
         """List of workspace dependencies."""
-        dependencies = self._data.get('dependencies', [])
+        dependencies = self._data.get("dependencies", [])
         return [ProjectEntry(dependency) for dependency in dependencies]
 
     def to_file(self, path: str) -> str:
@@ -492,7 +494,7 @@ class WorkspaceDefinition:
         """
         os.makedirs(path, exist_ok=True)
         definition_path = os.path.join(path, self.name + ".json")
-        with open(definition_path, "w", encoding='utf-8') as f:
+        with open(definition_path, "w", encoding="utf-8") as f:
             json.dump(self._data, f, indent=4)
         return definition_path
 
@@ -554,7 +556,7 @@ class Workspace(WorkspaceInterface):
         """Workspace definition."""
         definition = self._sal.workspace.workspace_get(
             workspace_id=self.id, size_info=False
-        )['definition']
+        )["definition"]
         return WorkspaceDefinition(definition)
 
     @property
@@ -576,7 +578,7 @@ class Workspace(WorkspaceInterface):
         workspace_data = self._sal.workspace.workspace_get(
             workspace_id=self.id, size_info=False
         )
-        workspace_data['definition']["name"] = new_name
+        workspace_data["definition"]["name"] = new_name
         self._sal.workspace.update_workspace(self.id, workspace_data)
 
     def get_custom_function(self, name: str) -> CustomFunction:
@@ -909,7 +911,7 @@ class Workspace(WorkspaceInterface):
         projects = [
             Project(
                 item["id"],
-                item['definition'],
+                item["definition"],
                 item["projectType"],
                 item["storageLocation"],
                 VcsUri.from_dict(item["vcsUri"]) if item.get("vcsUri") else None,
@@ -944,7 +946,7 @@ class Workspace(WorkspaceInterface):
         return [
             Project(
                 item["id"],
-                item['definition'],
+                item["definition"],
                 item["projectType"],
                 item["storageLocation"],
                 VcsUri.from_dict(item["vcsUri"]) if item.get("vcsUri") else None,
@@ -967,7 +969,7 @@ class Workspace(WorkspaceInterface):
         resp = self._sal.workspace.project_create(self._workspace_id, name)
         return Project(
             resp["id"],
-            resp['definition'],
+            resp["definition"],
             resp["projectType"],
             resp["storageLocation"],
             VcsUri.from_dict(resp["vcsUri"]) if resp.get("vcsUri") else None,
@@ -988,7 +990,7 @@ class Workspace(WorkspaceInterface):
         default_project_id = self.definition.default_project_id
         if not default_project_id:
             raise ValueError(
-                f'No default project exists for the workspace {self._workspace_id}!'
+                f"No default project exists for the workspace {self._workspace_id}!"
             )
         resp = self._sal.project.project_get(
             default_project_id,


### PR DESCRIPTION
This PR adds a documentation section with an example on workspace publishing to cloud storage and importing the workspace back into userspace.