### PR TITLE
fix: corrected the regex for file_name match for file_name property

### DIFF
--- a/modelon/impact/client/sal/response.py
+++ b/modelon/impact/client/sal/response.py
@@ -165,7 +165,13 @@ class FileResponse(Response):
     @property
     def file_name(self) -> str:
         d = self.headers["content-disposition"]
-        return re.findall("filename=(.+)", d)[0].strip('"')
+        found_file = re.findall(r"filename\*\s*=\s*UTF-8''(.+)", d)
+        if found_file:
+            return found_file[0].strip('"')
+        found_file = re.findall("filename=(.+)", d)
+        if found_file:
+            return found_file[0].strip('"')
+        return ""
 
 
 class CSVResponse(FileResponse):


### PR DESCRIPTION
This PR fixes https://modelonproducts.atlassian.net/browse/INS-1488. 
@efredriksson-modelon ,  this fix may likely cause older MI versions to return an empty string. Should we do this in a backward compatible way?