### PR TITLE
Single case vars

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -222,7 +222,7 @@ class Client:
 
     """
 
-    _SUPPORTED_VERSION_RANGE = ">=4.11.0,<5.0.0"
+    _SUPPORTED_VERSION_RANGE = ">=4.16.0,<5.0.0"
 
     def __init__(
         self,

--- a/modelon/impact/client/entities/case.py
+++ b/modelon/impact/client/entities/case.py
@@ -555,7 +555,7 @@ class Case(CaseReference):
         """
         _assert_case_is_complete(self.run_info.status, "Simulation")
         return Result(
-            self._sal.experiment.result_variables_get(self._workspace_id, self._exp_id),
+            self._sal.experiment.experiment_result_variables_get(self._workspace_id, self._exp_id),
             self._case_id,
             self._workspace_id,
             self._exp_id,

--- a/modelon/impact/client/entities/case.py
+++ b/modelon/impact/client/entities/case.py
@@ -555,11 +555,34 @@ class Case(CaseReference):
         """
         _assert_case_is_complete(self.run_info.status, "Simulation")
         return Result(
-            self._sal.experiment.experiment_result_variables_get(self._workspace_id, self._exp_id),
+            self._sal.experiment.case_result_variables_get(
+                self._workspace_id, self._exp_id, self._case_id
+            ),
             self._case_id,
             self._workspace_id,
             self._exp_id,
             self._sal,
+        )
+
+    @Experimental
+    def get_variables(self) -> List[str]:
+        """Returns a list of variables available in the result.
+
+        Returns:
+            An list of result variables.
+
+        Raises:
+            OperationNotCompleteError if simulation process is in progress.
+            OperationFailureError if simulation process has failed or was cancelled.
+
+        Example::
+
+            case.get_variables()
+
+        """
+        _assert_case_is_complete(self.run_info.status, "Simulation")
+        return self._sal.experiment.case_result_variables_get(
+            self._workspace_id, self._exp_id, self._case_id
         )
 
     def get_artifact(

--- a/modelon/impact/client/entities/experiment.py
+++ b/modelon/impact/client/entities/experiment.py
@@ -344,7 +344,7 @@ class Experiment(ExperimentReference):
 
         """
         _assert_experiment_is_complete(self.run_info.status, "Simulation")
-        return self._sal.experiment.result_variables_get(
+        return self._sal.experiment.experiment_result_variables_get(
             self._workspace_id, self._exp_id
         )
 

--- a/modelon/impact/client/operations/case_result.py
+++ b/modelon/impact/client/operations/case_result.py
@@ -68,8 +68,8 @@ class CaseResultImportOperation(AsyncOperation[Entity]):
             raise exceptions.IllegalContentImport(
                 f"Result import failed! Cause: {info['error'].get('message')}"
             )
-        variables = self._sal.experiment.experiment_result_variables_get(
-            self._workspace_id, self._exp_id
+        variables = self._sal.experiment.case_result_variables_get(
+            self._workspace_id, self._exp_id, self._case_id
         )
         return self._create_entity(
             self,

--- a/modelon/impact/client/operations/case_result.py
+++ b/modelon/impact/client/operations/case_result.py
@@ -68,7 +68,7 @@ class CaseResultImportOperation(AsyncOperation[Entity]):
             raise exceptions.IllegalContentImport(
                 f"Result import failed! Cause: {info['error'].get('message')}"
             )
-        variables = self._sal.experiment.result_variables_get(
+        variables = self._sal.experiment.experiment_result_variables_get(
             self._workspace_id, self._exp_id
         )
         return self._create_entity(

--- a/modelon/impact/client/sal/experiment.py
+++ b/modelon/impact/client/sal/experiment.py
@@ -68,7 +68,7 @@ class ExperimentService:
         ).resolve()
         return self._http_client.delete_json(url)
 
-    def result_variables_get(self, workspace_id: str, experiment_id: str) -> List[str]:
+    def experiment_result_variables_get(self, workspace_id: str, experiment_id: str) -> List[str]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/variables"

--- a/modelon/impact/client/sal/experiment.py
+++ b/modelon/impact/client/sal/experiment.py
@@ -68,10 +68,22 @@ class ExperimentService:
         ).resolve()
         return self._http_client.delete_json(url)
 
-    def experiment_result_variables_get(self, workspace_id: str, experiment_id: str) -> List[str]:
+    def experiment_result_variables_get(
+        self, workspace_id: str, experiment_id: str
+    ) -> List[str]:
         url = (
             self._base_uri
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/variables"
+        ).resolve()
+        return self._http_client.get_json(url)
+
+    def case_result_variables_get(
+        self, workspace_id: str, experiment_id: str, case_id: str
+    ) -> List[str]:
+        url = (
+            self._base_uri
+            / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"
+            f"{case_id}/variables"
         ).resolve()
         return self._http_client.get_json(url)
 

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive
@@ -381,8 +381,8 @@ interactions:
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "f0fe823d97ec47aaa1829506dbb9a2be", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217890879}, "id":
+        "format": "1.0.0", "guid": "7d27d97de0394fdfbf97dfbf5017aee6", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955057843}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -461,8 +461,8 @@ interactions:
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "f0fe823d97ec47aaa1829506dbb9a2be", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217890879}, "id":
+        "format": "1.0.0", "guid": "7d27d97de0394fdfbf97dfbf5017aee6", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955057843}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -498,15 +498,15 @@ interactions:
       string: '{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "definition": {"name":
         "Project", "format": "1.0.0", "dependencies": [{"name": "Modelica", "versionSpecifier":
         "4.0.0"}], "content": [{"relpath": "Resources/Views", "contentType": "VIEWS",
-        "defaultDisabled": false, "id": "c79c02dc90fb4f5d9d1c9de28773eee1"}, {"relpath":
+        "defaultDisabled": false, "id": "511be227f2304479ba28b457cb48bc90"}, {"relpath":
         "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled": false,
-        "id": "4980cb29f3b8462fb916f256b2e67c99"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "c171a89553db4d87910a68ec3aad7be7"},
+        "id": "a0c7919dae314414be1e46aa8089b3e3"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "14f6f8bb34e04428b9313ccbf9bb2ec2"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "fb3aa12c1ee04f378fb2d5d0f85abcbe"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "9fbef5715c8c4af2b71e94d0b3de5e74"},
+        false, "id": "bfec0a64126a425fb44c36eb6b150b65"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "06efefd3150b4a419432db393f8998fc"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "9beb8a24b12e44a8b943189d9c97c05e"}], "executionOptions":
+        "defaultDisabled": false, "id": "4c58c895d0814c6cb96b1252765ed86f"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}'
     headers:
       Connection:
