### PR TITLE
fix: accept any artifact content type

### DIFF
--- a/.secrets/README.md
+++ b/.secrets/README.md
@@ -1,3 +1,4 @@
 # Secrets
 
-This folder contains the MI api key and Jupterhub token required to authenticate against MI to generate the VCR test cassettes. Save the Modelon impact api key in the api.key file and the jupyterhub token in jupyterhub-api.key file in this folder. See https://modelon-impact-client.readthedocs.io/en/latest/authentication_with_modelon_impact.html for information on how to generate them.
+This folder contains the MI api key required to authenticate against MI to generate the VCR test cassettes.
+Save the Modelon impact api key in the api.key file in this folder. See https://modelon-impact-client.readthedocs.io/en/latest/authentication_with_modelon_impact.html for information on how to generate them.

--- a/modelon/impact/client/sal/experiment.py
+++ b/modelon/impact/client/sal/experiment.py
@@ -197,7 +197,7 @@ class ExperimentService:
             / f"api/workspaces/{workspace_id}/experiments/{experiment_id}/cases/"
             f"{case_id}/custom-artifacts/{artifact_id}"
         ).resolve()
-        resp = self._http_client.get_octet_response(url)
+        resp = self._http_client.get_file_response(url)
         return resp.stream, resp.file_name
 
     def case_artifacts_meta_get(

--- a/modelon/impact/client/sal/http.py
+++ b/modelon/impact/client/sal/http.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional
 from modelon.impact.client.sal.context import Context
 from modelon.impact.client.sal.request import (
     RequestCSV,
+    RequestFileStream,
     RequestJSON,
     RequestMatStream,
     RequestOctetStream,
@@ -13,6 +14,7 @@ from modelon.impact.client.sal.request import (
 )
 from modelon.impact.client.sal.response import (
     CSVResponse,
+    FileResponse,
     JSONResponse,
     MatStreamResponse,
     OctetStreamResponse,
@@ -66,6 +68,10 @@ class HTTPClient:
 
     def get_octet_response(self, url: str) -> OctetStreamResponse:
         request = RequestOctetStream(self._context, "GET", url)
+        return request.execute()
+
+    def get_file_response(self, url: str) -> FileResponse:
+        request = RequestFileStream(self._context, "GET", url)
         return request.execute()
 
     def get_zip(self, url: str) -> bytes:

--- a/modelon/impact/client/sal/request.py
+++ b/modelon/impact/client/sal/request.py
@@ -7,6 +7,7 @@ import requests
 from modelon.impact.client.sal import exceptions
 from modelon.impact.client.sal.response import (
     CSVResponse,
+    FileResponse,
     JSONResponse,
     MatStreamResponse,
     OctetStreamResponse,
@@ -186,3 +187,16 @@ class RequestMatStream(Request):
         headers: Optional[Dict[str, Any]] = None,
     ):
         super().__init__(context, method, url, MatStreamResponse, body, files, headers)
+
+
+class RequestFileStream(Request):
+    def __init__(
+        self,
+        context: Any,
+        method: str,
+        url: str,
+        body: Optional[Dict[str, Any]] = None,
+        files: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(context, method, url, FileResponse, body, files, headers)

--- a/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_import_custom_artifact_default_artifact_id.yaml
+++ b/tests/fixtures/vcr_cassettes/test_case/TestCase.test_case_import_custom_artifact_default_artifact_id.yaml
@@ -108,8 +108,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -284,8 +282,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -320,8 +316,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -352,8 +346,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -375,14 +367,14 @@ interactions:
   response:
     body:
       string: '{"definition": {"name": "impact-python-client-workspace1", "description":
-        "", "defaultProjectId": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "projects":
-        [{"reference": {"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038"}, "disabled":
+        "", "defaultProjectId": "5647d3e10045d4d812076676fe6f507df4a505ce", "projects":
+        [{"reference": {"id": "5647d3e10045d4d812076676fe6f507df4a505ce"}, "disabled":
         false, "disabledContent": []}], "dependencies": [{"reference": {"id": "fec43f77925949bd7e7c0f10ac49ebc1189dc840",
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "fa49bb39bc6e4e439ed07c52e791a07e", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1724383200550}, "id":
+        "format": "1.0.0", "guid": "a525d61cbfa545d882929fc8f59df34d", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1727751629782}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -397,8 +389,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -436,8 +426,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -455,14 +443,14 @@ interactions:
   response:
     body:
       string: '{"definition": {"name": "impact-python-client-workspace1", "description":
-        "", "defaultProjectId": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "projects":
-        [{"reference": {"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038"}, "disabled":
+        "", "defaultProjectId": "5647d3e10045d4d812076676fe6f507df4a505ce", "projects":
+        [{"reference": {"id": "5647d3e10045d4d812076676fe6f507df4a505ce"}, "disabled":
         false, "disabledContent": []}], "dependencies": [{"reference": {"id": "fec43f77925949bd7e7c0f10ac49ebc1189dc840",
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "fa49bb39bc6e4e439ed07c52e791a07e", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1724383200550}, "id":
+        "format": "1.0.0", "guid": "a525d61cbfa545d882929fc8f59df34d", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1727751629782}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -477,8 +465,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -492,21 +478,21 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/projects/8846294a20508e6aa118a9663cb8f0a41ccdc038
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/projects/5647d3e10045d4d812076676fe6f507df4a505ce
   response:
     body:
-      string: '{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "definition": {"name":
+      string: '{"id": "5647d3e10045d4d812076676fe6f507df4a505ce", "definition": {"name":
         "Project", "format": "1.0.0", "dependencies": [{"name": "Modelica", "versionSpecifier":
         "4.0.0"}], "content": [{"relpath": "Resources/Views", "contentType": "VIEWS",
-        "defaultDisabled": false, "id": "d21244da37ea468ca744cb5c20bfb81b"}, {"relpath":
+        "defaultDisabled": false, "id": "17afee8e4f2f4028aaab3e26484f76fd"}, {"relpath":
         "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled": false,
-        "id": "d2c3ac98074f45eb923732a0c2318020"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "5a4cf2cfa457458c96d2a91454cec63c"},
+        "id": "e038c532e2e64653a4ef383c5e7f6ce2"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "57dd4cb073224bbda65287f45a3a2d8c"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "f72fbfc73763475b9e82017594038eed"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "798cd6a8eb67445fa8bc3d03f054f258"},
+        false, "id": "2824aa66e5394bd1a67594d47753dbdd"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "6272a848030842ca85126ba652be987e"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "44a69a2ad9684b1bb16b257036ce15a4"}], "executionOptions":
+        "defaultDisabled": false, "id": "df47523d50374de5b2d5dadcf062a34b"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}'
     headers:
       Connection:
@@ -521,8 +507,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -555,8 +539,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -589,8 +571,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -623,8 +603,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -657,8 +635,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -687,7 +663,7 @@ interactions:
     uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments
   response:
     body:
-      string: '{"experiment_id": "modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d"}'
+      string: '{"experiment_id": "modelica_blocks_examples_pid_controller_20241001_030032_0916cb1"}'
     headers:
       Connection:
       - keep-alive
@@ -701,8 +677,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -718,7 +692,7 @@ interactions:
       Content-Length:
       - '0'
     method: POST
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
   response:
     body:
       string: ''
@@ -735,8 +709,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -750,7 +722,39 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
+  response:
+    body:
+      string: '{"finished_executions": 0, "total_executions": 1, "status": "pending",
+        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": false,
+        "stage": "compilation"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -769,8 +773,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -784,7 +786,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -803,8 +805,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -818,7 +818,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -837,8 +837,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -852,7 +850,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -871,8 +869,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -886,7 +882,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -905,8 +901,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -920,7 +914,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
   response:
     body:
       string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
@@ -939,8 +933,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -954,7 +946,71 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
+  response:
+    body:
+      string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
+        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": false,
+        "stage": "compilation"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
+  response:
+    body:
+      string: '{"finished_executions": 0, "total_executions": 1, "status": "running",
+        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": false,
+        "stage": "compilation"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 2, "status": "done",
@@ -974,8 +1030,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -989,7 +1043,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/execution
   response:
     body:
       string: '{"finished_executions": 2, "total_executions": 2, "status": "done",
@@ -1009,43 +1063,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-    method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/execution
-  response:
-    body:
-      string: '{"finished_executions": 2, "total_executions": 2, "status": "done",
-        "progresses": [{"message": "Simulating", "percentage": 0.0, "done": true,
-        "stage": "compilation"}, {"message": "Simulation at time 1", "percentage":
-        1.0, "done": true, "stage": "simulation"}]}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=utf-8
-      access-control-allow-headers:
-      - '*'
-      access-control-allow-methods:
-      - POST, PUT, GET, DELETE, OPTIONS
-      access-control-allow-origin:
-      - '*'
-      vary:
-      - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -1059,18 +1076,18 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1
   response:
     body:
-      string: '{"id": "case_1", "input": {"version": 2, "fmuId": "modelica_blocks_examples_pid_controller_20240823_032003_c6be3bb",
+      string: '{"id": "case_1", "input": {"version": 2, "fmuId": "modelica_blocks_examples_pid_controller_20241001_030032_610667d",
         "analysis": {"type": "dynamic", "simulationOptions": {"ncp": 500, "dynamic_diagnostics":
         false}, "solverOptions": {}, "simulationLogLevel": "WARNING", "parameters":
         [{"name": "start_time", "value": 0}, {"name": "final_time", "value": 1}, {"name":
         "interval", "value": 0}]}, "initializeFromCase": null, "initializeFromExternalResult":
         null, "parametrization": [], "structuralParametrization": [], "fmuBaseParametrization":
         []}, "meta": {"label": null, "orchestrator": false}, "run_info": {"status":
-        "successful", "datetime_started": 1724383206205, "consistent": true, "datetime_finished":
-        1724383206264}}'
+        "successful", "datetime_started": 1727751637711, "consistent": true, "datetime_finished":
+        1727751637765}}'
     headers:
       Connection:
       - keep-alive
@@ -1084,15 +1101,13 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
 - request:
-    body: "--ee6755d200b8b87b9587ee23afdd99c3\r\nContent-Disposition: form-data; name=\"file\";
-      filename=\"test_data.csv\"\r\n\r\nclutch_control_1,clutch_control_2,clutch_control_3,J1.w,J2.w,J3.w,J4.w\r\n0,0,0,1.0,1.0,1.0,1.0\r\n--ee6755d200b8b87b9587ee23afdd99c3\r\nContent-Disposition:
-      form-data; name=\"options\"; filename=\"options\"\r\n\r\n{\"overwrite\": false}\r\n--ee6755d200b8b87b9587ee23afdd99c3--\r\n"
+    body: "--0da18cc5f90b93a0f929a33882a0dbc7\r\nContent-Disposition: form-data; name=\"file\";
+      filename=\"test_data.csv\"\r\n\r\nclutch_control_1,clutch_control_2,clutch_control_3,J1.w,J2.w,J3.w,J4.w\r\n0,0,0,1.0,1.0,1.0,1.0\r\n--0da18cc5f90b93a0f929a33882a0dbc7\r\nContent-Disposition:
+      form-data; name=\"options\"; filename=\"options\"\r\n\r\n{\"overwrite\": false}\r\n--0da18cc5f90b93a0f929a33882a0dbc7--\r\n"
     headers:
       Accept:
       - '*/*'
@@ -1103,12 +1118,12 @@ interactions:
       Content-Length:
       - '370'
       Content-Type:
-      - multipart/form-data; boundary=ee6755d200b8b87b9587ee23afdd99c3
+      - multipart/form-data; boundary=0da18cc5f90b93a0f929a33882a0dbc7
     method: POST
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts-imports
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts-imports
   response:
     body:
-      string: '{"data": {"location": "api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts-imports/9e82f346ffec4e2881d71e0cad36b71d"}}'
+      string: '{"data": {"location": "api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts-imports/b146021bac3d4236a7603e9e0e206aa5"}}'
     headers:
       Connection:
       - keep-alive
@@ -1122,8 +1137,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 201
       message: Created
@@ -1137,11 +1150,11 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts-imports/9e82f346ffec4e2881d71e0cad36b71d
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts-imports/b146021bac3d4236a7603e9e0e206aa5
   response:
     body:
-      string: '{"data": {"id": "9e82f346ffec4e2881d71e0cad36b71d", "status": "ready",
-        "data": {"resourceUri": "/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts/imported_1",
+      string: '{"data": {"id": "b146021bac3d4236a7603e9e0e206aa5", "status": "ready",
+        "data": {"resourceUri": "/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts/imported_1",
         "artifactId": "imported_1"}}}'
     headers:
       Connection:
@@ -1156,8 +1169,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -1171,11 +1182,11 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts-imports/9e82f346ffec4e2881d71e0cad36b71d
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts-imports/b146021bac3d4236a7603e9e0e206aa5
   response:
     body:
-      string: '{"data": {"id": "9e82f346ffec4e2881d71e0cad36b71d", "status": "ready",
-        "data": {"resourceUri": "/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts/imported_1",
+      string: '{"data": {"id": "b146021bac3d4236a7603e9e0e206aa5", "status": "ready",
+        "data": {"resourceUri": "/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts/imported_1",
         "artifactId": "imported_1"}}}'
     headers:
       Connection:
@@ -1190,8 +1201,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -1205,11 +1214,11 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts-imports/9e82f346ffec4e2881d71e0cad36b71d
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts-imports/b146021bac3d4236a7603e9e0e206aa5
   response:
     body:
-      string: '{"data": {"id": "9e82f346ffec4e2881d71e0cad36b71d", "status": "ready",
-        "data": {"resourceUri": "/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts/imported_1",
+      string: '{"data": {"id": "b146021bac3d4236a7603e9e0e206aa5", "status": "ready",
+        "data": {"resourceUri": "/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts/imported_1",
         "artifactId": "imported_1"}}}'
     headers:
       Connection:
@@ -1224,8 +1233,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -1239,11 +1246,11 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts-imports/9e82f346ffec4e2881d71e0cad36b71d
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts-imports/b146021bac3d4236a7603e9e0e206aa5
   response:
     body:
-      string: '{"data": {"id": "9e82f346ffec4e2881d71e0cad36b71d", "status": "ready",
-        "data": {"resourceUri": "/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts/imported_1",
+      string: '{"data": {"id": "b146021bac3d4236a7603e9e0e206aa5", "status": "ready",
+        "data": {"resourceUri": "/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts/imported_1",
         "artifactId": "imported_1"}}}'
     headers:
       Connection:
