### PR TITLE
Add experiment v3 experimental support

### DIFF
--- a/modelon/impact/client/configuration.py
+++ b/modelon/impact/client/configuration.py
@@ -38,6 +38,16 @@ def get_client_experimental() -> bool:
     return experimental_env.lower() in ("1", "true")
 
 
+def get_client_experiments_v3_experimental() -> bool:
+    """If the client should use the new experimental V3 schema for experiments.
+
+    Can be overridden by the environment variable IMPACT_PYTHON_CLIENT_V3_EXPERIMENTS.
+
+    """
+    experimental_env = os.environ.get("IMPACT_PYTHON_CLIENT_V3_EXPERIMENTS", "false")
+    return experimental_env.lower() in ("1", "true")
+
+
 class Experimental:
     def __init__(self, fn: Callable):
         self.fn = fn

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from modelon.impact.client.configuration import Experimental
 from modelon.impact.client.entities.custom_function import CustomFunction
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 ExperimentDefinition = Union[
-    Type[BaseExperimentDefinition],
+    BaseExperimentDefinition,
     Dict[str, Any],
 ]
 

--- a/modelon/impact/client/experiment_definition/fmu_based.py
+++ b/modelon/impact/client/experiment_definition/fmu_based.py
@@ -155,6 +155,7 @@ class SimpleFMUExperimentDefinition(BaseExperimentDefinition):
             self._initialize_from,
         )
         new._extensions = self._extensions
