### PR TITLE
feat: added possibility to export a workspace without group share

### DIFF
--- a/docs/source/working_with_workspaces.rst
+++ b/docs/source/working_with_workspaces.rst
@@ -88,9 +88,12 @@ results and FMUs. Publishing specifying a model will publish an app mode workspa
    workspace.export(publish=True, class_path="Modelica.Blocks.Examples.PID_Controller").wait()
 
 A published workspace can be found and imported by a user who has appropriate access rights::
+   
+   from modelon.impact.client import PublishedWorkspaceType
 
    pwc = client.get_published_workspaces_client()
-   published_workspace = pwc.find(name="PublishDemo")[0]
+   published_workspace = pwc.find(name="PublishDemo", type=PublishedWorkspaceType.APP_MODE, 
+      owner_username='sasuke@gmail.com')[0]
    imported_workspace = published_workspace.import_to_userspace()
 
 The imported workspace will contain results that were bundled and experiment IDs will be kept intact::

--- a/modelon/impact/client/__init__.py
+++ b/modelon/impact/client/__init__.py
@@ -4,7 +4,10 @@ from modelon.impact.client.entities.project import (
     ProjectType,
     StorageLocation,
 )
-from modelon.impact.client.entities.workspace import WorkspaceDefinition
+from modelon.impact.client.entities.workspace import (
+    PublishedWorkspaceType,
+    WorkspaceDefinition,
+)
 from modelon.impact.client.experiment_definition.expansion import (
     FullFactorial,
     LatinHypercube,

--- a/modelon/impact/client/__init__.py
+++ b/modelon/impact/client/__init__.py
@@ -5,6 +5,7 @@ from modelon.impact.client.entities.project import (
     StorageLocation,
 )
 from modelon.impact.client.entities.workspace import (
+    AccessSettings,
     PublishedWorkspaceType,
     WorkspaceDefinition,
 )

--- a/modelon/impact/client/published_workspace_client.py
+++ b/modelon/impact/client/published_workspace_client.py
@@ -133,8 +133,11 @@ class PublishedWorkspacesClient:
 
         Example::
 
+            from modelon.impact.client.published_workspace_client import
+                PublishedWorkspaceAccessKind
+
             pw_client = client.get_published_workspaces_client()
-            pw_client.get_by_kind(PublishedWorkspaceAccessKind.REQUESTED_BY_ME)
+            pw_client.get_by_access_kind(PublishedWorkspaceAccessKind.REQUESTED_BY_ME)
 
         """
         data = self._sal.workspace.get_published_workspaces_by_kind(

--- a/modelon/impact/client/sal/workspace.py
+++ b/modelon/impact/client/sal/workspace.py
@@ -66,10 +66,16 @@ class WorkspaceService:
         return self._http_client.get_json(url)
 
     def workspace_export_setup(
-        self, workspace_id: str, publish: bool, class_path: Optional[str] = None
+        self,
+        workspace_id: str,
+        publish: bool,
+        class_path: Optional[str] = None,
+        access_settings: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspace-exports").resolve()
-        body = {"workspaceId": workspace_id, 'publish': publish}
+        body = {"workspaceId": workspace_id, "publish": publish}
+        if access_settings:
+            body["access"] = access_settings
         if class_path:
             body['appMode'] = {'model': class_path}
         return self._http_client.post_json(url, body=body)

--- a/tests/impact/client/entities/test_workspace.py
+++ b/tests/impact/client/entities/test_workspace.py
@@ -4,6 +4,7 @@ import unittest.mock as mock
 
 import pytest
 
+from modelon.impact.client import AccessSettings
 from tests.files.paths import TEST_WORKSPACE_PATH
 from tests.impact.client.helpers import (
     IDs,
@@ -159,6 +160,25 @@ class TestWorkspace:
     def test_export_workspace(self, workspace):
         resp = workspace.entity.export()
         assert resp == create_workspace_export_operation(IDs.EXPORT)
+
+    def test_publish_workspace_without_group_share(self, workspace):
+        workspace_entity = workspace.entity
+        service = workspace.service
+        workspace_service = service.workspace
+        workspace_entity.export(publish=True, access=AccessSettings(group_names=[]))
+        access_settings = {'groupNames': []}
+        workspace_service.workspace_export_setup.assert_has_calls(
+            [mock.call(IDs.WORKSPACE_PRIMARY, True, None, access_settings)]
+        )
+
+    def test_publish_workspace(self, workspace):
+        workspace_entity = workspace.entity
+        service = workspace.service
+        workspace_service = service.workspace
+        workspace_entity.export(publish=True)
+        workspace_service.workspace_export_setup.assert_has_calls(
+            [mock.call(IDs.WORKSPACE_PRIMARY, True, None, None)]
+        )
 
     def test_get_model(self, workspace):
         model = workspace.entity.get_model("Modelica.Blocks.PID")

--- a/tests/impact/client/sal/test_workspace_service.py
+++ b/tests/impact/client/sal/test_workspace_service.py
@@ -1,4 +1,5 @@
 import modelon.impact.client.sal.service
+from modelon.impact.client import AccessSettings
 from modelon.impact.client.sal.uri import URI
 from tests.files.paths import TEST_WORKSPACE_PATH
 from tests.impact.client.helpers import (
@@ -106,9 +107,16 @@ class TestWorkspaceService:
         service = modelon.impact.client.sal.service.Service(
             uri=uri, context=setup_export_workspace.context
         )
-        data = service.workspace.workspace_export_setup(IDs.WORKSPACE_PRIMARY, False)
+        access_settings = {'groupNames': None}
+        data = service.workspace.workspace_export_setup(
+            IDs.WORKSPACE_PRIMARY, False, access_settings=access_settings
+        )
         request_data = setup_export_workspace.adapter.request_history[0].json()
-        assert request_data == {'publish': False, 'workspaceId': IDs.WORKSPACE_PRIMARY}
+        assert request_data == {
+            'publish': False,
+            'workspaceId': IDs.WORKSPACE_PRIMARY,
+            "access": access_settings,
+        }
         assert data == {"data": {"location": f"api/workspace-exports/{IDs.EXPORT}"}}
 
     def test_app_mode_workspace_export_setup(self, setup_export_workspace):
@@ -124,6 +132,25 @@ class TestWorkspaceService:
             'publish': False,
             'workspaceId': IDs.WORKSPACE_PRIMARY,
             'appMode': {'model': IDs.MODELICA_CLASS_PATH},
+        }
+        assert data == {"data": {"location": f"api/workspace-exports/{IDs.EXPORT}"}}
+
+    def test_workspace_publish_without_group_share(self, setup_export_workspace):
+        uri = URI(setup_export_workspace.url)
+        service = modelon.impact.client.sal.service.Service(
+            uri=uri, context=setup_export_workspace.context
+        )
+        access_settings = {'groupNames': []}
+        data = service.workspace.workspace_export_setup(
+            IDs.WORKSPACE_PRIMARY,
+            publish=True,
+            access_settings=access_settings,
+        )
+        request_data = setup_export_workspace.adapter.request_history[0].json()
+        assert request_data == {
+            'publish': True,
+            'workspaceId': IDs.WORKSPACE_PRIMARY,
+            'access': access_settings,
         }
         assert data == {"data": {"location": f"api/workspace-exports/{IDs.EXPORT}"}}
 


### PR DESCRIPTION
Code to test

```
import os

os.environ["IMPACT_PYTHON_CLIENT_EXPERIMENTAL"] = "true"
from modelon.impact.client import AccessSettings, Client

client = Client(url="https://jhmi-staging.modelon.com", interactive=True)

pwc = client.get_published_workspaces_client()
workspace = client.get_workspace('abhilash')

# Export without group share
workspace.export(publish=True, access=AccessSettings(group_names=[]))

# Export with default group share
workspace.export(
    publish=True, access=AccessSettings(group_names=['impact-tenant-mycompany'])
)

```