### PR TITLE
chore(docs): added quickstart for setting sim opts for fmu based workflow

### DIFF
--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -22,8 +22,12 @@ A simple example using the :ref:`FMU based workflow <FMU based workflow>` is sho
    model = workspace.get_model("Modelica.Blocks.Examples.PID_Controller")
    fmu = model.compile(compiler_options=dynamic.get_compiler_options()).wait()
 
+   # Definiting simulation and solver options
+   solver_options = {'atol':1e-8}
+   simulation_options = dynamic.get_simulation_options().with_values(ncp=500)
+
    # Execute experiment
-   experiment_definition = fmu.new_experiment_definition(dynamic)
+   experiment_definition = fmu.new_experiment_definition(dynamic, solver_options, simulation_options)
    exp = workspace.execute(experiment_definition).wait()
 
    # Plot Trajectory


### PR DESCRIPTION
This PR improves the quickstart for FMU based experiment with snippet to set simulation and solver options.