@@ -687,7 +687,7 @@ interactions:
     uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments
   response:
     body:
-      string: '{"experiment_id": "modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8"}'
+      string: '{"experiment_id": "modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb"}'
     headers:
       Connection:
       - keep-alive
@@ -718,7 +718,7 @@ interactions:
       Content-Length:
       - '0'
     method: POST
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
   response:
     body:
       string: ''
@@ -750,7 +750,75 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
+  response:
+    body:
+      string: '{"finished_executions": 0, "total_executions": 1, "status": "pending",
+        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": false,
+        "stage": "compilation"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
+  response:
+    body:
+      string: '{"finished_executions": 0, "total_executions": 1, "status": "pending",
+        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": false,
+        "stage": "compilation"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -784,7 +852,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -818,7 +886,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -852,7 +920,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -886,7 +954,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -920,7 +988,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -954,7 +1022,110 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
+  response:
+    body:
+      string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
+        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": false,
+        "stage": "compilation"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
+  response:
+    body:
+      string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
+        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": false,
+        "stage": "compilation"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
+  response:
+    body:
+      string: '{"finished_executions": 1, "total_executions": 2, "status": "pending",
+        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": true,
+        "stage": "compilation"}, {"message": "Simulating", "percentage": 0.0, "done":
+        false, "stage": "simulation"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 2, "status": "done",
@@ -989,7 +1160,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 2, "status": "done",
@@ -1024,52 +1195,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1
   response:
     body:
-      string: '{"finished_executions": 2, "total_executions": 2, "status": "done",
-        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": true,
-        "stage": "compilation"}, {"message": "Simulation at time 1", "percentage":
-        1.0, "done": true, "stage": "simulation"}]}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=utf-8
-      access-control-allow-headers:
-      - '*'
-      access-control-allow-methods:
-      - POST, PUT, GET, DELETE, OPTIONS
-      access-control-allow-origin:
-      - '*'
-      vary:
-      - Accept-Encoding
-      x-powered-by:
-      - Express
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-    method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1
-  response:
-    body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012453_c7b299b",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073100_5ac2d9f",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {}, "fmu_base_parametrization": {}}, "meta":
         {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217896948, "consistent": true, "datetime_finished": 1715217897023}}'
+        1718955066163, "consistent": true, "datetime_finished": 1718955066221}}'
     headers:
       Connection:
       - keep-alive
@@ -1098,17 +1234,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012453_c7b299b",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073100_5ac2d9f",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {}, "fmu_base_parametrization": {}}, "meta":
         {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217896948, "consistent": true, "datetime_finished": 1715217897023}}'
+        1718955066163, "consistent": true, "datetime_finished": 1718955066221}}'
     headers:
       Connection:
       - keep-alive
@@ -1137,17 +1273,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012453_c7b299b",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073100_5ac2d9f",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {}, "fmu_base_parametrization": {}}, "meta":
         {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217896948, "consistent": true, "datetime_finished": 1715217897023}}'
+        1718955066163, "consistent": true, "datetime_finished": 1718955066221}}'
     headers:
       Connection:
       - keep-alive
@@ -1176,17 +1312,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012453_c7b299b",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073100_5ac2d9f",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {}, "fmu_base_parametrization": {}}, "meta":
         {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217896948, "consistent": true, "datetime_finished": 1715217897023}}'
+        1718955066163, "consistent": true, "datetime_finished": 1718955066221}}'
     headers:
       Connection:
       - keep-alive
@@ -1215,17 +1351,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012453_c7b299b",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073100_5ac2d9f",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {}, "fmu_base_parametrization": {}}, "meta":
         {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217896948, "consistent": true, "datetime_finished": 1715217897023}}'
+        1718955066163, "consistent": true, "datetime_finished": 1718955066221}}'
     headers:
       Connection:
       - keep-alive
@@ -1254,7 +1390,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1/log
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1/log
   response:
     body:
       string: "Final Run Statistics: --- \n\n Number of steps                                 :
@@ -1268,7 +1404,7 @@ interactions:
         solver         : Newton\n Linear solver type       : DENSE\n Maximal order
         \           : 5\n Tolerances (absolute)    : [1.e-06 1.e-06 1.e-06 1.e-10
         1.e-06 1.e-06]\n Tolerances (relative)    : 0.0001\n\nSimulation interval
-        \   : 0.0 - 1.0 seconds.\nElapsed simulation time: 0.04057015897706151 seconds.\n"
+        \   : 0.0 - 1.0 seconds.\nElapsed simulation time: 0.04224798300128896 seconds.\n"
     headers:
       Connection:
       - keep-alive
@@ -1301,17 +1437,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012453_c7b299b",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073100_5ac2d9f",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {}, "fmu_base_parametrization": {}}, "meta":
         {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217896948, "consistent": true, "datetime_finished": 1715217897023}}'
+        1718955066163, "consistent": true, "datetime_finished": 1718955066221}}'
     headers:
       Connection:
       - keep-alive
@@ -1340,7 +1476,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1/result
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1/result
   response:
     body:
       string: !!binary |
@@ -4249,7 +4385,7 @@ interactions:
       access-control-allow-origin:
       - '*'
       content-disposition:
