### PR TITLE
chore: bump sphinx-rtd-theme version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,12 +9,12 @@ build:
       # Install poetry
       # https://python-poetry.org/docs/#installing-manually
       - pip install poetry
-      # Tell poetry to not use a virtual environment
-      - poetry config virtualenvs.create false
     post_install:
       # Install dependencies with 'docs' dependency group
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install --with docs
+      # VIRTUAL_ENV needs to be set manually for now.
+      # See https://github.com/readthedocs/readthedocs.org/pull/11152/
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
 sphinx:
   configuration: docs/source/conf.py

--- a/poetry.lock
+++ b/poetry.lock
@@ -1010,18 +1010,18 @@ rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme", "sphinx-examples"]
 
 [[package]]
 name = "sphinx-rtd-theme"
-version = "1.3.0"
+version = "2.0.0"
 description = "Read the Docs theme for Sphinx"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+python-versions = ">=3.6"
 files = [
-    {file = "sphinx_rtd_theme-1.3.0-py2.py3-none-any.whl", hash = "sha256:46ddef89cc2416a81ecfbeaceab1881948c014b1b6e4450b815311a89fb977b0"},
-    {file = "sphinx_rtd_theme-1.3.0.tar.gz", hash = "sha256:590b030c7abb9cf038ec053b95e5380b5c70d61591eb0b552063fbe7c41f0931"},
+    {file = "sphinx_rtd_theme-2.0.0-py2.py3-none-any.whl", hash = "sha256:ec93d0856dc280cf3aee9a4c9807c60e027c7f7b461b77aeffed682e68f0e586"},
+    {file = "sphinx_rtd_theme-2.0.0.tar.gz", hash = "sha256:bd5d7b80622406762073a04ef8fadc5f9151261563d47027de09910ce03afe6b"},
 ]
 
 [package.dependencies]
-docutils = "<0.19"
-sphinx = ">=1.6,<8"
+docutils = "<0.21"
+sphinx = ">=5,<8"
 sphinxcontrib-jquery = ">=4,<5"
 
 [package.extras]
@@ -1394,4 +1394,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.0"
-content-hash = "fe92c57efae97c6ab625ad60205b95ee6ab7a293d01eaa12270f1ed8e7fed96d"
+content-hash = "38d4453c8a7ad08b3403926b5df2fb8af6c40914ede8eee740ab065ade9cf99d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ requests_mock = "^1.10"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "^6.0.0"
-sphinx-rtd-theme = "^1.1.1"
+sphinx-rtd-theme = "^2.0.0"
 sphinx-copybutton = "^0.5.1"
 sphinxcontrib-napoleon = "^0.7"
 sphinxcontrib-spelling = "^7.7.0"


### PR DESCRIPTION
The RTD builds were failing with the following error

```
Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/modelon-impact-client/envs/update-sphinx/lib/python3.9/site-packages/sphinx/config.py", line 358, in eval_config_file
    exec(code, namespace)  # NoQA: S102
  File "/home/docs/checkouts/readthedocs.org/user_builds/modelon-impact-client/checkouts/update-sphinx/docs/source/conf.py", line 16, in <module>
    import sphinx_rtd_theme
ModuleNotFoundError: No module named 'sphinx_rtd_theme'
```

I looked at the latest build docs available for setups with poetry at https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry and updated our configuration to be in sync with it.

Seems to work after this change - https://modelon-impact-client.readthedocs.io/en/update-sphinx/