### PR TITLE
FileURI support

### DIFF
--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -52,3 +52,4 @@ modelexecutableruninfo
 PublishedWorkspaceUploadStatus
 userspace
 sys
+netloc

--- a/modelon/impact/client/entities/case.py
+++ b/modelon/impact/client/entities/case.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import logging
-import os
-import tempfile
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Text, Tuple, Union
 
 from modelon.impact.client import exceptions
 from modelon.impact.client.entities.asserts import assert_successful_operation
+from modelon.impact.client.entities.custom_artifact import CustomArtifact
 from modelon.impact.client.entities.custom_function import CustomFunction
 from modelon.impact.client.entities.external_result import ExternalResult
 from modelon.impact.client.entities.interfaces.case import CaseReference
@@ -24,7 +23,6 @@ from modelon.impact.client.operations.case import CaseOperation
 from modelon.impact.client.sal.experiment import ResultFormat
 
 if TYPE_CHECKING:
-    from modelon.impact.client.sal.experiment import ExperimentService
     from modelon.impact.client.sal.service import Service
 
 logger = logging.getLogger(__name__)
@@ -207,85 +205,6 @@ class CaseAnalysis:
     @simulation_log_level.setter
     def simulation_log_level(self, simulation_log_level: str) -> None:
         self._analysis["simulation_log_level"] = simulation_log_level
-
-
-class CustomArtifact:
-    """CustomArtifact class."""
-
-    def __init__(
-        self,
-        workspace_id: str,
-        experiment_id: str,
-        case_id: str,
-        artifact_id: str,
-        download_as: str,
-        exp_sal: ExperimentService,
-    ):
-        self._workspace_id = workspace_id
-        self._exp_id = experiment_id
-        self._case_id = case_id
-        self._artifact_id = artifact_id
-        self._download_as = download_as
-        self._exp_sal = exp_sal
-
-    @property
-    def id(self) -> str:
-        """Id of the custom artifact."""
-        return self._artifact_id
-
-    @property
-    def download_as(self) -> str:
-        """File name for the downloaded artifact."""
-        return self._download_as
-
-    def download(self, path: Optional[str] = None) -> str:
-        """Downloads a custom artifact. Returns the local path to the downloaded
-        artifact.
-
-        Args:
-            path: The local path to the directory to store the downloaded custom
-                artifact. Default: None. If no path is given, custom artifact
-                will be downloaded in a temporary directory.
-
-        Returns:
-            path: Local path to the downloaded custom artifact.
-
-        Example::
-
-            artifact_path = artifact.download()
-            artifact_path = artifact.download('/home/Downloads')
-
-        """
-        artifact, _ = self._exp_sal.case_artifact_get(
-            self._workspace_id, self._exp_id, self._case_id, self.id
-        )
-        if path is None:
-            path = os.path.join(tempfile.gettempdir(), "impact-downloads")
-        os.makedirs(path, exist_ok=True)
-        artifact_path = os.path.join(path, self.download_as)
-        with open(artifact_path, mode="wb") as f:
-            f.write(artifact)
-        return artifact_path
-
-    def get_data(self) -> Union[Text, bytes]:
-        """Returns the custom artifact stream.
-
-        Returns:
-            artifact: The artifact byte stream.
-
-        Example::
-
-            artifact = case.get_artifact("ABCD")
-            data = artifact.get_data() # may raise exception on communication error
-            with open(artifact.download_as, "wb") as f:
-                f.write(data)
-
-        """
-        result_stream, _ = self._exp_sal.case_artifact_get(
-            self._workspace_id, self._exp_id, self._case_id, self.id
-        )
-
-        return result_stream
 
 
 class CaseMeta:

--- a/modelon/impact/client/entities/case.py
+++ b/modelon/impact/client/entities/case.py
@@ -394,6 +394,7 @@ class Case(CaseReference):
         self._exp_id = exp_id
         self._sal = service
         self._info = info
+        super().__init__(case_id, workspace_id, exp_id, service, info)
 
     def __eq__(self, obj: object) -> bool:
         return isinstance(obj, Case) and obj._case_id == self._case_id