@@ -1258,8 +1265,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -1273,7 +1278,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20240823_032002_ccc2a6d/cases/case_1/custom-artifacts
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts
   response:
     body:
       string: '{"data": {"items": [{"id": "imported_1", "downloadAs": "test_data.csv"}]}}'
@@ -1290,8 +1295,40 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+    method: GET
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/experiments/modelica_blocks_examples_pid_controller_20241001_030032_0916cb1/cases/case_1/custom-artifacts/imported_1
+  response:
+    body:
+      string: "clutch_control_1,clutch_control_2,clutch_control_3,J1.w,J2.w,J3.w,J4.w\r\n0,0,0,1.0,1.0,1.0,1.0"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/csv; charset=utf-8
+      access-control-allow-headers:
+      - '*'
+      access-control-allow-methods:
+      - POST, PUT, GET, DELETE, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      content-disposition:
+      - inline; filename="test_data.csv"
+      content-length:
+      - '93'
+      vary:
+      - Accept-Encoding
     status:
       code: 200
       message: OK
@@ -1309,14 +1346,14 @@ interactions:
   response:
     body:
       string: '{"data": {"items": [{"definition": {"name": "impact-python-client-workspace1",
-        "description": "", "defaultProjectId": "8846294a20508e6aa118a9663cb8f0a41ccdc038",
-        "projects": [{"reference": {"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038"},
+        "description": "", "defaultProjectId": "5647d3e10045d4d812076676fe6f507df4a505ce",
+        "projects": [{"reference": {"id": "5647d3e10045d4d812076676fe6f507df4a505ce"},
         "disabled": false, "disabledContent": []}], "dependencies": [{"reference":
         {"id": "fec43f77925949bd7e7c0f10ac49ebc1189dc840", "name": "Modelica", "version":
         "3.2.3"}, "disabled": true, "disabledContent": []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6",
         "name": "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent":
-        []}], "format": "1.0.0", "guid": "fa49bb39bc6e4e439ed07c52e791a07e", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1724383200550}, "id":
+        []}], "format": "1.0.0", "guid": "a525d61cbfa545d882929fc8f59df34d", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1727751629782}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}]}}'
     headers:
       Connection:
@@ -1331,8 +1368,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -1350,14 +1385,14 @@ interactions:
   response:
     body:
       string: '{"definition": {"name": "impact-python-client-workspace1", "description":
-        "", "defaultProjectId": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "projects":
-        [{"reference": {"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038"}, "disabled":
+        "", "defaultProjectId": "5647d3e10045d4d812076676fe6f507df4a505ce", "projects":
+        [{"reference": {"id": "5647d3e10045d4d812076676fe6f507df4a505ce"}, "disabled":
         false, "disabledContent": []}], "dependencies": [{"reference": {"id": "fec43f77925949bd7e7c0f10ac49ebc1189dc840",
         "name": "Modelica", "version": "3.2.3"}, "disabled": true, "disabledContent":
         []}, {"reference": {"id": "ac04a5da97bc2e11bffb7f41b2485da347846df6", "name":
         "Modelica", "version": "4.0.0"}, "disabled": false, "disabledContent": []}],
-        "format": "1.0.0", "guid": "fa49bb39bc6e4e439ed07c52e791a07e", "createdBy":
-        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1724383200550}, "id":
+        "format": "1.0.0", "guid": "a525d61cbfa545d882929fc8f59df34d", "createdBy":
+        "5c18f9f3-ef07-453a-9965-9de61f6d53f4", "createdAt": 1727751629782}, "id":
         "impact-python-client-workspace1", "conversion": {"state": "UP_TO_DATE"}}'
     headers:
       Connection:
@@ -1372,8 +1407,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -1390,18 +1423,18 @@ interactions:
     uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/workspaces/impact-python-client-workspace1/projects
   response:
     body:
-      string: '{"data": {"items": [{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038",
+      string: '{"data": {"items": [{"id": "5647d3e10045d4d812076676fe6f507df4a505ce",
         "definition": {"name": "Project", "format": "1.0.0", "dependencies": [{"name":
         "Modelica", "versionSpecifier": "4.0.0"}], "content": [{"relpath": "Resources/Views",
-        "contentType": "VIEWS", "defaultDisabled": false, "id": "d21244da37ea468ca744cb5c20bfb81b"},
+        "contentType": "VIEWS", "defaultDisabled": false, "id": "17afee8e4f2f4028aaab3e26484f76fd"},
         {"relpath": "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled":
-        false, "id": "d2c3ac98074f45eb923732a0c2318020"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "5a4cf2cfa457458c96d2a91454cec63c"},
+        false, "id": "e038c532e2e64653a4ef383c5e7f6ce2"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "57dd4cb073224bbda65287f45a3a2d8c"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "f72fbfc73763475b9e82017594038eed"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "798cd6a8eb67445fa8bc3d03f054f258"},
+        false, "id": "2824aa66e5394bd1a67594d47753dbdd"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "6272a848030842ca85126ba652be987e"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "44a69a2ad9684b1bb16b257036ce15a4"}], "executionOptions":
+        "defaultDisabled": false, "id": "df47523d50374de5b2d5dadcf062a34b"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}]}}'
     headers:
       Connection:
@@ -1418,8 +1451,6 @@ interactions:
       - '1043'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -1435,21 +1466,21 @@ interactions:
       Content-Length:
       - '0'
     method: DELETE