+        new._variable_modifiers = self._variable_modifiers
         for variable, value in modifiers_aggregate.items():
             new._variable_modifiers[variable] = (
                 str(value) if isinstance(value, Operator) else value

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -203,7 +203,7 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
         return new
 
     def with_expansion(
-        self, expansion: Optional[Type[ExpansionAlgorithm]] = None
+        self, expansion: Optional[ExpansionAlgorithm] = None
     ) -> SimpleModelicaExperimentDefinition:
         """Sets the expansion algorithm for an experiment.
 

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from modelon.impact.client.entities.interfaces.case import CaseInterface
 from modelon.impact.client.entities.interfaces.experiment import ExperimentInterface
@@ -150,7 +150,7 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
         self._initialize_from = initialize_from
         self._variable_modifiers: Dict[str, Any] = {}
         self._extensions: List[SimpleExperimentExtension] = []
-        self._expansion = FullFactorial()
+        self._expansion: ExpansionAlgorithm = FullFactorial()
 
     def validate(self) -> None:
         raise NotImplementedError(
@@ -227,7 +227,7 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
                 f"The expansion argument is of type '{type(expansion)}' "
                 "which is not a subtype of 'ExpansionAlgorithm'!"
             )
-        expansion = expansion or FullFactorial()
+        new_expansion = expansion or FullFactorial()
         new = SimpleModelicaExperimentDefinition(
             model=self._model,
             custom_function=self._custom_function,
@@ -243,7 +243,7 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
             initialize_from=self._initialize_from,
         )
         new._extensions = self._extensions
-        new._expansion = expansion
+        new._expansion = new_expansion
         new._variable_modifiers = self._variable_modifiers
         return new
 

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -201,6 +201,7 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
         )
         new._extensions = self._extensions
         new._expansion = self._expansion
+        new._variable_modifiers = self._variable_modifiers
 
         for name, value in modifiers.items():
             new._variable_modifiers[name] = ensure_as_modifier(value)

--- a/modelon/impact/client/experiment_definition/modifiers.py
+++ b/modelon/impact/client/experiment_definition/modifiers.py
@@ -1,5 +1,8 @@
+import abc
 import enum
-from typing import Union
+from typing import Any, Union
+
+from modelon.impact.client.configuration import get_client_experiments_v3_experimental
 
 Scalar = Union[bool, int, float, str]
 
@@ -9,6 +12,40 @@ class DataType(enum.Enum):
     INTEGER = "INTEGER"
     REAL = "REAL"
     STRING = "STRING"
+    ENUMERATION = "ENUMERATION"
+
+
+class Modifier(abc.ABC):
+    @abc.abstractmethod
+    def to_dict(self, name: str) -> dict[str, Any]:
+        """Returns a dict representation of the modifier."""
+
+    @abc.abstractmethod
+    def to_value(self) -> Scalar:
+        """Returns a single scalar representing the modifier, operators are serialized
+        as strings."""
+
+
+class ValueModifier(Modifier):
+    def __init__(self, value: Scalar, data_type: DataType) -> None:
+        self.value = value
+        self.data_type = data_type
+
+    def to_dict(self, name: str) -> dict[str, Any]:
+        return {
+            "kind": "value",
+            "name": name,
+            "value": self.value,
+            "dataType": self.data_type.value,
+        }
+
+    def to_value(self) -> Scalar:
+        return self.value
+
+
+class Enumeration(ValueModifier):
+    def __init__(self, value: str) -> None:
+        super().__init__(value, DataType.ENUMERATION)
 
 
 def data_type_from_value(value: Scalar) -> DataType:
@@ -22,3 +59,17 @@ def data_type_from_value(value: Scalar) -> DataType:
         return DataType.STRING
 
     raise ValueError(f"Unsupported type for modifier value {value}")
+
+
+def ensure_as_modifier(value: Union[Scalar, Modifier]) -> Modifier:
+    if isinstance(value, Modifier):
+        return value
+
+    return ValueModifier(value, data_type_from_value(value))
+
+
+def modifiers_to_dict(variable_modifiers: dict[str, Modifier]) -> Any:
+    if get_client_experiments_v3_experimental():
+        return [m.to_dict(name) for name, m in variable_modifiers.items()]
+    else:
+        return {name: m.to_value() for name, m in variable_modifiers.items()}

--- a/modelon/impact/client/experiment_definition/modifiers.py
+++ b/modelon/impact/client/experiment_definition/modifiers.py
@@ -1,0 +1,24 @@
+import enum
+from typing import Union
+
+Scalar = Union[bool, int, float, str]
+
+
+class DataType(enum.Enum):
+    BOOLEAN = "BOOLEAN"
+    INTEGER = "INTEGER"
+    REAL = "REAL"
+    STRING = "STRING"
+
+
+def data_type_from_value(value: Scalar) -> DataType:
+    if isinstance(value, bool):
+        return DataType.BOOLEAN
+    elif isinstance(value, int):
+        return DataType.INTEGER
+    elif isinstance(value, float):
+        return DataType.REAL
+    elif isinstance(value, str):
+        return DataType.STRING
+
+    raise ValueError(f"Unsupported type for modifier value {value}")

--- a/modelon/impact/client/experiment_definition/operators.py
+++ b/modelon/impact/client/experiment_definition/operators.py
@@ -122,7 +122,7 @@ class Beta(Operator):
     beta: float
 
     def __str__(self) -> str:
-        return f"beta({self.alpha},{self.alpha})"
+        return f"beta({self.alpha},{self.beta})"
 
 
 @dataclass

--- a/modelon/impact/client/experiment_definition/util.py
+++ b/modelon/impact/client/experiment_definition/util.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
+from modelon.impact.client.configuration import get_client_experiments_v3_experimental
 from modelon.impact.client.options import BaseExecutionOptions
 
 if TYPE_CHECKING:
@@ -23,3 +24,12 @@ def case_to_identifier_dict(case: Case) -> Dict[str, Any]:
         "caseId": case.id,
         "experimentId": case.experiment_id,
     }
+
+
+def custom_function_parameters_to_dict(parameter_values: dict[str, Any]) -> Any:
+    if get_client_experiments_v3_experimental():
+        return [
+            {"name": name, "value": value} for name, value in parameter_values.items()
+        ]
+    else:
+        return parameter_values

--- a/modelon/impact/client/sal/workspace.py
+++ b/modelon/impact/client/sal/workspace.py
@@ -1,6 +1,7 @@
 """Workspace service module."""
 from typing import Any, Dict, List, Optional
 
+from modelon.impact.client.configuration import get_client_experiments_v3_experimental
 from modelon.impact.client.sal.http import HTTPClient
 from modelon.impact.client.sal.uri import URI
 
@@ -9,6 +10,10 @@ class WorkspaceService:
     def __init__(self, uri: URI, http_client: HTTPClient):
         self._base_uri = uri
         self._http_client = http_client
+        if get_client_experiments_v3_experimental():
+            self._experiment_schema = "application/vnd.impact.experiment.v3+json"
+        else:
+            self._experiment_schema = "application/vnd.impact.experiment.v2+json"
 
     def workspace_create(self, name: str) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspaces").resolve()
@@ -120,7 +125,7 @@ class WorkspaceService:
             / f"api/workspaces/{workspace_id}/experiments{class_path_query}"
         ).resolve()
         return self._http_client.get_json(
-            url, headers={"Accept": "application/vnd.impact.experiment.v2+json"}
+            url, headers={"Accept": self._experiment_schema}
         )
 
     def experiment_get(self, workspace_id: str, experiment_id: str) -> Dict[str, Any]:
@@ -129,7 +134,7 @@ class WorkspaceService:
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}"
         ).resolve()
         return self._http_client.get_json(
-            url, headers={"Accept": "application/vnd.impact.experiment.v2+json"}
+            url, headers={"Accept": self._experiment_schema}
         )
 
     def experiment_create(

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,2 @@
-[mypy]
-python_version = 3.7
-
 [mypy-typer.*]
 ignore_missing_imports = True

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -1221,6 +1221,30 @@ class TestSimpleModelicaExperimentDefinition:
             },
         ]
 
+    def test_model_experiment_definition_with_many_modifiers(
+        self, model, custom_function_no_param
+    ):
+        definition = (
+            SimpleModelicaExperimentDefinition(
+                model.entity, custom_function=custom_function_no_param
+            )
+            .with_modifiers({"p1": 1})
+            .with_modifiers({"p2": 2})
+        )
+        modifiers_dict = definition.to_dict()["experiment"]["base"]["modifiers"]
+        assert modifiers_dict["variables"] == {"p1": 1, "p2": 2}
+
+    def test_fmu_experiment_definition_with_many_modifiers(
+        self, fmu, custom_function_no_param
+    ):
+        definition = (
+            SimpleFMUExperimentDefinition(fmu, custom_function=custom_function_no_param)
+            .with_modifiers({"p1": 1})
+            .with_modifiers({"p2": 2})
+        )
+        modifiers_dict = definition.to_dict()["experiment"]["base"]["modifiers"]
+        assert modifiers_dict["variables"] == {"p1": 1, "p2": 2}
+
     def test_experiment_definition_with_extensions_initialize_from_result(self):
         ext = SimpleExperimentExtension()
         pytest.raises(TypeError, ext.with_initialize_from, Result)

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -17,6 +17,7 @@ from modelon.impact.client import (
     exceptions,
 )
 from modelon.impact.client.entities.result import Result
+from modelon.impact.client.experiment_definition.modifiers import DataType
 from tests.impact.client.helpers import (
     IDs,
     create_case_entity,
@@ -1084,6 +1085,31 @@ class TestSimpleModelicaExperimentDefinition:
             "h0": "range(0.1,0.5,3)",
             "v": "choices(0.1, 0.5, 3)",
         }
+
+    def test_given_str_and_bool_when_choices_then_type_error(self):
+        with pytest.raises(ValueError):
+            Choices("test", True)
+
+    def test_given_int_and_real_when_choices_then_type_real(self):
+        assert Choices(1, 2.3).data_type == DataType.REAL
+
+    def test_given_real_and_int_when_choices_then_type_real(self):
+        assert Choices(2.3, 1).data_type == DataType.REAL
+
+    def test_given_real_int_and_bool_when_choices_then_type_error(self):
+        with pytest.raises(ValueError):
+            Choices(2.3, 1, False)
+
+    def test_given_int_and_real_data_type_set_to_real_when_choices_then_type_real(
+        self,
+    ):
+        assert Choices(2.3, 1, data_type=DataType.REAL).data_type == DataType.REAL
+
+    def test_given_int_and_real_data_type_set_to_integer_when_choices_then_type_error(
+        self,
+    ):
+        with pytest.raises(ValueError):
+            assert Choices(1, 2.3, data_type=DataType.INTEGER)
 
     def test_experiment_definition_with_distribution_modifier(
         self, model, custom_function_no_param

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -1096,7 +1096,7 @@ class TestSimpleModelicaExperimentDefinition:
         config = definition.to_dict()
         assert config["experiment"]["base"]["modifiers"]["variables"] == {
             "h0": "uniform(0.1,0.5)",
-            "v": "beta(0.1,0.1)",
+            "v": "beta(0.1,0.5)",
             "t": "normal(0.1,0.5,-5,inf)",
         }
 


### PR DESCRIPTION
:warning: :warning: :warning: It is recommended to review commit by commit   :warning: :warning: :warning:

This MR fixes a few bugs found during development (initial fix commits). It adds type consistency checking for the 'choices' operator and adds an experimental mode using V3 of experiment definition.

For testing the experimental V3 functionality:
 * Spin up latest impact locally
 * Create a workspace test-v3
 * Import the library [dataTypes.txt](https://github.com/modelon-community/impact-client-python/files/14744034/dataTypes.txt) (rename file from `.txt` -> `.mo`)
 * Run a script like:
```
import os

from modelon.impact.client import Client
from modelon.impact.client.experiment_definition.modifiers import Enumeration
from modelon.impact.client.experiment_definition.operators import Choices

os.environ["IMPACT_PYTHON_CLIENT_V3_EXPERIMENTS"] = "true"

c = Client(url='http://localhost:8888/impact', interactive=True)
w = c.get_workspace_by_name("test-v3")[0]

dynamic = w.get_custom_function("dynamic")
m = w.get_model("dataTypes.A")
exp_def = (
    m.new_experiment_definition(dynamic)
    .with_modifiers({"e": Enumeration("dataTypes.Enumeration.alt1")})
    .with_modifiers({"i": Choices(1, 2, 3)})
)
res = w.execute(exp_def).wait()
res.get_cases()[0].get_log().show()
for case in res.get_cases():
    print(case.get_trajectories()['i'][0])
    print(case.get_trajectories()['e'][0])
assert res.is_successful()


exp_def = m.new_experiment_definition(dynamic).with_modifiers(
    {"e": Enumeration("dataTypes.Enumeration.alt2")}
)
res = w.execute(exp_def).wait()
res.get_cases()[0].get_log().show()
print(res.get_cases()[0].get_trajectories()['e'][0])
assert res.is_successful()
```

Initial run with compilation and second run using cache should both work and set modifiers.