### PR TITLE
feat: add user agent that is specific for the client

### DIFF
--- a/modelon/impact/client/sal/request.py
+++ b/modelon/impact/client/sal/request.py
@@ -37,12 +37,13 @@ class Request:
         self.body = body
         self.files = files
         self.request_type = request_type
-        self.headers = headers
+        self.headers = headers or {}
+        self.headers.update({"User-Agent": "impact-python-client"})
         self.params = params
 
     def execute(self, check_return: bool = True) -> Any:
         try:
-            extra_headers = self.headers or {}
+            extra_headers = self.headers
             headers = {**self.context.session.headers, **extra_headers}
             if self.method == "POST":
                 logger.debug("POST with JSON body: {}".format(self.body))


### PR DESCRIPTION
In order for the python-client to uniquely identify itself against the server, we need to add a specific header in order to separate it from other consumers.