-      - attachment; filename="Modelica.Blocks.Examples.PID_Controller_2024-05-09_01-24.mat"
+      - attachment; filename="Modelica.Blocks.Examples.PID_Controller_2024-06-21_07-31.mat"
       content-length:
       - '164850'
       vary:
@@ -4269,17 +4405,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012453_c7b299b",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073100_5ac2d9f",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {}, "fmu_base_parametrization": {}}, "meta":
         {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217896948, "consistent": true, "datetime_finished": 1715217897023}}'
+        1718955066163, "consistent": true, "datetime_finished": 1718955066221}}'
     headers:
       Connection:
       - keep-alive
@@ -4308,17 +4444,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012453_c7b299b",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073100_5ac2d9f",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {}, "fmu_base_parametrization": {}}, "meta":
         {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217896948, "consistent": true, "datetime_finished": 1715217897023}}'
+        1718955066163, "consistent": true, "datetime_finished": 1718955066221}}'
     headers:
       Connection:
       - keep-alive
@@ -4347,7 +4483,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/variables
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1/variables
   response:
     body:
       string: '["time", "PI.y_start", "speedSensor.flange.tau", "driveAngle", "PI.k",
@@ -4413,7 +4549,7 @@ interactions:
       Content-Type:
       - application/json
     method: POST
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012453_b7f17f8/cases/case_1/trajectories
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073100_6d84fdb/cases/case_1/trajectories
   response:
     body:
       string: '[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -4536,8 +4672,8 @@ interactions:
         {"id": "fec43f77925949bd7e7c0f10ac49ebc1189dc840", "name": "Modelica", "version":
         "3.2.3"}, "disabled": true, "disabledContent": []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6",
         "name": "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent":
-        []}], "format": "1.0.0", "guid": "f0fe823d97ec47aaa1829506dbb9a2be", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217890879}, "id":
+        []}], "format": "1.0.0", "guid": "7d27d97de0394fdfbf97dfbf5017aee6", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955057843}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}]}}'
     headers:
       Connection:
@@ -4577,8 +4713,8 @@ interactions:
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "f0fe823d97ec47aaa1829506dbb9a2be", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217890879}, "id":
+        "format": "1.0.0", "guid": "7d27d97de0394fdfbf97dfbf5017aee6", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955057843}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -4614,15 +4750,15 @@ interactions:
       string: '{"data": {"items": [{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038",
         "definition": {"name": "Project", "format": "1.0.0", "dependencies": [{"name":
         "Modelica", "versionSpecifier": "4.0.0"}], "content": [{"relpath": "Resources/Views",
-        "contentType": "VIEWS", "defaultDisabled": false, "id": "c79c02dc90fb4f5d9d1c9de28773eee1"},
+        "contentType": "VIEWS", "defaultDisabled": false, "id": "511be227f2304479ba28b457cb48bc90"},
         {"relpath": "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled":
-        false, "id": "4980cb29f3b8462fb916f256b2e67c99"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "c171a89553db4d87910a68ec3aad7be7"},
+        false, "id": "a0c7919dae314414be1e46aa8089b3e3"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "14f6f8bb34e04428b9313ccbf9bb2ec2"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "fb3aa12c1ee04f378fb2d5d0f85abcbe"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "9fbef5715c8c4af2b71e94d0b3de5e74"},
+        false, "id": "bfec0a64126a425fb44c36eb6b150b65"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "06efefd3150b4a419432db393f8998fc"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "9beb8a24b12e44a8b943189d9c97c05e"}], "executionOptions":
+        "defaultDisabled": false, "id": "4c58c895d0814c6cb96b1252765ed86f"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}]}}'
     headers:
       Connection:
@@ -4662,15 +4798,15 @@ interactions:
       string: '{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "definition": {"name":
         "Project", "format": "1.0.0", "dependencies": [{"name": "Modelica", "versionSpecifier":
         "4.0.0"}], "content": [{"relpath": "Resources/Views", "contentType": "VIEWS",
-        "defaultDisabled": false, "id": "c79c02dc90fb4f5d9d1c9de28773eee1"}, {"relpath":
+        "defaultDisabled": false, "id": "511be227f2304479ba28b457cb48bc90"}, {"relpath":
         "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled": false,
-        "id": "4980cb29f3b8462fb916f256b2e67c99"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "c171a89553db4d87910a68ec3aad7be7"},
+        "id": "a0c7919dae314414be1e46aa8089b3e3"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "14f6f8bb34e04428b9313ccbf9bb2ec2"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "fb3aa12c1ee04f378fb2d5d0f85abcbe"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "9fbef5715c8c4af2b71e94d0b3de5e74"},
+        false, "id": "bfec0a64126a425fb44c36eb6b150b65"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "06efefd3150b4a419432db393f8998fc"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "9beb8a24b12e44a8b943189d9c97c05e"}], "executionOptions":
+        "defaultDisabled": false, "id": "4c58c895d0814c6cb96b1252765ed86f"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}'
     headers:
       Connection:

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_execute_explicit_sync.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_execute_explicit_sync.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_execute_implicit_sync.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_execute_implicit_sync.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_execute_with_auto_sync.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_execute_with_auto_sync.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_initialize_from_external_result.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_initialize_from_external_result.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_input.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_input.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_consistent_flag_set_to_false_when_calling_sync.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_consistent_flag_set_to_false_when_calling_sync.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_failed_case.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_failed_case.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive
@@ -381,8 +381,8 @@ interactions:
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "318e7dfa70a9473bbac164b94e9c97b8", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217960207}, "id":
+        "format": "1.0.0", "guid": "71a31b965a874014bcfc011eb978aa20", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955095417}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -461,8 +461,8 @@ interactions:
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "318e7dfa70a9473bbac164b94e9c97b8", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217960207}, "id":
+        "format": "1.0.0", "guid": "71a31b965a874014bcfc011eb978aa20", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955095417}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -498,15 +498,15 @@ interactions:
       string: '{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "definition": {"name":
         "Project", "format": "1.0.0", "dependencies": [{"name": "Modelica", "versionSpecifier":
         "4.0.0"}], "content": [{"relpath": "Resources/Views", "contentType": "VIEWS",
-        "defaultDisabled": false, "id": "2bbf4dc2f4924a22bdf750ecdbc2a13d"}, {"relpath":
+        "defaultDisabled": false, "id": "1eefeea215a049bd9d6e77b3d1106e11"}, {"relpath":
         "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled": false,
-        "id": "d16ec58eb8664e4c8ef683f208ec75eb"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "5a835761fe7d4b7a85969c34366e72d4"},
+        "id": "cfa75ebf57b04b5f8fdaa5132b91d1be"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "c356a4af3f4f4edca8bc6a6aed6f8779"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "88e188e948194e27a8e4a90011afd980"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "a3a1686ca8684a06bc82fe28ab9bd43b"},
+        false, "id": "c10237c959e2429697bdf41628be1339"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "ae5c3000ab24488ea8e7e4c369b3a601"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "eecebca66b654fddb7fb4692b7a3ed57"}], "executionOptions":
+        "defaultDisabled": false, "id": "36c2f28343614f6399f931fd7a7cacf9"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}'
     headers:
       Connection:
@@ -687,7 +687,7 @@ interactions:
     uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments
   response:
     body:
-      string: '{"experiment_id": "modelica_blocks_examples_pid_controller_20240509_012602_ca67c88"}'
+      string: '{"experiment_id": "modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9"}'
     headers:
       Connection:
       - keep-alive
@@ -718,7 +718,7 @@ interactions:
       Content-Length:
       - '0'
     method: POST
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: ''
@@ -750,7 +750,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -784,7 +784,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -818,7 +818,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -852,7 +852,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -886,7 +886,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -920,7 +920,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -954,7 +954,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 2, "status": "done",
@@ -989,7 +989,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 2, "status": "done",
@@ -1024,7 +1024,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 2, "status": "done",
@@ -1059,18 +1059,18 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012602_f9e623e",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073137_d8ad816",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {"inertia1.J": 0}, "structural_parametrization": {}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "failed", "datetime_started":
-        1715217966039, "consistent": true, "failed_at": "simulation", "datetime_finished":
-        1715217966068}}'
+        1718955100715, "consistent": true, "failed_at": "simulation", "datetime_finished":
+        1718955100741}}'
     headers:
       Connection:
       - keep-alive
@@ -1099,18 +1099,18 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012602_f9e623e",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073137_d8ad816",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {"inertia1.J": 0}, "structural_parametrization": {}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "failed", "datetime_started":
-        1715217966039, "consistent": true, "failed_at": "simulation", "datetime_finished":
-        1715217966068}}'
+        1718955100715, "consistent": true, "failed_at": "simulation", "datetime_finished":
+        1718955100741}}'
     headers:
       Connection:
       - keep-alive
@@ -1139,18 +1139,18 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012602_f9e623e",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073137_d8ad816",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {"inertia1.J": 0}, "structural_parametrization": {}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "failed", "datetime_started":
-        1715217966039, "consistent": true, "failed_at": "simulation", "datetime_finished":
-        1715217966068}}'
+        1718955100715, "consistent": true, "failed_at": "simulation", "datetime_finished":
+        1718955100741}}'
     headers:
       Connection:
       - keep-alive
@@ -1179,18 +1179,18 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012602_f9e623e",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073137_d8ad816",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {"inertia1.J": 0}, "structural_parametrization": {}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "failed", "datetime_started":
-        1715217966039, "consistent": true, "failed_at": "simulation", "datetime_finished":
-        1715217966068}}'
+        1718955100715, "consistent": true, "failed_at": "simulation", "datetime_finished":
+        1718955100741}}'
     headers:
       Connection:
       - keep-alive
@@ -1219,18 +1219,18 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/cases/case_1
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012602_f9e623e",
+      string: '{"id": "case_1", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073137_d8ad816",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {"inertia1.J": 0}, "structural_parametrization": {}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "failed", "datetime_started":
-        1715217966039, "consistent": true, "failed_at": "simulation", "datetime_finished":
-        1715217966068}}'
+        1718955100715, "consistent": true, "failed_at": "simulation", "datetime_finished":
+        1718955100741}}'
     headers:
       Connection:
       - keep-alive
@@ -1259,7 +1259,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/variables
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/cases/case_1/variables
   response:
     body:
       string: '["time", "PI.y_start", "speedSensor.flange.tau", "driveAngle", "PI.k",
@@ -1325,7 +1325,7 @@ interactions:
       Content-Type:
       - application/json
     method: POST
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012602_ca67c88/cases/case_1/trajectories
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073137_a9d76c9/cases/case_1/trajectories
   response:
     body:
       string: '[[0.0]]'
@@ -1367,8 +1367,8 @@ interactions:
         {"id": "fec43f77925949bd7e7c0f10ac49ebc1189dc840", "name": "Modelica", "version":
         "3.2.3"}, "disabled": true, "disabledContent": []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6",
         "name": "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent":
-        []}], "format": "1.0.0", "guid": "318e7dfa70a9473bbac164b94e9c97b8", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217960207}, "id":
+        []}], "format": "1.0.0", "guid": "71a31b965a874014bcfc011eb978aa20", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955095417}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}]}}'
     headers:
       Connection:
@@ -1408,8 +1408,8 @@ interactions:
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "318e7dfa70a9473bbac164b94e9c97b8", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217960207}, "id":
+        "format": "1.0.0", "guid": "71a31b965a874014bcfc011eb978aa20", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955095417}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -1445,15 +1445,15 @@ interactions:
       string: '{"data": {"items": [{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038",
         "definition": {"name": "Project", "format": "1.0.0", "dependencies": [{"name":
         "Modelica", "versionSpecifier": "4.0.0"}], "content": [{"relpath": "Resources/Views",
-        "contentType": "VIEWS", "defaultDisabled": false, "id": "2bbf4dc2f4924a22bdf750ecdbc2a13d"},
+        "contentType": "VIEWS", "defaultDisabled": false, "id": "1eefeea215a049bd9d6e77b3d1106e11"},
         {"relpath": "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled":
-        false, "id": "d16ec58eb8664e4c8ef683f208ec75eb"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "5a835761fe7d4b7a85969c34366e72d4"},
+        false, "id": "cfa75ebf57b04b5f8fdaa5132b91d1be"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "c356a4af3f4f4edca8bc6a6aed6f8779"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "88e188e948194e27a8e4a90011afd980"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "a3a1686ca8684a06bc82fe28ab9bd43b"},
+        false, "id": "c10237c959e2429697bdf41628be1339"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "ae5c3000ab24488ea8e7e4c369b3a601"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "eecebca66b654fddb7fb4692b7a3ed57"}], "executionOptions":
+        "defaultDisabled": false, "id": "36c2f28343614f6399f931fd7a7cacf9"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}]}}'
     headers:
       Connection:
@@ -1493,15 +1493,15 @@ interactions:
       string: '{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "definition": {"name":
         "Project", "format": "1.0.0", "dependencies": [{"name": "Modelica", "versionSpecifier":
         "4.0.0"}], "content": [{"relpath": "Resources/Views", "contentType": "VIEWS",
-        "defaultDisabled": false, "id": "2bbf4dc2f4924a22bdf750ecdbc2a13d"}, {"relpath":
+        "defaultDisabled": false, "id": "1eefeea215a049bd9d6e77b3d1106e11"}, {"relpath":
         "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled": false,
-        "id": "d16ec58eb8664e4c8ef683f208ec75eb"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "5a835761fe7d4b7a85969c34366e72d4"},
+        "id": "cfa75ebf57b04b5f8fdaa5132b91d1be"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "c356a4af3f4f4edca8bc6a6aed6f8779"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "88e188e948194e27a8e4a90011afd980"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "a3a1686ca8684a06bc82fe28ab9bd43b"},
+        false, "id": "c10237c959e2429697bdf41628be1339"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "ae5c3000ab24488ea8e7e4c369b3a601"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "eecebca66b654fddb7fb4692b7a3ed57"}], "executionOptions":
+        "defaultDisabled": false, "id": "36c2f28343614f6399f931fd7a7cacf9"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}'
     headers:
       Connection:

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_failed_execution_result.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_failed_execution_result.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_get_csv_result.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_get_csv_result.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_get_result_invalid_format.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_get_result_invalid_format.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_multiple_cases.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_multiple_cases.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive
@@ -381,8 +381,8 @@ interactions:
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "647955f09f6640b59f1edb132c02d70a", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217924456}, "id":
+        "format": "1.0.0", "guid": "9db41d7f5c334d68b869354952a21fea", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955076063}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -461,8 +461,8 @@ interactions:
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "647955f09f6640b59f1edb132c02d70a", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217924456}, "id":
+        "format": "1.0.0", "guid": "9db41d7f5c334d68b869354952a21fea", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955076063}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -498,15 +498,15 @@ interactions:
       string: '{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "definition": {"name":
         "Project", "format": "1.0.0", "dependencies": [{"name": "Modelica", "versionSpecifier":
         "4.0.0"}], "content": [{"relpath": "Resources/Views", "contentType": "VIEWS",
-        "defaultDisabled": false, "id": "7a0a8f0fafde4bf29c5a4a13b2e3d6a1"}, {"relpath":
+        "defaultDisabled": false, "id": "26944b7ba35044aabb2406f55bead273"}, {"relpath":
         "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled": false,
-        "id": "8c02f25880f74769aca9ec14dc3875f0"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "e748da05cf11428793a43a059212f312"},
+        "id": "8a03a39a27444861bf9eb65e918a0702"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "c0dfcf6360024c6a9f7298a03e4d09b9"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "c53dff47a40b4cb5961259cd90606fda"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "5ef2d6db64c94233b2ed115eaf339aaf"},
+        false, "id": "d53a06b1590b409aa849517e16632203"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "172d33a0cc2748218d0e282689c18efc"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "c23fe6df91444f769aac61e4c3411422"}], "executionOptions":
+        "defaultDisabled": false, "id": "6dfe3d25f15a41b29f34f4d0947b2ddc"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}'
     headers:
       Connection:
@@ -687,7 +687,7 @@ interactions:
     uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments
   response:
     body:
-      string: '{"experiment_id": "modelica_blocks_examples_pid_controller_20240509_012526_6923c62"}'
+      string: '{"experiment_id": "modelica_blocks_examples_pid_controller_20240621_073118_357c6b3"}'
     headers:
       Connection:
       - keep-alive
