### PR TITLE
Fix fixture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SECRETS := $(CURDIR)/.secrets
 export MODELON_IMPACT_CLIENT_INTERACTIVE:=false
 export MODELON_IMPACT_CLIENT_API_KEY ?= $(shell cat $(SECRETS)/api.key)
 export JUPYTERHUB_API_TOKEN ?= $(shell cat $(SECRETS)/jupyterhub-api.key)
-export MODELON_IMPACT_CLIENT_URL ?= https://jhmi-staging.modelon.com/
+export MODELON_IMPACT_CLIENT_URL ?= https://impact.modelon.com/
 export MODELON_IMPACT_USERNAME ?= $(shell git config user.email)
 
 define _run

--- a/tests/impact/client/fixtures/fixtures.py
+++ b/tests/impact/client/fixtures/fixtures.py
@@ -2308,10 +2308,10 @@ def setup_client():
         os.environ["JUPYTERHUB_API_TOKEN"] = "dummy"
         os.environ["MODELON_IMPACT_USERNAME"] = IDs.MOCK_EMAIL
     client = Client()
-    assert (
-        client._sal.users.get_me()["data"]["username"].lower()
-        == os.environ.get("MODELON_IMPACT_USERNAME", "").lower()
-    )
+    assert client._sal.users.get_me()["data"]["username"].lower() in [
+        os.environ.get("MODELON_IMPACT_USERNAME", "").lower(),
+        IDs.MOCK_EMAIL,
+    ]
     _clean_workspace_and_its_projects(client)
     yield ClientHelper(client)
     _clean_workspace_and_its_projects(client)


### PR DESCRIPTION
This PR fixes a minor issue when a user tries regenerate cassettes for just a single test. In this case, although only the single test cassette is regenerated, the assert for username errors out as the user name doesn't match the one in cassettes