-    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/projects/8846294a20508e6aa118a9663cb8f0a41ccdc038
+    uri: /user/5c18f9f3-ef07-453a-9965-9de61f6d53f4/impact/api/projects/5647d3e10045d4d812076676fe6f507df4a505ce
   response:
     body:
-      string: '{"id": "8846294a20508e6aa118a9663cb8f0a41ccdc038", "definition": {"name":
+      string: '{"id": "5647d3e10045d4d812076676fe6f507df4a505ce", "definition": {"name":
         "Project", "format": "1.0.0", "dependencies": [{"name": "Modelica", "versionSpecifier":
         "4.0.0"}], "content": [{"relpath": "Resources/Views", "contentType": "VIEWS",
-        "defaultDisabled": false, "id": "d21244da37ea468ca744cb5c20bfb81b"}, {"relpath":
+        "defaultDisabled": false, "id": "17afee8e4f2f4028aaab3e26484f76fd"}, {"relpath":
         "Resources/Favorites", "contentType": "FAVORITES", "defaultDisabled": false,
-        "id": "d2c3ac98074f45eb923732a0c2318020"}, {"relpath": "Resources/CustomFunctions",
-        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "5a4cf2cfa457458c96d2a91454cec63c"},
+        "id": "e038c532e2e64653a4ef383c5e7f6ce2"}, {"relpath": "Resources/CustomFunctions",
+        "contentType": "CUSTOM_FUNCTIONS", "defaultDisabled": false, "id": "57dd4cb073224bbda65287f45a3a2d8c"},
         {"relpath": "Resources/Custom", "contentType": "GENERIC", "defaultDisabled":
-        false, "id": "f72fbfc73763475b9e82017594038eed"}, {"relpath": "ReferenceResults",
-        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "798cd6a8eb67445fa8bc3d03f054f258"},
+        false, "id": "2824aa66e5394bd1a67594d47753dbdd"}, {"relpath": "ReferenceResults",
+        "contentType": "REFERENCE_RESULTS", "defaultDisabled": false, "id": "6272a848030842ca85126ba652be987e"},
         {"relpath": "Resources/ExperimentDefinitions", "contentType": "EXPERIMENT_DEFINITIONS",
-        "defaultDisabled": false, "id": "44a69a2ad9684b1bb16b257036ce15a4"}], "executionOptions":
+        "defaultDisabled": false, "id": "df47523d50374de5b2d5dadcf062a34b"}], "executionOptions":
         []}, "projectType": "LOCAL", "storageLocation": "USERSPACE"}'
     headers:
       Connection:
@@ -1464,8 +1495,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK
@@ -1498,8 +1527,6 @@ interactions:
       - '*'
       vary:
       - Accept-Encoding
-      x-powered-by:
-      - Express
     status:
       code: 200
       message: OK

--- a/tests/impact/client/entities/test_case.py
+++ b/tests/impact/client/entities/test_case.py
@@ -339,7 +339,12 @@ class TestCase:
         custom_artifact = case.import_custom_artifact(
             path_to_artifact=TEST_CSV_RESULT_PATH
         ).wait()
+
         assert custom_artifact.id == "imported_1"
+
+        # TODO: extend test
+        #    data = custom_artifact.get_data()
+        #    assert data == open(TEST_CSV_RESULT_PATH, "rb").read()
 
     @pytest.mark.vcr()
     def test_case_import_result(self, client_helper: ClientHelper):

--- a/tests/impact/client/entities/test_case.py
+++ b/tests/impact/client/entities/test_case.py
@@ -342,9 +342,8 @@ class TestCase:
 
         assert custom_artifact.id == "imported_1"
 
-        # TODO: extend test
-        #    data = custom_artifact.get_data()
-        #    assert data == open(TEST_CSV_RESULT_PATH, "rb").read()
+        data = custom_artifact.get_data()
+        assert data == open(TEST_CSV_RESULT_PATH, "rb").read()
 
     @pytest.mark.vcr()
     def test_case_import_result(self, client_helper: ClientHelper):


### PR DESCRIPTION
See FLOW-652:
Artifact download end-point can return different content types depending on the file extension. Client should accept any.