@@ -718,7 +718,7 @@ interactions:
       Content-Length:
       - '0'
     method: POST
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: ''
@@ -750,7 +750,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -784,7 +784,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -818,7 +818,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -852,7 +852,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -886,7 +886,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -920,7 +920,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -954,7 +954,43 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
+  response:
+    body:
+      string: '{"finished_executions": 1, "total_executions": 3, "status": "pending",
+        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": true,
+        "stage": "compilation"}, {"message": "Simulating", "percentage": 0.0, "done":
+        false, "stage": "simulation"}, {"message": "Simulating", "percentage": 0.0,
+        "done": false, "stage": "compilation"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 3, "status": "running",
@@ -990,7 +1026,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 3, "status": "running",
@@ -1026,7 +1062,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 3, "status": "running",
@@ -1062,7 +1098,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 3, "status": "running",
@@ -1098,7 +1134,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 3, "status": "running",
@@ -1134,51 +1170,15 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
-  response:
-    body:
-      string: '{"finished_executions": 2, "total_executions": 3, "status": "running",
-        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": true,
-        "stage": "compilation"}, {"message": "Simulation at time 1", "percentage":
-        1.0, "done": true, "stage": "simulation"}, {"message": "Simulating", "percentage":
-        0.0, "done": false, "stage": "compilation"}]}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=utf-8
-      access-control-allow-headers:
-      - '*'
-      access-control-allow-methods:
-      - POST, PUT, GET, DELETE, OPTIONS
-      access-control-allow-origin:
-      - '*'
-      vary:
-      - Accept-Encoding
-      x-powered-by:
-      - Express
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-    method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 3, "total_executions": 4, "status": "done",
         "progresses": [{"message": "Simulating", "percentage": 0.0, "done": true,
         "stage": "compilation"}, {"message": "Simulation at time 1", "percentage":
         1.0, "done": true, "stage": "simulation"}, {"message": "Simulating", "percentage":
-        0.0, "done": true, "stage": "compilation"}, {"message": "Simulation at time
-        1", "percentage": 1.0, "done": false, "stage": "simulation"}]}'
+        0.0, "done": false, "stage": "compilation"}, {"message": "Simulation at time
+        1", "percentage": 1.0, "done": true, "stage": "simulation"}]}'
     headers:
       Connection:
       - keep-alive
@@ -1207,7 +1207,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 4, "total_executions": 4, "status": "done",
@@ -1244,7 +1244,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/execution
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/execution
   response:
     body:
       string: '{"finished_executions": 4, "total_executions": 4, "status": "done",
@@ -1281,17 +1281,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/cases/case_2
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/cases/case_2
   response:
     body:
-      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012530_527ab1c",
+      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073121_7da2761",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {"PI.yMax": 13}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217934128, "consistent": true, "datetime_finished": 1715217934211}}'
+        1718955084915, "consistent": true, "datetime_finished": 1718955084989}}'
     headers:
       Connection:
       - keep-alive
@@ -1320,17 +1320,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/cases/case_2
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/cases/case_2
   response:
     body:
-      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012530_527ab1c",
+      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073121_7da2761",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {"PI.yMax": 13}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217934128, "consistent": true, "datetime_finished": 1715217934211}}'
+        1718955084915, "consistent": true, "datetime_finished": 1718955084989}}'
     headers:
       Connection:
       - keep-alive
@@ -1359,7 +1359,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/cases/case_2/log
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/cases/case_2/log
   response:
     body:
       string: "Final Run Statistics: --- \n\n Number of steps                                 :
@@ -1373,7 +1373,7 @@ interactions:
         solver         : Newton\n Linear solver type       : DENSE\n Maximal order
         \           : 5\n Tolerances (absolute)    : [1.e-06 1.e-06 1.e-06 1.e-10
         1.e-06 1.e-06]\n Tolerances (relative)    : 0.0001\n\nSimulation interval
-        \   : 0.0 - 1.0 seconds.\nElapsed simulation time: 0.04357349197380245 seconds.\n"
+        \   : 0.0 - 1.0 seconds.\nElapsed simulation time: 0.042580529989209026 seconds.\n"
     headers:
       Connection:
       - keep-alive
@@ -1388,7 +1388,7 @@ interactions:
       content-disposition:
       - attachment; filename="log.txt"
       content-length:
-      - '904'
+      - '905'
       vary:
       - Accept-Encoding
       x-powered-by:
@@ -1406,17 +1406,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/cases/case_2
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/cases/case_2
   response:
     body:
-      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012530_527ab1c",
+      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073121_7da2761",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {"PI.yMax": 13}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217934128, "consistent": true, "datetime_finished": 1715217934211}}'
+        1718955084915, "consistent": true, "datetime_finished": 1718955084989}}'
     headers:
       Connection:
       - keep-alive
@@ -1445,7 +1445,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/cases/case_2/result
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/cases/case_2/result
   response:
     body:
       string: !!binary |
@@ -4354,7 +4354,7 @@ interactions:
       access-control-allow-origin:
       - '*'
       content-disposition:
-      - attachment; filename="Modelica.Blocks.Examples.PID_Controller_2024-05-09_01-25_case_2.mat"
+      - attachment; filename="Modelica.Blocks.Examples.PID_Controller_2024-06-21_07-31_case_2.mat"
       content-length:
       - '164850'
       vary:
@@ -4374,17 +4374,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/cases/case_2
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/cases/case_2
   response:
     body:
-      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012530_527ab1c",
+      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073121_7da2761",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {"PI.yMax": 13}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217934128, "consistent": true, "datetime_finished": 1715217934211}}'
+        1718955084915, "consistent": true, "datetime_finished": 1718955084989}}'
     headers:
       Connection:
       - keep-alive
@@ -4413,17 +4413,17 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/cases/case_2
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/cases/case_2
   response:
     body:
-      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240509_012530_527ab1c",
+      string: '{"id": "case_2", "input": {"fmu_id": "modelica_blocks_examples_pid_controller_20240621_073121_7da2761",
         "analysis": {"analysis_function": "dynamic", "simulation_options": {"ncp":
         500, "dynamic_diagnostics": false}, "solver_options": {}, "simulation_log_level":
         "WARNING", "parameters": {"start_time": 0, "final_time": 1, "interval": 0}},
         "initialize_from_case": null, "initialize_from_external_result": null, "parametrization":
         {}, "structural_parametrization": {"PI.yMax": 13}, "fmu_base_parametrization":
         {}}, "meta": {"label": null}, "run_info": {"status": "successful", "datetime_started":
-        1715217934128, "consistent": true, "datetime_finished": 1715217934211}}'
+        1718955084915, "consistent": true, "datetime_finished": 1718955084989}}'
     headers:
       Connection:
       - keep-alive
@@ -4452,7 +4452,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/variables
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/cases/case_2/variables
   response:
     body:
       string: '["time", "PI.y_start", "speedSensor.flange.tau", "driveAngle", "PI.k",
@@ -4518,7 +4518,7 @@ interactions:
       Content-Type:
       - application/json
     method: POST
