### PR TITLE
Query as Params

### DIFF
--- a/modelon/impact/client/published_workspace_client.py
+++ b/modelon/impact/client/published_workspace_client.py
@@ -44,7 +44,7 @@ class PublishedWorkspacesClient:
         name: str = "",
         first: int = 0,
         maximum: int = 20,
-        has_data: bool = False,
+        has_data: bool = True,
         owner_username: str = "",
         type: Optional[PublishedWorkspaceType] = None,
         group_name: Optional[str] = None,

--- a/modelon/impact/client/sal/http.py
+++ b/modelon/impact/client/sal/http.py
@@ -27,13 +27,21 @@ class HTTPClient:
         if api_key:
             self._context.session.headers["impact-api-key"] = api_key
 
-    def get_json(self, url: str, headers: Optional[Dict[str, Any]] = None) -> Any:
-        return self.get_json_response(url, headers=headers).data
+    def get_json(
+        self,
+        url: str,
+        headers: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        return self.get_json_response(url, headers=headers, params=params).data
 
     def get_json_response(
-        self, url: str, headers: Optional[Dict[str, Any]] = None
+        self,
+        url: str,
+        headers: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> JSONResponse:
-        request = RequestJSON(self._context, "GET", url, headers=headers)
+        request = RequestJSON(self._context, "GET", url, headers=headers, params=params)
         return request.execute()
 
     def get_text(self, url: str) -> str:

--- a/modelon/impact/client/sal/project.py
+++ b/modelon/impact/client/sal/project.py
@@ -22,23 +22,20 @@ class ProjectService:
         project_type: Optional[ProjectType] = None,
         storage_location: Optional[StorageLocation] = None,
     ) -> Dict[str, Any]:
-        prj_type = "&type=" + project_type.value if project_type else ""
-        stg_loc = (
-            "&storageLocation=" + storage_location.value if storage_location else ""
-        )
-        url = (
-            self._base_uri / f"api/projects?vcsInfo={vcs_info}{prj_type}{stg_loc}"
-        ).resolve()
-        return self._http_client.get_json(url)
+        query = {
+            "vcsInfo": vcs_info,
+            "type": project_type.value if project_type else "",
+            "storageLocation": storage_location.value if storage_location else "",
+        }
+        url = (self._base_uri / "api/projects").resolve()
+        return self._http_client.get_json(url, params=query)
 
     def project_get(
         self, project_id: str, vcs_info: bool, size_info: bool
     ) -> Dict[str, Any]:
-        url = (
-            self._base_uri
-            / f"api/projects/{project_id}?vcsInfo={vcs_info}&sizeInfo={size_info}"
-        ).resolve()
-        return self._http_client.get_json(url)
+        query = {"vcsInfo": vcs_info, "sizeInfo": size_info}
+        url = (self._base_uri / f"api/projects/{project_id}").resolve()
+        return self._http_client.get_json(url, params=query)
 
     def project_delete(self, project_id: str) -> None:
         url = (self._base_uri / f"api/projects/{project_id}").resolve()

--- a/modelon/impact/client/sal/request.py
+++ b/modelon/impact/client/sal/request.py
@@ -28,6 +28,7 @@ class Request:
         body: Optional[Dict[str, Any]] = None,
         files: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ):
         self.context = context
         self.method = method
@@ -36,6 +37,7 @@ class Request:
         self.files = files
         self.request_type = request_type
         self.headers = headers
+        self.params = params
 
     def execute(self, check_return: bool = True) -> Any:
         try:
@@ -50,7 +52,11 @@ class Request:
                     headers=headers,
                 )
             elif self.method == "GET":
-                resp = self.context.session.get(self.url, headers=headers)
+                resp = self.context.session.get(
+                    self.url,
+                    headers=headers,
+                    params=self.params,
+                )
             elif self.method == "PUT":
                 resp = self.context.session.put(
                     self.url,
@@ -95,8 +101,11 @@ class RequestJSON(Request):
         body: Optional[Dict[str, Any]] = None,
         files: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
     ):
-        super().__init__(context, method, url, JSONResponse, body, files, headers)
+        super().__init__(
+            context, method, url, JSONResponse, body, files, headers, params
+        )
 
 
 class RequestZip(Request):

--- a/modelon/impact/client/sal/workspace.py
+++ b/modelon/impact/client/sal/workspace.py
@@ -24,10 +24,9 @@ class WorkspaceService:
         self._http_client.delete_json(url)
 
     def workspace_get(self, workspace_id: str, size_info: bool) -> Dict[str, Any]:
-        url = (
-            self._base_uri / f"api/workspaces/{workspace_id}?sizeInfo={size_info}"
-        ).resolve()
-        return self._http_client.get_json(url)
+        query = {"sizeInfo": size_info}
+        url = (self._base_uri / f"api/workspaces/{workspace_id}").resolve()
+        return self._http_client.get_json(url, params=query)
 
     def workspaces_get(
         self,
@@ -35,26 +34,16 @@ class WorkspaceService:
         name: Optional[str] = None,
         sharing_id: Optional[str] = None,
     ) -> Dict[str, Any]:
-        query = {}
-        if name:
-            query["name"] = name
-        if sharing_id:
-            query["sharingId"] = sharing_id
-        if only_app_mode:
-            query["onlyAppMode"] = str(only_app_mode)
-        query_args = "&".join(f"{key}={value}" for key, value in query.items())
-        url = (self._base_uri / f"api/workspaces?{query_args}").resolve()
-        return self._http_client.get_json(url)
+        query = {"name": name, "sharingId": sharing_id, "onlyAppMode": only_app_mode}
+        url = (self._base_uri / "api/workspaces").resolve()
+        return self._http_client.get_json(url, params=query)
 
     def projects_get(
         self, workspace_id: str, vcs_info: bool, include_disabled: bool
     ) -> Dict[str, Any]:
-        url = (
-            self._base_uri
-            / f"api/workspaces/{workspace_id}/projects?vcsInfo={vcs_info}"
-            f"&includeDisabled={include_disabled}"
-        ).resolve()
-        return self._http_client.get_json(url)
+        query = {"vcsInfo": vcs_info, "includeDisabled": include_disabled}
+        url = (self._base_uri / f"api/workspaces/{workspace_id}/projects").resolve()
+        return self._http_client.get_json(url, params=query)
 
     def project_create(self, workspace_id: str, name: str) -> Dict[str, Any]:
         url = (self._base_uri / f"api/workspaces/{workspace_id}/projects").resolve()
@@ -63,12 +52,9 @@ class WorkspaceService:
     def dependencies_get(
         self, workspace_id: str, vcs_info: bool, include_disabled: bool
     ) -> Dict[str, Any]:
-        url = (
-            self._base_uri
-            / f"api/workspaces/{workspace_id}/dependencies?vcsInfo={vcs_info}"
-            f"&includeDisabled={include_disabled}"
-        ).resolve()
-        return self._http_client.get_json(url)
+        query = {"vcsInfo": vcs_info, "includeDisabled": include_disabled}
+        url = (self._base_uri / f"api/workspaces/{workspace_id}/dependencies").resolve()
+        return self._http_client.get_json(url, params=query)
 
     def workspace_export_setup(
         self,
@@ -119,13 +105,10 @@ class WorkspaceService:
     def experiments_get(
         self, workspace_id: str, class_path: Optional[str] = None
     ) -> Dict[str, Any]:
-        class_path_query = f"?classPath={class_path}" if class_path else ""
-        url = (
-            self._base_uri
-            / f"api/workspaces/{workspace_id}/experiments{class_path_query}"
-        ).resolve()
+        class_path_query = {"classPath": class_path}
+        url = (self._base_uri / f"api/workspaces/{workspace_id}/experiments").resolve()
         return self._http_client.get_json(
-            url, headers={"Accept": self._experiment_schema}
+            url, headers={"Accept": self._experiment_schema}, params=class_path_query
         )
 
     def experiment_get(self, workspace_id: str, experiment_id: str) -> Dict[str, Any]:
@@ -153,11 +136,11 @@ class WorkspaceService:
     def shared_definition_get(
         self, workspace_id: str, strict: bool = False
     ) -> Dict[str, Any]:
+        query = {"strict": strict}
         url = (
-            self._base_uri / f"api/workspaces/{workspace_id}/"
-            f"sharing-definition?strict={'true' if strict else 'false'}"
+            self._base_uri / f"api/workspaces/{workspace_id}/sharing-definition"
         ).resolve()
-        return self._http_client.get_json(url)
+        return self._http_client.get_json(url, params=query)
 
     def import_from_zip(self, path_to_workspace: str) -> Dict[str, Any]:
         url = (self._base_uri / "api/workspace-imports").resolve()
@@ -226,24 +209,20 @@ class WorkspaceService:
         type: Optional[str] = None,
         group_name: Optional[str] = None,
     ) -> Dict[str, Any]:
-        query = {}
-        if name:
-            query["workspaceName"] = name
-        if has_data:
-            query["hasData"] = str(has_data)
+        query = {
+            "workspaceName": name,
+            "hasData": has_data,
+            "ownerUsername": owner_username,
+            "type": type,
+            "groupName": group_name,
+        }
         if first > 0:
-            query["first"] = str(first)
+            query["first"] = first
         if maximum >= 0:
-            query["max"] = str(maximum)
-        if owner_username:
-            query["ownerUsername"] = owner_username
-        if type:
-            query["type"] = type
-        if group_name:
-            query["groupName"] = group_name
-        query_args = "&".join(f"{key}={value}" for key, value in query.items())
-        url = (self._base_uri / f"api/published-workspaces?{query_args}").resolve()
-        resp = self._http_client.get_json_response(url)
+            query["max"] = maximum
+
+        url = (self._base_uri / "api/published-workspaces").resolve()
+        resp = self._http_client.get_json_response(url, params=query)
         return resp.data
 
     def get_published_workspaces_by_kind(
@@ -252,18 +231,13 @@ class WorkspaceService:
         first: int = 0,
         maximum: int = 20,
     ) -> Dict[str, Any]:
-        query = {}
-        if kind:
-            query["kind"] = kind
+        query = {"kind": kind}
         if first > 0:
             query["first"] = str(first)
         if maximum >= 0:
             query["max"] = str(maximum)
-        query_args = "&".join(f"{key}={value}" for key, value in query.items())
-        url = (
-            self._base_uri / f"/api/published-workspaces/access/users?{query_args}"
-        ).resolve()
-        resp = self._http_client.get_json_response(url)
+        url = (self._base_uri / "/api/published-workspaces/access/users").resolve()
+        resp = self._http_client.get_json_response(url, params=query)
         return resp.data
 
     def get_published_workspace(self, sharing_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
The requests library supports query strings to be sent for a request in the params arument See https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls. This is a safer and neater approach than embedding them as raw strings in the url.