### PR TITLE
Remove redundant convenience methods

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,7 @@
+/*
+Fix for horizontal stacking weirdness in the RTD theme with Python properties:
+https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
+*/
+.py.property {
+    display: block !important;
+  }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,18 +15,18 @@ import sys
 
 import sphinx_rtd_theme
 
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath("../.."))
 
 # -- Project information -----------------------------------------------------
 
-project = 'Modelon-impact-client'
-copyright = '2020, Modelon'
-author = 'Modelon'
+project = "Modelon-impact-client"
+copyright = "2020, Modelon"
+author = "Modelon"
 
 # The full version, including alpha/beta/rc tags
 # TODO : Need to ensure version number is set correctly with the release bot.
-release = '1.0.0'
-master_doc = 'index'
+release = "1.0.0"
+master_doc = "index"
 
 # -- General configuration ---------------------------------------------------
 
@@ -34,21 +34,21 @@ master_doc = 'index'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx_rtd_theme",
-    'sphinx_copybutton',
-    'sphinx.ext.autosectionlabel',
-    'sphinx.ext.napoleon',
-    'sphinxcontrib.spelling',
-    'sphinx_search.extension',
-    'sphinx_autodoc_typehints',
+    "sphinx_copybutton",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.napoleon",
+    "sphinxcontrib.spelling",
+    "sphinx_search.extension",
+    "sphinx_autodoc_typehints",
 ]
 
 add_module_names = False
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -61,17 +61,17 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 html_theme_options = {
-    'style_nav_header_background': '#fb8c00',
+    "style_nav_header_background": "#fb8c00",
 }
 
 # The wordlist with known words, like Jupyterlab
 spelling_word_list_filename = "spelling_wordlist.txt"
 spelling_show_suggestions = True
 spelling_ignore_acronyms = True
-spelling_exclude_patterns = ['modelon.*']
+spelling_exclude_patterns = ["modelon.*"]
 
 # Enable google style docstrings
 napoleon_google_docstring = True
@@ -80,8 +80,9 @@ napoleon_google_docstring = True
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 
 suppress_warnings = [
-    'autosectionlabel.*'
+    "autosectionlabel.*"
 ]  # See https://github.com/sphinx-doc/sphinx/issues/7697

--- a/modelon/impact/client/entities/experiment.py
+++ b/modelon/impact/client/entities/experiment.py
@@ -37,8 +37,6 @@ from modelon.impact.client.options import (
 )
 
 if TYPE_CHECKING:
-    from modelon.impact.client.entities.model import CaseOrExperimentOrExternalResult
-    from modelon.impact.client.experiment_definition.extension import CaseOrExperiment
     from modelon.impact.client.operations.base import BaseOperation
     from modelon.impact.client.sal.service import Service
 
@@ -612,7 +610,7 @@ class Experiment(ExperimentInterface):
 
     def _get_initialize_from(
         self, modifiers: Dict[str, Any]
-    ) -> Optional[CaseOrExperimentOrExternalResult]:
+    ) -> Optional[Union[Case, Experiment, ExternalResult]]:
         if "initializeFrom" in modifiers:
             exp_id = modifiers["initializeFrom"]
             return self._get_initialize_from_experiment(exp_id)
@@ -627,7 +625,7 @@ class Experiment(ExperimentInterface):
 
     def _get_extension_initialize_from(
         self, modifiers: Dict[str, Any]
-    ) -> Optional[CaseOrExperiment]:
+    ) -> Optional[Union[Case, Experiment]]:
         if "initializeFrom" in modifiers:
             exp_id = modifiers["initializeFrom"]
             return self._get_initialize_from_experiment(exp_id)

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -39,7 +39,6 @@ from modelon.impact.client.sal.exceptions import HTTPError
 from modelon.impact.client.sal.service import Service
 
 if TYPE_CHECKING:
-    from modelon.impact.client.entities.experiment import ValidExperimentDefinitions
     from modelon.impact.client.operations.base import BaseOperation
 
 logger = logging.getLogger(__name__)