-    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240509_012526_6923c62/cases/case_2/trajectories
+    uri: /user/test-user/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240621_073118_357c6b3/cases/case_2/trajectories
   response:
     body:
       string: '[[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
@@ -4641,8 +4641,8 @@ interactions:
         {"id": "fec43f77925949bd7e7c0f10ac49ebc1189dc840", "name": "Modelica", "version":
         "3.2.3"}, "disabled": true, "disabledContent": []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6",
         "name": "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent":
-        []}], "format": "1.0.0", "guid": "647955f09f6640b59f1edb132c02d70a", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217924456}, "id":
+        []}], "format": "1.0.0", "guid": "9db41d7f5c334d68b869354952a21fea", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955076063}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}]}}'
     headers:
       Connection:
@@ -4682,8 +4682,8 @@ interactions:
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "647955f09f6640b59f1edb132c02d70a", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1715217924456}, "id":
+        "format": "1.0.0", "guid": "9db41d7f5c334d68b869354952a21fea", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1718955076063}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -4719,15 +4719,15 @@ interactions:
       string: '{"data": {"items": [{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038",
         "definition": {"name": "Project", "format": "1.0.0", "dependencies": [{"name":
         "Modelica", "versionSpecifier": "4.0.0"}], "content": [{"relpath": "Resources/Views",
-        "contentType": "VIEWS", "defaultDisabled": false, "id": "7a0a8f0fafde4bf29c5a4a13b2e3d6a1"},
+        "contentType": "VIEWS", "defaultDisabled": false, "id": "26944b7ba35044aabb2406f55bead273"},
         {"relpath": "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled":
-        false, "id": "8c02f25880f74769aca9ec14dc3875f0"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "e748da05cf11428793a43a059212f312"},
+        false, "id": "8a03a39a27444861bf9eb65e918a0702"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "c0dfcf6360024c6a9f7298a03e4d09b9"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "c53dff47a40b4cb5961259cd90606fda"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "5ef2d6db64c94233b2ed115eaf339aaf"},
+        false, "id": "d53a06b1590b409aa849517e16632203"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "172d33a0cc2748218d0e282689c18efc"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "c23fe6df91444f769aac61e4c3411422"}], "executionOptions":
+        "defaultDisabled": false, "id": "6dfe3d25f15a41b29f34f4d0947b2ddc"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}]}}'
     headers:
       Connection:
@@ -4767,15 +4767,15 @@ interactions:
       string: '{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "definition": {"name":
         "Project", "format": "1.0.0", "dependencies": [{"name": "Modelica", "versionSpecifier":
         "4.0.0"}], "content": [{"relpath": "Resources/Views", "contentType": "VIEWS",
-        "defaultDisabled": false, "id": "7a0a8f0fafde4bf29c5a4a13b2e3d6a1"}, {"relpath":
+        "defaultDisabled": false, "id": "26944b7ba35044aabb2406f55bead273"}, {"relpath":
         "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled": false,
-        "id": "8c02f25880f74769aca9ec14dc3875f0"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "e748da05cf11428793a43a059212f312"},
+        "id": "8a03a39a27444861bf9eb65e918a0702"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "c0dfcf6360024c6a9f7298a03e4d09b9"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "c53dff47a40b4cb5961259cd90606fda"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "5ef2d6db64c94233b2ed115eaf339aaf"},
+        false, "id": "d53a06b1590b409aa849517e16632203"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "172d33a0cc2748218d0e282689c18efc"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "c23fe6df91444f769aac61e4c3411422"}], "executionOptions":
+        "defaultDisabled": false, "id": "6dfe3d25f15a41b29f34f4d0947b2ddc"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}'
     headers:
       Connection:

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_reinitiazlizing_case_initialized_case_from_result.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_reinitiazlizing_case_initialized_case_from_result.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_reinitiazlizing_result_initialized_case_from_case.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_reinitiazlizing_result_initialized_case_from_case.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_create_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_create_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_case_by_reference.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_case_by_reference.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_executions.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_executions.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_executions_for_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_executions_for_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_experiment_by_reference.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_experiment_by_reference.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_me.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_me.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_project.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_project.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_system_projects.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_system_projects.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_workspace_by_name.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_workspace_by_name.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_workspace_filtered_by_name.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_workspace_filtered_by_name.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_workspaces.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_get_workspaces.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_import_project_from_zip.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_import_project_from_zip.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_import_workspace_from_zip.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_import_workspace_from_zip.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_client/TestClient.test_upload_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_client/TestClient.test_upload_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_custom_function/TestCustomFunction.test_compiler_options.yaml
+++ b/tests/fixtures/vcr_cassettes/test_custom_function/TestCustomFunction.test_compiler_options.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_custom_function/TestCustomFunction.test_runtime_options.yaml
+++ b/tests/fixtures/vcr_cassettes/test_custom_function/TestCustomFunction.test_runtime_options.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_custom_function/TestCustomFunction.test_simulation_options.yaml
+++ b/tests/fixtures/vcr_cassettes/test_custom_function/TestCustomFunction.test_simulation_options.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_custom_function/TestCustomFunction.test_solver_options.yaml
+++ b/tests/fixtures/vcr_cassettes/test_custom_function/TestCustomFunction.test_solver_options.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_cancelled_execution.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_cancelled_execution.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execute.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execute.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execute_with_case_filter.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execute_with_case_filter.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execute_with_case_filter_no_sync.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execute_with_case_filter_no_sync.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execute_with_user_data.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execute_with_user_data.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execution_with_failed_cases.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_execution_with_failed_cases.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_exp_trajectories_invalid_keys.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_exp_trajectories_invalid_keys.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_exp_trajectories_non_list_entry.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_exp_trajectories_non_list_entry.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_experiment_get_last_time_point.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_experiment_get_last_time_point.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_experiment_get_last_time_point_all_variables.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_experiment_get_last_time_point_all_variables.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_failed_execution.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_failed_execution.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_get_cases_label.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_get_cases_label.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_running_execution.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_running_execution.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_set_experiment_label.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_set_experiment_label.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_some_successful_batch_execute.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_some_successful_batch_execute.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_successful_batch_execute.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_successful_batch_execute.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_successful_fmu_based_experiment.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_successful_fmu_based_experiment.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_successful_model_based_experiment.yaml
+++ b/tests/fixtures/vcr_cassettes/test_experiment/TestExperiment.test_successful_model_based_experiment.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model/TestModel.test_compile_invalid_compiler_options_type.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model/TestModel.test_compile_invalid_compiler_options_type.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model/TestModel.test_compile_invalid_runtime_options_type.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model/TestModel.test_compile_invalid_runtime_options_type.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model/TestModel.test_experiment_definition_default_execution_options.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model/TestModel.test_experiment_definition_default_execution_options.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model/TestModel.test_find_cached.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model/TestModel.test_find_cached.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model/TestModel.test_force_compile.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model/TestModel.test_force_compile.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model/TestModel.test_force_compile_dict_options.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model/TestModel.test_force_compile_dict_options.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model/TestModel.test_import_fmu.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model/TestModel.test_import_fmu.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_compilation_failed.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_compilation_failed.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_compilation_running.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_compilation_running.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_compile_successful.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_compile_successful.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_create_experiment_definition.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_create_experiment_definition.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_delete_fmu.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_delete_fmu.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_download_fmu.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_download_fmu.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_download_fmu_failed_compilation.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_download_fmu_failed_compilation.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_download_fmu_no_path.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_download_fmu_no_path.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_parse_model_description.yaml
+++ b/tests/fixtures/vcr_cassettes/test_model_exe/TestModelExecutable.test_parse_model_description.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_delete_project.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_delete_project.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_delete_project_contents.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_delete_project_contents.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_modelica_library_by_name.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_modelica_library_by_name.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_content_by_id.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_content_by_id.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_content_by_name.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_content_by_name.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_contents.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_contents.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_default_options.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_default_options.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_options.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_options.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_size.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_get_project_size.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_import_content.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_import_content.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_import_modelica_library.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_import_modelica_library.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_project/TestProject.test_rename_project.yaml
+++ b/tests/fixtures/vcr_cassettes/test_project/TestProject.test_rename_project.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_class_based_experiment_definition_from_case_result.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_class_based_experiment_definition_from_case_result.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_class_based_experiment_definition_from_experiment_result.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_class_based_experiment_definition_from_experiment_result.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_experiment.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_experiment.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_experiment_with_user_data.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_experiment_with_user_data.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_fmu_based_experiment_definition_from_experiment_result.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_fmu_based_experiment_definition_from_experiment_result.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_project.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_create_project.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_delete.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_delete.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_download_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_download_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_experiment_def_as_dict.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_experiment_def_as_dict.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_export_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_export_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_all_dependencies.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_all_dependencies.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_custom_function.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_custom_function.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_custom_functions.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_custom_functions.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_default_project.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_default_project.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_experiment.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_experiment.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_experiments.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_experiments.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_fmu.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_fmu.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_fmus.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_fmus.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_model.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_model.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_model_experiments.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_model_experiments.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_projects.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_projects.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_published_app_mode_workspace_corresponding_to_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_published_app_mode_workspace_corresponding_to_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_published_workspace_corresponding_to_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_published_workspace_corresponding_to_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_published_workspace_fails_for_remote_imported_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_published_workspace_fails_for_remote_imported_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_remote_workspace_corresponding_to_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_remote_workspace_corresponding_to_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_remote_workspace_fails_for_local_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_remote_workspace_fails_for_local_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_remote_workspace_fails_if_remote_deleted.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_remote_workspace_fails_if_remote_deleted.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_workspace_size.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_get_workspace_size.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_has_remote_update_fails_for_local_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_has_remote_update_fails_for_local_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_has_remote_update_returns_None_if_no_published_workspace_found.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_has_remote_update_returns_None_if_no_published_workspace_found.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_import_dependency_from_zip.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_import_dependency_from_zip.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_import_project_from_zip.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_import_project_from_zip.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_model_repr.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_model_repr.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_publish_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_publish_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_rename_workspace.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_rename_workspace.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_update_from_remote.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_update_from_remote.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_upload_result.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_upload_result.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_workspace_has_remote_updates.yaml
+++ b/tests/fixtures/vcr_cassettes/test_workspace/TestWorkspace.test_workspace_has_remote_updates.yaml
@@ -270,7 +270,7 @@ interactions:
     uri: /user/test-user/impact/api/
   response:
     body:
-      string: '{"version": "4.11.1"}'
+      string: '{"version": "4.16.0"}'
     headers:
       Connection:
       - keep-alive

--- a/tests/impact/client/conftest.py
+++ b/tests/impact/client/conftest.py
@@ -69,7 +69,7 @@ def mock_server_base():
 
 @pytest.fixture
 def sem_ver_check(mock_server_base):
-    json = {"version": "4.11.0"}
+    json = {"version": "4.16.0"}
     return with_json_route(mock_server_base, "GET", "api/", json)
 
 

--- a/tests/impact/client/test_client.py
+++ b/tests/impact/client/test_client.py
@@ -65,7 +65,7 @@ class TestClient:
             )
         assert (
             "Version '1.0.0' of the HTTP REST API is not supported, must be in the "
-            "range '>=4.11.0,<5.0.0'! Updgrade or downgrade this package to a "
+            "range '>=4.16.0,<5.0.0'! Updgrade or downgrade this package to a "
             "version that supports version '1.0.0' of the HTTP REST API."
             in str(excinfo.value)
         )


### PR DESCRIPTION
Jira - https://modelonproducts.atlassian.net/browse/FLOW-558

This MR adds support for fetching result variables for a single case. This api addresses the concerns raised by @maraberg  in https://github.com/modelon-community/impact-client-python/pull/289 where result variables for a multi-execution case didnt contain case specific result variables.
