### PR TITLE
fix: correct input passed to to_domain_parameter_value method in compile_fmu

### DIFF
--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -184,7 +184,7 @@ class Model(ModelInterface):
                 self._workspace_id, body, True
             )
             modifiers_dict = {
-                modifier["name"]: to_domain_parameter_value(modifier["value"])
+                modifier["name"]: to_domain_parameter_value(modifier)
                 for modifier in modifiers
             }
             if fmu_id:


### PR DESCRIPTION
This MR fixes a but reported in https://modelonproducts.atlassian.net/browse/SUP-829. 
The data returned by the POST /workspaces/{workspace}/model-executables is of the form when a external modification is detected. 

```
{
  "id": "sandbox_pid_controller_20250716_065052_6115f67",
  "parameters": {
    "inertia1.J": "9"
  },
  "parametersResolved": [
    {
      "name": "inertia1.J",
      "value": 9,
      "dataType": "REAL"
    }
  ],
  "parametersMissing": []
}
```