### PR TITLE
fix: pass user defined context to unauthenticated HTTPClient

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -241,7 +241,7 @@ class Client:
         if credential_manager is None:
             uri = (
                 self._uri / "user-redirect/impact"
-                if is_jupyterhub_url(self._uri)
+                if is_jupyterhub_url(self._uri, context)
                 else self._uri
             )
             help_hint = f"can be generated at {uri / 'admin/keys'}"

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -25,12 +25,12 @@ def _get_impact_base_uri(uri: URI, http_client: HTTPClient) -> URI:
     return uri / f"{server_url}/impact"
 
 
-def is_jupyterhub_url(uri: URI) -> bool:
+def is_jupyterhub_url(uri: URI, context: Optional[Context] = None) -> bool:
     _JUPYTERHUB_VERSION_HEADER = "x-jupyterhub-version"
     url = (uri / "hub/api/").resolve()
 
     try:
-        http_client = HTTPClient()
+        http_client = HTTPClient(context=context)
         response = http_client.get_json_response(url)
     except (
         exceptions.CommunicationError,


### PR DESCRIPTION
This PR fixes such that a user defined context is passed to the unauthenticated HttpClient as well.