### PR TITLE
feat: add api support for cleaning orphaned published ws

### DIFF
--- a/modelon/impact/client/__init__.py
+++ b/modelon/impact/client/__init__.py
@@ -32,6 +32,7 @@ from modelon.impact.client.experiment_definition.operators import (
     Uniform,
 )
 from modelon.impact.client.published_workspace_client import (
+    OrphanPublishedWorkspaceOwner,
     PublishedWorkspaceAccessKind,
 )
 

--- a/modelon/impact/client/exceptions.py
+++ b/modelon/impact/client/exceptions.py
@@ -57,6 +57,10 @@ class OperationCompleteError(Error):
     pass
 
 
+class FailedOrphanCleanup(Error):
+    pass
+
+
 class IllegalProjectImport(Error):
     pass
 

--- a/modelon/impact/client/operations/orphan_cleanup.py
+++ b/modelon/impact/client/operations/orphan_cleanup.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from modelon.impact.client import exceptions
+from modelon.impact.client.operations.base import AsyncOperationStatus
+from modelon.impact.client.sal.service import Service
+
+logger = logging.getLogger(__name__)
+
+
+class OrphanPublishedWorkspaceOperation:
+    """An operation class for the published workspace orphan cleanup."""
+
+    def __init__(self, location: str, service: Service, operation_name: str):
+        self._location = location
+        self._sal = service
+        self._name = operation_name
+
+    def __repr__(self) -> str:
+        return f"Orphan operations with id '{self.id}'"
+
+    def __eq__(self, obj: object) -> bool:
+        return (
+            isinstance(obj, OrphanPublishedWorkspaceOperation)
+            and obj._location == self._location
+        )
+
+    @property
+    def id(self) -> str:
+        """Orphan operation id."""
+        return self._location.split("/")[-1]
+
+    @property
+    def name(self) -> str:
+        """Return the name of operation."""
+        return self._name
+
+    def _info(self) -> Dict[str, Any]:
+        return self._sal.imports.get_import_status(self._location)["data"]
+
+    def data(self) -> List[str]:
+        """Returns a list of orphaned published workspace IDs.
+
+        Returns:
+            A a list of orphaned published workspace IDs.
+
+        """
+        info = self._info()
+        if info["status"] == AsyncOperationStatus.ERROR.value:
+            raise exceptions.FailedOrphanCleanup(
+                f"Orphan cleanup failed! Cause: {info['error'].get('message')}"
+            )
+        return info["data"]["orphans"]
+
+    @property
+    def status(self) -> AsyncOperationStatus:
+        """Returns the operation status as an enumeration.
+
+        Returns:
+            The AsyncOperationStatus enum. The status can have the enum values
+            AsyncOperationStatus.READY, AsyncOperationStatus.RUNNING or
+            AsyncOperationStatus.ERROR
+
+        Example::
+
+            pw_client = client.get_published_workspaces_client()
+            status = pw_client.wipe_orphans().status
+
+        """
+        return AsyncOperationStatus(self._info()["status"])
+
+    def wait(self, timeout: Optional[float] = None) -> List[str]:
+        """Waits until the operation completes. Returns the operation class instance if
+        operation completes.
+
+        Args:
+            timeout: Time to wait in seconds for achieving the status. By default
+                the timeout is set to 'None', which signifies an infinite time
+                to wait until the status is achieved.
+
+        Raises:
+            OperationTimeOutError if time exceeds set timeout.
+
+        Example::
+
+            pw_client = client.get_published_workspaces_client()
+            status = pw_client.wipe_orphans().wait()
+
+        """
+        start_t = time.time()
+        while True:
+            logger.info(f"{self.name} in progress! Status : {self.status.name}")
+            if self.status.done():
+                logger.info(f"{self.name} completed! Status : {self.status.name}")
+                return self.data()
+
+            current_t = time.time()
+            if timeout and current_t - start_t > timeout:
+                raise exceptions.OperationTimeOutError(
+                    f"Time exceeded the set timeout - {timeout}s! "
+                    f"Present status of operation is {self.status.name}!"
+                )
+
+            time.sleep(0.5)

--- a/modelon/impact/client/sal/workspace.py
+++ b/modelon/impact/client/sal/workspace.py
@@ -1,8 +1,15 @@
 """Workspace service module."""
-from typing import Any, Dict, List, Optional
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from modelon.impact.client.sal.http import HTTPClient
 from modelon.impact.client.sal.uri import URI
+
+if TYPE_CHECKING:
+    from modelon.impact.client.published_workspace_client import (
+        OrphanPublishedWorkspaceOwner,
+    )
 
 
 class WorkspaceService:
@@ -144,6 +151,21 @@ class WorkspaceService:
         url = (self._base_uri / "api/workspace-imports").resolve()
         with open(path_to_workspace, "rb") as f:
             return self._http_client.post_json(url, files={"file": f})
+
+    def cleanup_orphans(
+        self,
+        user: Optional[OrphanPublishedWorkspaceOwner] = None,
+        only_list_orphans: bool = False,
+    ) -> Dict[str, Any]:
+        url = (self._base_uri / "api/published-workspaces/orphans/cleanup").resolve()
+        body: Dict[str, Any] = {"onlyListOrphans": only_list_orphans}
+        if user:
+            body["user"] = {
+                "username": user.username,
+                "id": user.id,
+                "groupName": user.group_name,
+            }
+        return self._http_client.post_json(url, body=body)
 
     def import_from_shared_definition(
         self,


### PR DESCRIPTION
Jira - https://modelonproducts.atlassian.net/browse/FLOW-614

```
import os  
os.environ["IMPACT_PYTHON_CLIENT_EXPERIMENTAL"] = "true"  
from modelon.impact.client import Client, OrphanPublishedWorkspaceOwner
from urllib3.exceptions import InsecureRequestWarning  
import requests

requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)

class Context:  
    def __init__(self):
        self.session = requests.Session()
        self.session.verify = False

client = Client('https://impact.local', interactive=True, context=Context())  
pwc = client.get_published_workspaces_client()
user = OrphanPublishedWorkspaceOwner(id="8143248a-49ee-4473-a2ba-c721b9aafb42", username="akn", group_name="impact-tenant-mycompany")
ops = pwc.list_orphans(user)
print(ops, ops.status)
ops.wait()

ops = pwc.wipe_orphans()
print(ops, ops.status)
ops.wait()
```