--- a/modelon/impact/client/entities/custom_artifact.py
+++ b/modelon/impact/client/entities/custom_artifact.py
@@ -1,0 +1,90 @@
+import os
+import tempfile
+from typing import Optional, Text, Union
+
+from modelon.impact.client.entities.interfaces.custom_artifact import (
+    CustomArtifactInterface,
+)
+from modelon.impact.client.sal.experiment import ExperimentService
+
+
+class CustomArtifact(CustomArtifactInterface):
+    """CustomArtifact class."""
+
+    def __init__(
+        self,
+        workspace_id: str,
+        experiment_id: str,
+        case_id: str,
+        artifact_id: str,
+        download_as: str,
+        exp_sal: ExperimentService,
+    ):
+        self._workspace_id = workspace_id
+        self._exp_id = experiment_id
+        self._case_id = case_id
+        self._artifact_id = artifact_id
+        self._download_as = download_as
+        self._exp_sal = exp_sal
+        super().__init__(
+            workspace_id, experiment_id, case_id, artifact_id, download_as, exp_sal
+        )
+
+    @property
+    def id(self) -> str:
+        """Id of the custom artifact."""
+        return self._artifact_id
+
+    @property
+    def download_as(self) -> str:
+        """File name for the downloaded artifact."""
+        return self._download_as
+
+    def download(self, path: Optional[str] = None) -> str:
+        """Downloads a custom artifact. Returns the local path to the downloaded
+        artifact.
+
+        Args:
+            path: The local path to the directory to store the downloaded custom
+                artifact. Default: None. If no path is given, custom artifact
+                will be downloaded in a temporary directory.
+
+        Returns:
+            path: Local path to the downloaded custom artifact.
+
+        Example::
+
+            artifact_path = artifact.download()
+            artifact_path = artifact.download('/home/Downloads')
+
+        """
+        artifact, _ = self._exp_sal.case_artifact_get(
+            self._workspace_id, self._exp_id, self._case_id, self.id
+        )
+        if path is None:
+            path = os.path.join(tempfile.gettempdir(), "impact-downloads")
+        os.makedirs(path, exist_ok=True)
+        artifact_path = os.path.join(path, self.download_as)
+        with open(artifact_path, mode="wb") as f:
+            f.write(artifact)
+        return artifact_path
+
+    def get_data(self) -> Union[Text, bytes]:
+        """Returns the custom artifact stream.
+
+        Returns:
+            artifact: The artifact byte stream.
+
+        Example::
+
+            artifact = case.get_artifact("ABCD")
+            data = artifact.get_data() # may raise exception on communication error
+            with open(artifact.download_as, "wb") as f:
+                f.write(data)
+
+        """
+        result_stream, _ = self._exp_sal.case_artifact_get(
+            self._workspace_id, self._exp_id, self._case_id, self.id
+        )
+
+        return result_stream

--- a/modelon/impact/client/entities/custom_artifact.py
+++ b/modelon/impact/client/entities/custom_artifact.py
@@ -2,6 +2,8 @@ import os
 import tempfile
 from typing import Optional, Text, Union
 
+from modelon.impact.client.configuration import Experimental
+from modelon.impact.client.entities.file_uri import CustomArtifactReference
 from modelon.impact.client.entities.interfaces.custom_artifact import (
     CustomArtifactInterface,
 )
@@ -88,3 +90,17 @@ class CustomArtifact(CustomArtifactInterface):
         )
 
         return result_stream
+
+    @Experimental
+    def get_uri(self) -> CustomArtifactReference:
+        """Returns a CustomArtifactReference class.
+
+        Returns:
+            The CustomArtifactReference class object.
+
+        Example::
+
+            artifact_file_uri = artifact.get_uri()
+
+        """
+        return CustomArtifactReference(self._exp_id, self._case_id, self._artifact_id)

--- a/modelon/impact/client/entities/custom_artifact.py
+++ b/modelon/impact/client/entities/custom_artifact.py
@@ -3,7 +3,7 @@ import tempfile
 from typing import Optional, Text, Union
 
 from modelon.impact.client.configuration import Experimental
-from modelon.impact.client.entities.file_uri import CustomArtifactReference
+from modelon.impact.client.entities.file_uri import CustomArtifactURI
 from modelon.impact.client.entities.interfaces.custom_artifact import (
     CustomArtifactInterface,
 )
@@ -92,15 +92,15 @@ class CustomArtifact(CustomArtifactInterface):
         return result_stream
 
     @Experimental
-    def get_uri(self) -> CustomArtifactReference:
-        """Returns a CustomArtifactReference class.
+    def get_uri(self) -> CustomArtifactURI:
+        """Returns a CustomArtifactURI class.
 
         Returns:
-            The CustomArtifactReference class object.
+            The CustomArtifactURI class object.
 
         Example::
 
             artifact_file_uri = artifact.get_uri()
 
         """
-        return CustomArtifactReference(self._exp_id, self._case_id, self._artifact_id)
+        return CustomArtifactURI(self._exp_id, self._case_id, self._artifact_id)

--- a/modelon/impact/client/entities/custom_function.py
+++ b/modelon/impact/client/entities/custom_function.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from modelon.impact.client.entities.file_uri import (
-    FileURI,
-    get_resource_reference_from_str,
-)
+from modelon.impact.client.entities.file_uri import FileURI, get_resource_URI_from_str
 from modelon.impact.client.entities.interfaces.case import CaseInterface, CaseReference
 from modelon.impact.client.entities.interfaces.custom_function import (
     CustomFunctionInterface,
@@ -165,7 +162,7 @@ class CustomFunction(CustomFunctionInterface):
                     case_id, self._workspace_id, experiment_id, self._sal, case_info
                 )
             elif parameter.type == "FileURI" and isinstance(value, str):
-                parameter.value = get_resource_reference_from_str(value)
+                parameter.value = get_resource_URI_from_str(value)
             else:
                 parameter.value = value
 

--- a/modelon/impact/client/entities/custom_function.py
+++ b/modelon/impact/client/entities/custom_function.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from modelon.impact.client.entities.file_uri import (
+    FileURI,
+    get_resource_reference_from_str,
+)
 from modelon.impact.client.entities.interfaces.case import CaseInterface, CaseReference
 from modelon.impact.client.entities.interfaces.custom_function import (
     CustomFunctionInterface,
@@ -38,6 +42,7 @@ class _Parameter:
         "Enumeration": (str,),
         "CaseResult": (CaseInterface,),
         "ExperimentResult": (ExperimentInterface,),
+        "FileURI": (FileURI,),
     }
 
     def __init__(self, name: str, value: Any, value_type: str, valid_values: List[Any]):
@@ -81,6 +86,8 @@ class ParameterDict(dict):
                 new_dict[key] = value.id
             elif isinstance(value, CaseInterface):
                 new_dict[key] = f"{value.experiment_id}/{value.id}"
+            elif isinstance(value, FileURI):
+                new_dict[key] = str(value)
             else:
                 new_dict[key] = value
         return new_dict
@@ -157,6 +164,8 @@ class CustomFunction(CustomFunctionInterface):
                 parameter.value = CaseReference(
                     case_id, self._workspace_id, experiment_id, self._sal, case_info
                 )
+            elif parameter.type == "FileURI" and isinstance(value, str):
+                parameter.value = get_resource_reference_from_str(value)
             else:
                 parameter.value = value
 

--- a/modelon/impact/client/entities/file_uri.py
+++ b/modelon/impact/client/entities/file_uri.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import enum
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Union
+from urllib.parse import urlparse
+
+from typing_extensions import assert_never
+
+
+@enum.unique
+class URISchema(enum.Enum):
+    """Supported Version Control System services."""
+
+    MODELICA = "MODELICA"
+    IMPACT_ARTIFACT = "IMPACT-ARTIFACT"
+
+    @classmethod
+    def from_str(cls, value: str) -> URISchema:
+        for member in cls:
+            if member.value == value.upper():
+                return member
+        raise ValueError(f"Incorrect schema in URI: {value!r}")
+
+
+@dataclass
+class URI:
+    schema: URISchema
+    netloc: str
+    path: str
+
+    @classmethod
+    def from_str(cls, uri_str: str) -> URI:
+        """Parse URI str into this class instance.
+
+        Args:
+            uri_str (str): <scheme>://<netloc>/<path>
+
+        Returns:
+            URI: This class instance.
+
+        """
+        parsed_url = urlparse(uri_str)
+        netloc = parsed_url.netloc
+        scheme = parsed_url.scheme
+        path = parsed_url.path.lstrip("/")
+        uri_schema = URISchema.from_str(scheme)
+        return cls(uri_schema, netloc, path)
+
+    def __str__(self) -> str:
+        return f"{self.schema.value.lower()}://{self.netloc}/{self.path}"
+
+
+class FileURI(ABC):
+    def __str__(self) -> str:
+        return str(self.uri)
+
+    @property
+    @abstractmethod
+    def uri(self) -> URI:
+        """URI class."""
+        raise NotImplementedError
+
+
+class ModelicaResourceReference(FileURI):
+    def __init__(self, library: str, resource_path: str) -> None:
+        self._library = library
+        self._resource_path = resource_path
+
+    @property
+    def uri(self) -> URI:
+        return URI.from_str(f"modelica://{self._library}/{self._resource_path}")
+
+    @classmethod
+    def from_uri(cls, uri: URI) -> ModelicaResourceReference:
+        return cls(uri.netloc, uri.path)
+
+
+class CustomArtifactReference(FileURI):
+    def __init__(self, experiment_id: str, case_id: str, artifact_id: str) -> None:
+        self._experiment_id = experiment_id
+        self._case_id = case_id
+        self._artifact_id = artifact_id
+
+    @property
+    def uri(self) -> URI:
+        return URI.from_str(
+            f"impact-artifact://workspace/{self._experiment_id}/{self._case_id}/"
+            f"{self._artifact_id}"
+        )
+
+    @classmethod
+    def from_uri(cls, uri: URI) -> CustomArtifactReference:
+        experiment_id, case_id, artifact_id = uri.path.split("/")
+        return cls(experiment_id, case_id, artifact_id)
+
+
+def get_resource_reference_from_str(
+    uri_str: str,
+) -> Union[ModelicaResourceReference, CustomArtifactReference]:
+    file_uri = URI.from_str(uri_str)
+    if file_uri.schema == URISchema.MODELICA:
+        return ModelicaResourceReference.from_uri(file_uri)
+    elif file_uri.schema == URISchema.IMPACT_ARTIFACT:
+        return CustomArtifactReference.from_uri(file_uri)
+    else:
+        assert_never(file_uri.schema)

--- a/modelon/impact/client/entities/file_uri.py
+++ b/modelon/impact/client/entities/file_uri.py
@@ -63,7 +63,7 @@ class FileURI(ABC):
         raise NotImplementedError
 
 
-class ModelicaResourceReference(FileURI):
+class ModelicaResourceURI(FileURI):
     def __init__(self, library: str, resource_path: str) -> None:
         self._library = library
         self._resource_path = resource_path
@@ -73,11 +73,11 @@ class ModelicaResourceReference(FileURI):
         return URI.from_str(f"modelica://{self._library}/{self._resource_path}")
 
     @classmethod
-    def from_uri(cls, uri: URI) -> ModelicaResourceReference:
+    def from_uri(cls, uri: URI) -> ModelicaResourceURI:
         return cls(uri.netloc, uri.path)
 
 
-class CustomArtifactReference(FileURI):
+class CustomArtifactURI(FileURI):
     def __init__(self, experiment_id: str, case_id: str, artifact_id: str) -> None:
         self._experiment_id = experiment_id
         self._case_id = case_id
@@ -91,18 +91,18 @@ class CustomArtifactReference(FileURI):
         )
 
     @classmethod
-    def from_uri(cls, uri: URI) -> CustomArtifactReference:
+    def from_uri(cls, uri: URI) -> CustomArtifactURI:
         experiment_id, case_id, artifact_id = uri.path.split("/")
         return cls(experiment_id, case_id, artifact_id)
 
 
-def get_resource_reference_from_str(
+def get_resource_URI_from_str(
     uri_str: str,
-) -> Union[ModelicaResourceReference, CustomArtifactReference]:
+) -> Union[ModelicaResourceURI, CustomArtifactURI]:
     file_uri = URI.from_str(uri_str)
     if file_uri.schema == URISchema.MODELICA:
-        return ModelicaResourceReference.from_uri(file_uri)
+        return ModelicaResourceURI.from_uri(file_uri)
     elif file_uri.schema == URISchema.IMPACT_ARTIFACT:
-        return CustomArtifactReference.from_uri(file_uri)
+        return CustomArtifactURI.from_uri(file_uri)
     else:
         assert_never(file_uri.schema)

--- a/modelon/impact/client/entities/interfaces/custom_artifact.py
+++ b/modelon/impact/client/entities/interfaces/custom_artifact.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from modelon.impact.client.sal.experiment import ExperimentService
+
+
+class CustomArtifactInterface(ABC):
+    def __init__(
+        self,
+        workspace_id: str,
+        experiment_id: str,
+        case_id: str,
+        artifact_id: str,
+        download_as: str,
+        exp_sal: ExperimentService,
+    ):
+        self._workspace_id = workspace_id
+        self._exp_id = experiment_id
+        self._case_id = case_id
+        self._artifact_id = artifact_id
+        self._download_as = download_as
+        self._exp_sal = exp_sal
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        """Custom artifact id."""
+        raise NotImplementedError

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -11,7 +11,7 @@ from modelon.impact.client.configuration import Experimental
 from modelon.impact.client.entities.custom_function import CustomFunction
 from modelon.impact.client.entities.experiment import Experiment
 from modelon.impact.client.entities.external_result import ExternalResult
-from modelon.impact.client.entities.file_uri import ModelicaResourceReference
+from modelon.impact.client.entities.file_uri import ModelicaResourceURI
 from modelon.impact.client.entities.interfaces.workspace import WorkspaceInterface
 from modelon.impact.client.entities.model import Model
 from modelon.impact.client.entities.model_executable import ModelExecutable
@@ -1276,20 +1276,20 @@ class Workspace(WorkspaceInterface):
         )
 
     @Experimental
-    def get_modelica_resource_reference(
+    def get_modelica_resource_uri(
         self, library: str, resource_path: str
-    ) -> ModelicaResourceReference:
-        """Returns a ModelicaResourceReference class.
+    ) -> ModelicaResourceURI:
+        """Returns a ModelicaResourceURI class.
 
         Returns:
-            The ModelicaResourceReference class object.
+            The ModelicaResourceURI class object.
 
         Example::
 
-            modelica_resource_ref = workspace.get_modelica_resource_reference(
+            modelica_resource_ref = workspace.get_modelica_resource_uri(
                 library,
                 resource_path
             )
 
         """
