### PR TITLE
feat: added publisher check for workspace imports of published workspaces not in recievers whitelist and added apis to get/append/delete from whitelist

### DIFF
--- a/modelon/impact/client/client.py
+++ b/modelon/impact/client/client.py
@@ -27,6 +27,7 @@ from modelon.impact.client.entities.project import (
     StorageLocation,
     VcsUri,
 )
+from modelon.impact.client.entities.whitelist import Whitelist
 from modelon.impact.client.entities.workspace import Workspace, WorkspaceDefinition
 from modelon.impact.client.operations.experiment import ExperimentOperation
 from modelon.impact.client.operations.model_executable import ModelExecutableOperation
@@ -771,6 +772,9 @@ class Client:
 
         """
         return Experiment.from_reference(reference)
+
+    def get_whitelist(self) -> Whitelist:
+        return Whitelist(service=self._sal.whitelist)
 
 
 @dataclass

--- a/modelon/impact/client/entities/whitelist.py
+++ b/modelon/impact/client/entities/whitelist.py
@@ -1,0 +1,76 @@
+from typing import List
+
+from modelon.impact.client.sal.whitelist import WhitelistService
+
+
+class Whitelist:
+    def __init__(self, service: WhitelistService):
+        self._sal = service
+
+    def remove_user(self, username: str) -> None:
+        """Remove a user from whitelisted users.
+
+        Args:
+            username: Username of the user to remove from whitelist.
+
+        Example::
+
+            whitelist = client.get_whitelist()
+            whitelist.remove_user("naruto")
+
+        """
+        self._sal.whitelist_remove_user(username)
+
+    def remove_group(self, group_name: str) -> None:
+        """Remove a group from whitelisted groups.
+
+        Args:
+            group_name: Group name to remove from whitelist.
+
+        Example::
+
+            whitelist = client.get_whitelist()
+            whitelist.remove_group("impact-tenant-konoha")
+
+        """
+        self._sal.whitelist_remove_group(group_name)
+
+    def add_user(self, user_name: str) -> None:
+        """Add a user to whitelisted users.
+
+        Args:
+            username: Username of the user to add to whitelisted users.
+
+        Example::
+
+            whitelist = client.get_whitelist()
+            whitelist.add_user("naruto")
+
+        """
+        self._sal.whitelist_append(users=[user_name], groups=[])
+
+    def add_group(self, group_name: str) -> None:
+        """Add a group to whitelisted groups.
+
+        Args:
+            group_name: Group name to add to whitelisted groups.
+
+        Example::
+
+            whitelist = client.get_whitelist()
+            whitelist.add_group("impact-tenant-konoha")
+
+        """
+        self._sal.whitelist_append(users=[], groups=[group_name])
+
+    @property
+    def users(self) -> List[str]:
+        """List of whitelisted users."""
+        data = self._sal.whitelist_get()
+        return data["users"]
+
+    @property
+    def groups(self) -> List[str]:
+        """List of whitelisted groups."""
+        data = self._sal.whitelist_get()
+        return data["groups"]

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -52,7 +52,7 @@ ExperimentDefinition = Union[
 
 @dataclass
 class AccessSettings:
-    group_names: Optional[List[str]] = None
+    share_with_own_tenant: bool = True
 
 
 @dataclass
@@ -810,17 +810,17 @@ class Workspace(WorkspaceInterface):
             workspace.export(publish=True,
                 class_path='Modelica.Blocks.Examples.PID_Controller').wait()
 
-            # Publish a workspace without sharing with group
+            # Publish a workspace without sharing with tenant
             from modelon.impact.client import AccessSettings
 
             workspace.export(publish=True,
                 class_path='Modelica.Blocks.Examples.PID_Controller',
-                access=AccessSettings(group_names=[]).wait()
+                access=AccessSettings(share_with_own_tenant=False).wait()
             )
 
         """
         if access:
-            access_settings = {"groupNames": access.group_names}
+            access_settings = {"shareWithOwnTenant": access.share_with_own_tenant}
         else:
             access_settings = None
         resp = self._sal.workspace.workspace_export_setup(

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -14,6 +14,7 @@ from modelon.impact.client.sal.model_executable import ModelExecutableService
 from modelon.impact.client.sal.project import ProjectService
 from modelon.impact.client.sal.uri import URI
 from modelon.impact.client.sal.users import UsersService
+from modelon.impact.client.sal.whitelist import WhitelistService
 from modelon.impact.client.sal.workspace import WorkspaceService
 
 logger = logging.getLogger(__name__)
@@ -58,6 +59,7 @@ class Service:
             else uri
         )
         self.workspace = WorkspaceService(self._base_uri, self._http_client)
+        self.whitelist = WhitelistService(self._base_uri, self._http_client)
         self.project = ProjectService(self._base_uri, self._http_client)
         self.model_executable = ModelExecutableService(
             self._base_uri, self._http_client

--- a/modelon/impact/client/sal/whitelist.py
+++ b/modelon/impact/client/sal/whitelist.py
@@ -1,0 +1,29 @@
+"""Workspace service module."""
+from typing import Any, Dict, List
+
+from modelon.impact.client.sal.http import HTTPClient
+from modelon.impact.client.sal.uri import URI
+
+
+class WhitelistService:
+    def __init__(self, uri: URI, http_client: HTTPClient):
+        self._base_uri = uri
+        self._http_client = http_client
+
+    def whitelist_get(self) -> Dict[str, Any]:
+        url = (self._base_uri / "api/whitelist").resolve()
+        return self._http_client.get_json(url)
+
+    def whitelist_append(self, users: List[str], groups: List[str]) -> None:
+        url = (self._base_uri / "api/whitelist").resolve()
+        return self._http_client.patch_json_no_response_body(
+            url, body={"users": users, "groups": groups}
+        )
+
+    def whitelist_remove_user(self, username: str) -> None:
+        url = (self._base_uri / f"api/whitelist/users/{username}").resolve()
+        self._http_client.delete_json(url)
+
+    def whitelist_remove_group(self, group_name: str) -> None:
+        url = (self._base_uri / f"api/whitelist/groups/{group_name}").resolve()
+        self._http_client.delete_json(url)

--- a/tests/impact/client/entities/test_workspace.py
+++ b/tests/impact/client/entities/test_workspace.py
@@ -234,8 +234,10 @@ class TestWorkspace:
         workspace_entity = workspace.entity
         service = workspace.service
         workspace_service = service.workspace
-        workspace_entity.export(publish=True, access=AccessSettings(group_names=[]))
-        access_settings = {"groupNames": []}
+        workspace_entity.export(
+            publish=True, access=AccessSettings(share_with_own_tenant=False)
+        )
+        access_settings = {"shareWithOwnTenant": False}
         workspace_service.workspace_export_setup.assert_has_calls(
             [mock.call(IDs.WORKSPACE_ID_PRIMARY, True, None, access_settings)]
         )


### PR DESCRIPTION
Jira  https://modelonproducts.atlassian.net/browse/FLOW-585

**Code to test**

```
import os
os.environ["IMPACT_PYTHON_CLIENT_EXPERIMENTAL"] = "true"
from modelon.impact.client import Client, PublishedWorkspaceAccessKind

client = Client()
pwc = client.get_published_workspaces_client()

wl = client.get_whitelist()
print(wl.groups, wl.users)

wl.add_user("abhilash")
print(wl.groups, wl.users)
wl.add_group("impact-hub")
print(wl.groups, wl.users)


wl.remove_user("abhilash")
print(wl.groups, wl.users)
wl.remove_group("impact-hub")
print(wl.groups, wl.users)

pw_access = pwc.get_by_access_kind(access_kind=PublishedWorkspaceAccessKind.SHARED_WITH_ME)
pw_id = pw_access[0].sharing_id
pw = pwc.get_by_id(pw_id)
ws = pw.import_to_userspace(add_publisher_to_whitelist=True)
```