@@ -984,52 +983,6 @@ class Workspace(WorkspaceInterface):
             self._workspace_id, definition_as_dict, user_data
         )
         return Experiment(self._workspace_id, resp["experiment_id"], self._sal)
-
-    @Experimental
-    def create_experiment_definition_from_experiment_result(
-        self, experiment_id: str
-    ) -> ValidExperimentDefinitions:
-        """Creates an experiment definition that can be used to reproduce the results
-        with the experiment ID.
-
-        Args:
-            experiment_id: The ID of the experiment.
-
-        Returns:
-            An instance of SimpleFMUExperimentDefinition or
-            SimpleModelicaExperimentDefinition class.
-
-        Example::
-
-            definition = workspace.create_experiment_definition_from_experiment_result(
-                experiment_id)
-
-        """
-        experiment = self.get_experiment(experiment_id)
-        return experiment.get_definition()
-
-    @Experimental
-    def create_experiment_definition_from_case_result(
-        self, experiment_id: str, case_id: str
-    ) -> ValidExperimentDefinitions:
-        """Creates an experiment definition that can be used to reproduce the results
-        for a case.
-
-        Args:
-            experiment_id: The ID of the experiment.
-            case_id: The ID of the case.
-
-        Returns:
-            An instance of SimpleModelicaExperimentDefinition class.
-
-        Example::
-
-            definition = workspace.create_experiment_definition_from_case_result(
-                experiment_id, case_id)
-
-        """
-        case = self.get_experiment(experiment_id).get_case(case_id)
-        return case.get_definition()
 
     def execute(
         self,

--- a/modelon/impact/client/experiment_definition/extension.py
+++ b/modelon/impact/client/experiment_definition/extension.py
@@ -104,6 +104,31 @@ class SimpleExperimentExtension(BaseExperimentExtension):
         self._initialize_from = initialize_from
         self._case_label: Optional[str] = None
 
+    @property
+    def simulation_options(self) -> Dict[str, Any]:
+        "Returns the simulation options as a dict."
+        return self._simulation_options
+
+    @property
+    def solver_options(self) -> Dict[str, Any]:
+        "Returns the solver options as a dict."
+        return self._solver_options
+
+    @property
+    def simulation_log_level(self) -> Optional[str]:
+        "Returns the simulation log level, if set."
+        return self._simulation_log_level
+
+    @property
+    def modifiers(self) -> Dict[str, Any]:
+        "Returns the variable modifiers dict."
+        return self._variable_modifiers
+
+    @property
+    def case_label(self) -> Optional[str]:
+        "Returns the case label if any set."
+        return self._case_label
+
     def with_modifiers(
         self, modifiers: Optional[Dict[str, Any]] = None, **modifiers_kwargs: Any
     ) -> SimpleExperimentExtension:

--- a/modelon/impact/client/experiment_definition/extension.py
+++ b/modelon/impact/client/experiment_definition/extension.py
@@ -129,6 +129,11 @@ class SimpleExperimentExtension(BaseExperimentExtension):
         "Returns the case label if any set."
         return self._case_label
 
+    @property
+    def initialize_from(self) -> Optional[CaseOrExperiment]:
+        "Returns the case or experiment the experiment extension was initialized from."
+        return self._initialize_from
+
     def with_modifiers(
         self, modifiers: Optional[Dict[str, Any]] = None, **modifiers_kwargs: Any
     ) -> SimpleExperimentExtension:
@@ -206,10 +211,6 @@ class SimpleExperimentExtension(BaseExperimentExtension):
         new._case_label = case_label
 
         return new
-
-    @property
-    def initialize_from(self) -> Optional[CaseOrExperiment]:
-        return self._initialize_from
 
     def with_initialize_from(
         self, entity: Optional[CaseOrExperiment] = None

--- a/modelon/impact/client/experiment_definition/fmu_based.py
+++ b/modelon/impact/client/experiment_definition/fmu_based.py
@@ -111,38 +111,44 @@ class SimpleFMUExperimentDefinition(BaseExperimentDefinition):
 
     @property
     def fmu(self) -> ModelExecutable:
-        "Returns the ModelExecutable class."
+        """Returns the ModelExecutable class."""
         return self._fmu
 
     @property
     def modifiers(self) -> Dict[str, Any]:
-        "Returns the variable modifiers dict."
+        """Returns the variable modifiers dict."""
         return self._variable_modifiers
 
     @property
     def simulation_options(self) -> Dict[str, Any]:
-        "Returns the simulation options as a dict."
+        """Returns the simulation options as a dict."""
         return self._simulation_options
 
     @property
     def solver_options(self) -> Dict[str, Any]:
-        "Returns the solver options as a dict."
+        """Returns the solver options as a dict."""
         return self._solver_options
 
     @property
     def simulation_log_level(self) -> str:
-        "Returns the simulation log level."
+        """Returns the simulation log level."""
         return self._simulation_log_level
 
     @property
     def custom_function(self) -> CustomFunction:
-        "Returns the custom function class."
+        """Returns the custom function class."""
         return self._custom_function
 
     @property
     def extensions(self) -> List[SimpleExperimentExtension]:
-        "Returns the list of experiment extensions."
+        """Returns the list of experiment extensions."""
         return self._extensions
+
+    @property
+    def initialize_from(self) -> Optional[CaseOrExperimentOrExternalResult]:
+        """Returns the case, experiment or result the experiment definition was
+        initialized from."""
+        return self._initialize_from
 
     def validate(self) -> None:
         add = set(self._variable_modifiers.keys()) - set(
@@ -317,10 +323,6 @@ class SimpleFMUExperimentDefinition(BaseExperimentDefinition):
                 "initializeFromExternalResult"
             ] = self.initialize_from.id
         return exp_dict
-
-    @property
-    def initialize_from(self) -> Optional[CaseOrExperimentOrExternalResult]:
-        return self._initialize_from
 
     def with_initialize_from(
         self, entity: Optional[CaseOrExperimentOrExternalResult] = None

--- a/modelon/impact/client/experiment_definition/fmu_based.py
+++ b/modelon/impact/client/experiment_definition/fmu_based.py
@@ -109,6 +109,41 @@ class SimpleFMUExperimentDefinition(BaseExperimentDefinition):
         self._variable_modifiers = fmu._variable_modifiers()
         self._extensions: List[SimpleExperimentExtension] = []
 
+    @property
+    def fmu(self) -> ModelExecutable:
+        "Returns the ModelExecutable class."
+        return self._fmu
+
+    @property
+    def modifiers(self) -> Dict[str, Any]:
+        "Returns the variable modifiers dict."
+        return self._variable_modifiers
+
+    @property
+    def simulation_options(self) -> Dict[str, Any]:
+        "Returns the simulation options as a dict."
+        return self._simulation_options
+
+    @property
+    def solver_options(self) -> Dict[str, Any]:
+        "Returns the solver options as a dict."
+        return self._solver_options
+
+    @property
+    def simulation_log_level(self) -> str:
+        "Returns the simulation log level."
+        return self._simulation_log_level
+
+    @property
+    def custom_function(self) -> CustomFunction:
+        "Returns the custom function class."
+        return self._custom_function
+
+    @property
+    def extensions(self) -> List[SimpleExperimentExtension]:
+        "Returns the list of experiment extensions."
+        return self._extensions
+
     def validate(self) -> None:
         add = set(self._variable_modifiers.keys()) - set(
             self._fmu.get_settable_parameters()

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -160,73 +160,79 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
 
     @property
     def modifiers(self) -> Dict[str, Any]:
-        "Returns the variable modifiers dict."
+        """Returns the variable modifiers dict."""
         return self._variable_modifiers
 
     @property
     def model(self) -> Model:
-        "Returns the Model class."
+        """Returns the Model class."""
         return self._model
 
     @property
     def fmi_target(self) -> str:
-        "Returns the FMI target."
+        """Returns the FMI target."""
         return self._fmi_target
 
     @property
     def fmi_version(self) -> str:
-        "Returns the FMI version."
+        """Returns the FMI version."""
         return self._fmi_version
 
     @property
     def platform(self) -> str:
-        "Returns the platform to compile FMU for."
+        """Returns the platform to compile FMU for."""
         return self._platform
 
     @property
     def compiler_log_level(self) -> str:
-        "Returns the compiler log level."
+        """Returns the compiler log level."""
         return self._compiler_log_level
 
     @property
     def compiler_options(self) -> Dict[str, Any]:
-        "Returns the compiler options as a dict."
+        """Returns the compiler options as a dict."""
         return self._compiler_options
 
     @property
     def runtime_options(self) -> Dict[str, Any]:
-        "Returns the runtime options as a dict."
+        """Returns the runtime options as a dict."""
         return self._runtime_options
 
     @property
     def simulation_options(self) -> Dict[str, Any]:
-        "Returns the simulation options as a dict."
+        """Returns the simulation options as a dict."""
         return self._simulation_options
 
     @property
     def solver_options(self) -> Dict[str, Any]:
-        "Returns the solver options as a dict."
+        """Returns the solver options as a dict."""
         return self._solver_options
 
     @property
     def simulation_log_level(self) -> str:
-        "Returns the simulation log level."
+        """Returns the simulation log level."""
         return self._simulation_log_level
 
     @property
     def custom_function(self) -> CustomFunction:
-        "Returns the custom function class."
+        """Returns the custom function class."""
         return self._custom_function
 
     @property
     def extensions(self) -> List[SimpleExperimentExtension]:
-        "Returns the list of experiment extensions."
+        """Returns the list of experiment extensions."""
         return self._extensions
 
     @property
     def expansion(self) -> ExpansionAlgorithm:
-        "Returns the expansion algorithm class."
+        """Returns the expansion algorithm class."""
         return self._expansion
+
+    @property
+    def initialize_from(self) -> Optional[CaseOrExperimentOrExternalResult]:
+        """Returns the case, experiment or result the experiment definition was
+        initialized from."""
+        return self._initialize_from
 
     def validate(self) -> None:
         raise NotImplementedError(
@@ -321,10 +327,6 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
         new._expansion = new_expansion
         new._variable_modifiers = self._variable_modifiers
         return new
-
-    @property
-    def initialize_from(self) -> Optional[CaseOrExperimentOrExternalResult]:
-        return self._initialize_from
 
     def with_initialize_from(
         self, entity: Optional[CaseOrExperimentOrExternalResult] = None

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -158,6 +158,76 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
         self._extensions: List[SimpleExperimentExtension] = []
         self._expansion: ExpansionAlgorithm = FullFactorial()
 
+    @property
+    def modifiers(self) -> Dict[str, Any]:
+        "Returns the variable modifiers dict."
+        return self._variable_modifiers
+
+    @property
+    def model(self) -> Model:
+        "Returns the Model class."
+        return self._model
+
+    @property
+    def fmi_target(self) -> str:
+        "Returns the FMI target."
+        return self._fmi_target
+
+    @property
+    def fmi_version(self) -> str:
+        "Returns the FMI version."
+        return self._fmi_version
+
+    @property
+    def platform(self) -> str:
+        "Returns the platform to compile FMU for."
+        return self._platform
+
+    @property
+    def compiler_log_level(self) -> str:
+        "Returns the compiler log level."
+        return self._compiler_log_level
+
+    @property
+    def compiler_options(self) -> Dict[str, Any]:
+        "Returns the compiler options as a dict."
+        return self._compiler_options
+
+    @property
+    def runtime_options(self) -> Dict[str, Any]:
+        "Returns the runtime options as a dict."
+        return self._runtime_options
+
+    @property
+    def simulation_options(self) -> Dict[str, Any]:
+        "Returns the simulation options as a dict."
+        return self._simulation_options
+
+    @property
+    def solver_options(self) -> Dict[str, Any]:
+        "Returns the solver options as a dict."
+        return self._solver_options
+
+    @property
+    def simulation_log_level(self) -> str:
+        "Returns the simulation log level."
+        return self._simulation_log_level
+
+    @property
+    def custom_function(self) -> CustomFunction:
+        "Returns the custom function class."
+        return self._custom_function
+
+    @property
+    def extensions(self) -> List[SimpleExperimentExtension]:
+        "Returns the list of experiment extensions."
+        return self._extensions
+
+    @property
+    def expansion(self) -> ExpansionAlgorithm:
+        "Returns the expansion algorithm class."
+        return self._expansion
+
     def validate(self) -> None:
         raise NotImplementedError(
             "Validation is not supported for SimpleModelicaExperimentDefinition class"

--- a/tests/impact/client/entities/test_workspace.py
+++ b/tests/impact/client/entities/test_workspace.py
@@ -600,9 +600,9 @@ class TestWorkspace:
         )
         experiment = workspace.create_experiment(experiment_definition)
 
-        definition_dict = workspace.create_experiment_definition_from_experiment_result(
-            experiment.id
-        ).to_dict()
+        definition_dict = (
+            workspace.get_experiment(experiment.id).get_definition().to_dict()
+        )
         expected_definition_dict = experiment_definition.to_dict()
         assert definition_dict == expected_definition_dict
 
@@ -615,9 +615,9 @@ class TestWorkspace:
             .with_initialize_from(case_for_init)
         )
         experiment = workspace.create_experiment(experiment_definition)
-        definition_dict = workspace.create_experiment_definition_from_experiment_result(
-            experiment.id
-        ).to_dict()
+        definition_dict = (
+            workspace.get_experiment(experiment.id).get_definition().to_dict()
+        )
         expected_definition_dict = experiment_definition.to_dict()
         assert definition_dict == expected_definition_dict
 
@@ -666,9 +666,9 @@ class TestWorkspace:
         )
         experiment = workspace.create_experiment(experiment_definition)
 
-        definition_dict = workspace.create_experiment_definition_from_experiment_result(
-            experiment.id
-        ).to_dict()
+        definition_dict = (
+            workspace.get_experiment(experiment.id).get_definition().to_dict()
+        )
         expected_definition_dict = experiment_definition.to_dict()
         assert definition_dict == expected_definition_dict
 
@@ -680,9 +680,9 @@ class TestWorkspace:
             .with_initialize_from(case_for_init)
         )
         experiment = workspace.create_experiment(experiment_definition)
-        definition_dict = workspace.create_experiment_definition_from_experiment_result(
-            experiment.id
-        ).to_dict()
+        definition_dict = (
+            workspace.get_experiment(experiment.id).get_definition().to_dict()
+        )
         expected_definition_dict = experiment_definition.to_dict()
         assert definition_dict == expected_definition_dict
 
@@ -705,9 +705,11 @@ class TestWorkspace:
         experiment = workspace.execute(experiment_definition).wait()
         case = experiment.get_case(IDs.CASE_ID_PRIMARY)
 
-        definition_dict = workspace.create_experiment_definition_from_case_result(
-            experiment.id, case.id
-        ).to_dict()
+        definition = (
+            workspace.get_experiment(experiment.id).get_case(case.id).get_definition()
+        )
+        definition_dict = definition.to_dict()
+
         expected_definition_dict = experiment_definition.to_dict()
         expected_definition_dict["experiment"]["base"]["modifiers"]["variables"][
             "PI.yMax"


### PR DESCRIPTION
This MR removes the experimental convenience methods as discussed here - https://github.com/modelon-community/impact-client-python/pull/275. Also it exposes some of the internal variables in Experiment definition classes as properties