-        return ModelicaResourceReference(library=library, resource_path=resource_path)
+        return ModelicaResourceURI(library=library, resource_path=resource_path)

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -11,6 +11,7 @@ from modelon.impact.client.configuration import Experimental
 from modelon.impact.client.entities.custom_function import CustomFunction
 from modelon.impact.client.entities.experiment import Experiment
 from modelon.impact.client.entities.external_result import ExternalResult
+from modelon.impact.client.entities.file_uri import ModelicaResourceReference
 from modelon.impact.client.entities.interfaces.workspace import WorkspaceInterface
 from modelon.impact.client.entities.model import Model
 from modelon.impact.client.entities.model_executable import ModelExecutable
@@ -1273,3 +1274,22 @@ class Workspace(WorkspaceInterface):
             definition=PublishedWorkspaceDefinition.from_dict(published_workspaces[0]),
             service=self._sal,
         )
+
+    @Experimental
+    def get_modelica_resource_reference(
+        self, library: str, resource_path: str
+    ) -> ModelicaResourceReference:
+        """Returns a ModelicaResourceReference class.
+
+        Returns:
+            The ModelicaResourceReference class object.
+
+        Example::
+
+            modelica_resource_ref = workspace.get_modelica_resource_reference(
+                library,
+                resource_path
+            )
+
+        """
+        return ModelicaResourceReference(library=library, resource_path=resource_path)

