### PR TITLE
chore: update compile FMU tests to be more deterministic

### DIFF
--- a/tests/impact/client/entities/test_model_exe.py
+++ b/tests/impact/client/entities/test_model_exe.py
@@ -24,19 +24,15 @@ class TestModelExecutable:
         assert fmu.id
         assert fmu.is_successful()
         settable_params = fmu.get_settable_parameters()
-        assert len(settable_params) == 76
         assert "Bessel.gain" in settable_params
         log = fmu.get_log()
-        assert log == "\n"
+        assert log
         log.show()
         out, err = capfd.readouterr()
-        assert out == "\n\n"
-        assert fmu.metadata == {
-            "steady_state": {
-                "residual_variable_count": 0,
-                "iteration_variable_count": 0,
-            }
-        }
+        assert out
+        metadata = fmu.metadata["steady_state"]
+        assert "residual_variable_count" in metadata
+        assert "iteration_variable_count" in metadata
         assert fmu.run_info.status == ModelExecutableStatus.SUCCESSFUL
         assert fmu.run_info.errors == []
 


### PR DESCRIPTION
The integration tests were failing due to change in OCT as reported here - https://modelonproducts.atlassian.net/browse/INS-841. (See comments) which added a new internal parameter in the settable parameters.