### PR TITLE
fix: ensure that client can always be imported with other modelon packages in all cases

### DIFF
--- a/modelon/__init__.py
+++ b/modelon/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore

--- a/modelon/impact/__init__.py
+++ b/modelon/impact/__init__.py
@@ -1,0 +1,1 @@
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore


### PR DESCRIPTION
This MR is to unify how other 'modelon-impact-*' packages handles the top level init files. Without this it is for example not possible to source install another 'modelon-impact-*' package if the client package is installed (as only modelon package or installed last).