--- a/tests/impact/client/conftest.py
+++ b/tests/impact/client/conftest.py
@@ -288,6 +288,8 @@ def _custom_function_parameter_list():
         {"name": "p5", "defaultValue": 0.0, "type": "Number"},
         {"name": "p6", "defaultValue": "", "type": "ExperimentResult"},
         {"name": "p7", "defaultValue": "", "type": "CaseResult"},
+        {"name": "p8", "defaultValue": "", "type": "FileURI"},
+        {"name": "p9", "defaultValue": "", "type": "FileURI"},
     ]
 
 

--- a/tests/impact/client/entities/test_case.py
+++ b/tests/impact/client/entities/test_case.py
@@ -6,6 +6,7 @@ import pytest
 
 from modelon.impact.client import Range, exceptions
 from modelon.impact.client.entities.case import CaseStatus
+from modelon.impact.client.entities.file_uri import CustomArtifactURI
 from tests.impact.client.helpers import (
     ClientHelper,
     IDs,
@@ -259,6 +260,14 @@ class TestCase:
         assert resp == t
         artifact_stream = artifact.get_data()
         assert artifact_stream == b"\x00\x00\x00\x00"
+
+    @pytest.mark.experimental
+    def test_get_custom_artifact_uri(self, experiment):
+        case = experiment.entity.get_case(IDs.CASE_ID_PRIMARY)
+        artifact = case.get_artifact(IDs.CUSTOM_ARTIFACT_ID)
+        artifact_uri = artifact.get_uri()
+        assert isinstance(artifact_uri, CustomArtifactURI)
+        assert str(artifact_uri) == IDs.ARTIFACT_RESOURCE_URI
 
     def test_get_custom_artifact_with_download_as(self, experiment):
         case = experiment.entity.get_case(IDs.CASE_ID_PRIMARY)

--- a/tests/impact/client/entities/test_workspace.py
+++ b/tests/impact/client/entities/test_workspace.py
@@ -30,6 +30,7 @@ from tests.impact.client.helpers import (
     ClientHelper,
     IDs,
     create_published_workspace_entity,
+    create_workspace_entity,
 )
 
 
@@ -113,6 +114,15 @@ class TestPublishedWorkspace:
         service.workspace.revoke_group_access.assert_called_with(
             IDs.PUBLISHED_WORKSPACE_ID, IDs.GROUP_NAME
         )
+
+    @pytest.mark.experimental
+    def test_get_modelica_resource_uri(self):
+        service = mock.MagicMock()
+        workspace = create_workspace_entity(IDs.WORKSPACE_ID_PRIMARY, service=service)
+        uri = workspace.get_modelica_resource_uri(
+            library="Modelica", resource_path=IDs.MODELICA_RESOURCE_PATH
+        )
+        assert str(uri) == IDs.MODELICA_RESOURCE_URI
 
     def test_rename_published_workspace(self, publish_workspace):
         workspace = publish_workspace.entity

--- a/tests/impact/client/helpers.py
+++ b/tests/impact/client/helpers.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 from modelon.impact.client import Client, Range, SimpleModelicaExperimentDefinition
 from modelon.impact.client.entities.case import Case
+from modelon.impact.client.entities.custom_artifact import CustomArtifact
 from modelon.impact.client.entities.custom_function import CustomFunction
 from modelon.impact.client.entities.experiment import Experiment, _Workflow
 from modelon.impact.client.entities.external_result import ExternalResult
@@ -215,6 +216,12 @@ class IDs:
     FILTER_MODELICA_CLASS_PATH = "Modelica.Blocks.Examples.Filter"
     LOCAL_PROJECT_MODELICA_CLASS_PATH = "Test.PID"
     EXPERIMENT_LABEL = "EXPERIMENT_LABEL"
+    ARTIFACT_RESOURCE_URI = (
+        f"impact-artifact://workspace/{EXPERIMENT_ID_PRIMARY}/"
+        f"{CASE_ID_PRIMARY}/{CUSTOM_ARTIFACT_ID}"
+    )
+    MODELICA_RESOURCE_PATH = "Resources/Data/Electrical/Digital/Memory_Matrix.txt"
+    MODELICA_RESOURCE_URI = f"modelica://Modelica/{MODELICA_RESOURCE_PATH}"
 
 
 UNVERSIONED_PROJECT = {
@@ -515,6 +522,14 @@ def create_case_reference(workspace_id, case_id, exp_id, service=None, info=None
 def create_case_entity(case_id, workspace_id, exp_id, service=None, info=None):
     return Case(
         case_id, workspace_id, exp_id, service or MagicMock(), info or MagicMock()
+    )
+
+
+def create_custom_artifact_entity(
+    case_id, workspace_id, exp_id, artifact_id, download_as
+):
+    return CustomArtifact(
+        workspace_id, exp_id, case_id, artifact_id, download_as, exp_sal=MagicMock()
     )
 
 


### PR DESCRIPTION
This PR is a first cut implementation for FileURI data type support 
Code snippet to test
```
import os
os.environ["IMPACT_PYTHON_CLIENT_EXPERIMENTAL"] = "1"
from modelon.impact.client import Client
client = Client(url="https://jhmi-staging.modelon.com/", interactive=True)
workspace = client.get_workspace("arne")
uri_cf = workspace.get_custom_function('uri cf')
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")
modelica_resource_ref = workspace.get_modelica_resource_reference(
    "Modelica",
    resource_path ="Resources/Data/Electrical/Digital/Memory_Matrix.txt"
)
artifact = workspace.get_experiment("modelica_blocks_examples_pid_controller_20240530_130205_319ed9d").get_case('case_1').get_artifact('ABCD')
artifact_resource_ref = artifact.get_uri()
exp_def = model.new_experiment_definition(uri_cf.with_parameters(file_path=artifact_resource_ref))
exp = workspace.execute(exp_def).wait()
exp.get_case('case_1').get_log()

```