### PR TITLE
feat: added support for result import to case behind experimental flag

### DIFF
--- a/modelon/impact/client/entities/case.py
+++ b/modelon/impact/client/entities/case.py
@@ -21,6 +21,7 @@ from modelon.impact.client.entities.result import Result
 from modelon.impact.client.entities.status import CaseStatus
 from modelon.impact.client.operations.base import BaseOperation
 from modelon.impact.client.operations.case import CaseOperation
+from modelon.impact.client.operations.case_result import CaseResultImportOperation
 from modelon.impact.client.operations.custom_artifact import (
     CustomArtifactImportOperation,
 )
@@ -821,4 +822,41 @@ class Case(CaseReference):
             self._case_id,
             self._sal,
             CustomArtifact.from_operation,
+        )
+
+    @Experimental
+    def import_result(
+        self,
+        path_to_result: str,
+        overwrite: bool = False,
+    ) -> CaseResultImportOperation:
+        """Upload result to a case.
+
+        Args:
+
+            path_to_result: The path for the result to be imported. Only mat or csv
+                result file format is supported for import.
+            overwrite: Overwrite, if a result already exists
+                for the case. Default: False.
+
+
+        Example::
+
+            case.import_result('/home/test.csv').wait()
+
+        """
+        resp = self._sal.experiment.case_result_upload(
+            path_to_result,
+            self._workspace_id,
+            self._exp_id,
+            self._case_id,
+            overwrite,
+        )
+        return CaseResultImportOperation[Result](
+            resp["data"]["location"],
+            self._workspace_id,
+            self._exp_id,
+            self._case_id,
+            self._sal,
+            Result.from_operation,
         )

--- a/modelon/impact/client/entities/result.py
+++ b/modelon/impact/client/entities/result.py
@@ -4,6 +4,8 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List
 
 from modelon.impact.client.entities.asserts import assert_variable_in_result
+from modelon.impact.client.operations.base import BaseOperation
+from modelon.impact.client.operations.case_result import CaseResultImportOperation
 
 if TYPE_CHECKING:
     from modelon.impact.client.sal.experiment import ExperimentService
@@ -69,3 +71,8 @@ class Result(Mapping):
 
     def keys(self):  # type: ignore
         return self._variables
+
+    @classmethod
+    def from_operation(cls, operation: BaseOperation[Result], **kwargs: Any) -> Result:
+        assert isinstance(operation, CaseResultImportOperation)
+        return cls(**kwargs, service=operation._sal)

--- a/modelon/impact/client/operations/case_result.py
+++ b/modelon/impact/client/operations/case_result.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from modelon.impact.client import exceptions
+from modelon.impact.client.operations.base import (
+    AsyncOperation,
+    AsyncOperationStatus,
+    Entity,
+)
+
+if TYPE_CHECKING:
+    from modelon.impact.client.operations.base import EntityFromOperation
+    from modelon.impact.client.sal.service import Service
+
+
+class CaseResultImportOperation(AsyncOperation[Entity]):
+    """An operation class for the Result class."""
+
+    def __init__(
+        self,
+        location: str,
+        workspace_id: str,
+        exp_id: str,
+        case_id: str,
+        service: Service,
+        create_entity: EntityFromOperation,
+    ):
+        super().__init__(create_entity)
+        self._location = location
+        self._workspace_id = workspace_id
+        self._exp_id = exp_id
+        self._case_id = case_id
+        self._sal = service
+        self._create_entity = create_entity
+
+    def __repr__(self) -> str:
+        return f"Case result import operations for id '{self.id}'"
+
+    def __eq__(self, obj: object) -> bool:
+        return (
+            isinstance(obj, CaseResultImportOperation)
+            and obj._location == self._location
+        )
+
+    @property
+    def id(self) -> str:
+        """Case result import id."""
+        return self._location.split("/")[-1]
+
+    @property
+    def name(self) -> str:
+        """Return the name of operation."""
+        return "Case result import"
+
+    def _info(self) -> Dict[str, Any]:
+        return self._sal.imports.get_import_status(self._location)["data"]
+
+    def data(self) -> Entity:
+        """Returns a new Result class instance.
+
+        Returns:
+            A Result class instance.
+
+        """
+        info = self._info()
+        if info["status"] == AsyncOperationStatus.ERROR.value:
+            raise exceptions.IllegalContentImport(
+                f"Result import failed! Cause: {info['error'].get('message')}"
+            )
+        variables = self._sal.experiment.result_variables_get(
+            self._workspace_id, self._exp_id
+        )
+        return self._create_entity(
+            self,
+            variables=variables,
+            workspace_id=self._workspace_id,
+            exp_id=self._exp_id,
+            case_id=self._case_id,
+        )
+
+    @property
+    def status(self) -> AsyncOperationStatus:
+        """Returns the upload status as an enumeration.
+
+        Returns:
+            The AsyncOperationStatus enum. The status can have the enum values
+            AsyncOperationStatus.READY, AsyncOperationStatus.RUNNING or
+            AsyncOperationStatus.ERROR
+
+        Example::
+
+            case.import_result('path/to/result.csv').status
+
+        """
+        return AsyncOperationStatus(self._info()["status"])

--- a/modelon/impact/client/sal/experiment.py
+++ b/modelon/impact/client/sal/experiment.py
@@ -216,3 +216,24 @@ class ExperimentService:
                 "options": json.dumps(options),
             }
             return self._http_client.post_json(url, files=multipart_form_data)
+
+    def case_result_upload(
+        self,
+        path_to_result: str,
+        workspace_id: str,
+        experiment_id: str,
+        case_id: str,
+        overwrite: bool = False,
+    ) -> Dict[str, Any]:
+        url = (
+            self._base_uri
+            / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"
+            f"{case_id}/result-imports"
+        ).resolve()
+        options: Dict[str, Any] = {"overwrite": overwrite}
+        with open(path_to_result, "rb") as f:
+            multipart_form_data = {
+                "file": f,
+                "options": json.dumps(options),
+            }
+            return self._http_client.post_json(url, files=multipart_form_data)


### PR DESCRIPTION
**Jira** - https://modelonproducts.atlassian.net/browse/FLOW-523

**Code to test**

```
import os
os.environ["IMPACT_PYTHON_CLIENT_EXPERIMENTAL"] = "1"
from modelon.impact.client import Client

client = Client(url="http://localhost:8888/impact", interactive=True)
workspace = client.get_workspace("test")

# Choose analysis type
dynamic = workspace.get_custom_function('dynamic')

# Get model class
model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")

# Execute experiment
experiment_definition = model.new_experiment_definition(dynamic)
exp = workspace.execute(experiment_definition).wait()
case_1 = exp.get_case('case_1')
result = case_1.import_result('/home/akn/Downloads/Result.csv', overwrite=True).wait()
print(result.keys())
```