### PR TITLE
refactor: add factory classmethods for building CustomFunction and SimpleModelicaExperimentDefinition from API response dicts

### DIFF
--- a/modelon/impact/client/entities/_initialize_from.py
+++ b/modelon/impact/client/entities/_initialize_from.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+from modelon.impact.client.entities.external_result import ExternalResult
+
+if TYPE_CHECKING:
+    from modelon.impact.client.entities.case import Case
+    from modelon.impact.client.entities.experiment import Experiment
+    from modelon.impact.client.sal.service import Service
+
+
+def _resolve_initialize_from(
+    workspace_id: str,
+    sal: Service,
+    modifiers: Dict[str, Any],
+) -> Optional[Union[Case, Experiment, ExternalResult]]:
+    if "initializeFrom" in modifiers:
+        from modelon.impact.client.entities.experiment import Experiment
+
+        resp = sal.workspace.experiment_get(workspace_id, modifiers["initializeFrom"])
+        return Experiment(workspace_id, resp["id"], sal, resp)
+    elif "initializeFromCase" in modifiers:
+        from modelon.impact.client.entities.case import Case
+
+        exp_id = modifiers["initializeFromCase"]["experimentId"]
+        case_id = modifiers["initializeFromCase"]["caseId"]
+        case_data = sal.experiment.case_get(workspace_id, exp_id, case_id)
+        return Case(case_data["id"], workspace_id, exp_id, sal, case_data)
+    elif "initializeFromExternalResult" in modifiers:
+        return ExternalResult(
+            result_id=modifiers["initializeFromExternalResult"], service=sal
+        )
+    return None

--- a/modelon/impact/client/entities/case.py
+++ b/modelon/impact/client/entities/case.py
@@ -7,7 +7,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Text, Tuple, Union
 from modelon.impact.client import exceptions
 from modelon.impact.client.entities.asserts import assert_successful_operation
 from modelon.impact.client.entities.custom_artifact import CustomArtifact
-from modelon.impact.client.entities.custom_function import CustomFunction
+from modelon.impact.client.entities.custom_function import (
+    CustomFunction,
+    _build_custom_function,
+)
 from modelon.impact.client.entities.external_result import ExternalResult
 from modelon.impact.client.entities.interfaces.case import CaseReference
 from modelon.impact.client.entities.log import Log
@@ -770,7 +773,7 @@ class Case(CaseReference):
         meta = self._sal.custom_function.custom_function_get(
             self._workspace_id, self.input.analysis.analysis_function
         )
-        return CustomFunction.from_response_dict(
+        return _build_custom_function(
             self._workspace_id, meta, self._sal
         ).with_parameters(**self.input.analysis.parameters)
 

--- a/modelon/impact/client/entities/case.py
+++ b/modelon/impact/client/entities/case.py
@@ -767,16 +767,12 @@ class Case(CaseReference):
         )
 
     def _get_custom_function(self) -> CustomFunction:
-        custom_function_meta = self._sal.custom_function.custom_function_get(
+        meta = self._sal.custom_function.custom_function_get(
             self._workspace_id, self.input.analysis.analysis_function
         )
-        custom_function_params = self.input.analysis.parameters
-        return CustomFunction(
-            self._workspace_id,
-            custom_function_meta["name"],
-            custom_function_meta["parameters"],
-            self._sal,
-        ).with_parameters(**custom_function_params)
+        return CustomFunction.from_response_dict(
+            self._workspace_id, meta, self._sal
+        ).with_parameters(**self.input.analysis.parameters)
 
     def get_definition(self) -> SimpleModelicaExperimentDefinition:
         """Get an experiment definition that can be used to reproduce this case result.

--- a/modelon/impact/client/entities/custom_function.py
+++ b/modelon/impact/client/entities/custom_function.py
@@ -91,6 +91,14 @@ class ParameterDict(dict):
         return new_dict
 
 
+def _build_custom_function(
+    workspace_id: str,
+    meta: Dict[str, Any],
+    sal: Service,
+) -> CustomFunction:
+    return CustomFunction(workspace_id, meta["name"], meta["parameters"], sal)
+
+
 class CustomFunction(CustomFunctionInterface):
     """Class containing CustomFunction functionalities."""
 
@@ -168,15 +176,6 @@ class CustomFunction(CustomFunctionInterface):
                 parameter.value = value
 
         return new
-
-    @classmethod
-    def from_response_dict(
-        cls,
-        workspace_id: str,
-        meta: Dict[str, Any],
-        sal: Service,
-    ) -> CustomFunction:
-        return cls(workspace_id, meta["name"], meta["parameters"], sal)
 
     @property
     def parameter_values(self) -> ParameterDict:

--- a/modelon/impact/client/entities/custom_function.py
+++ b/modelon/impact/client/entities/custom_function.py
@@ -169,6 +169,15 @@ class CustomFunction(CustomFunctionInterface):
 
         return new
 
+    @classmethod
+    def from_response_dict(
+        cls,
+        workspace_id: str,
+        meta: Dict[str, Any],
+        sal: Service,
+    ) -> CustomFunction:
+        return cls(workspace_id, meta["name"], meta["parameters"], sal)
+
     @property
     def parameter_values(self) -> ParameterDict:
         """Custom_function parameters and value as a dictionary."""

--- a/modelon/impact/client/entities/experiment.py
+++ b/modelon/impact/client/entities/experiment.py
@@ -8,7 +8,10 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from modelon.impact.client.entities.asserts import assert_variable_in_result
 from modelon.impact.client.entities.case import Case
-from modelon.impact.client.entities.custom_function import CustomFunction
+from modelon.impact.client.entities.custom_function import (
+    CustomFunction,
+    _build_custom_function,
+)
 from modelon.impact.client.entities.external_result import ExternalResult
 from modelon.impact.client.entities.interfaces.experiment import ExperimentReference
 from modelon.impact.client.entities.model import (
@@ -739,7 +742,7 @@ class Experiment(ExperimentReference):
             self._workspace_id, self.custom_function
         )
         params = {p["name"]: p["value"] for p in analysis.get("parameters", [])}
-        return CustomFunction.from_response_dict(
+        return _build_custom_function(
             self._workspace_id, meta, self._sal
         ).with_parameters(**params)
 

--- a/modelon/impact/client/entities/experiment.py
+++ b/modelon/impact/client/entities/experiment.py
@@ -25,12 +25,6 @@ from modelon.impact.client.entities.model_executable import (
     SimpleFMUExperimentDefinition,
 )
 from modelon.impact.client.entities.status import ExperimentStatus
-from modelon.impact.client.experiment_definition.expansion import (
-    ExpansionAlgorithm,
-    FullFactorial,
-    LatinHypercube,
-    Sobol,
-)
 from modelon.impact.client.experiment_definition.extension import (
     SimpleExperimentExtension,
 )
@@ -674,11 +668,6 @@ class Experiment(ExperimentReference):
             definition = _build_simple_modelica_experiment_definition(
                 model, base, custom_function, self._workspace_id, self._sal
             )
-            expansion = base.get("expansion", {})
-            expansion = self._get_expansion_algorithm(
-                expansion.get("algorithm"), expansion.get("parameters", {})
-            )
-            definition = definition.with_expansion(expansion=expansion)
         else:
             fmu_id = base["model"]["fmu"]["id"]
             definition = SimpleFMUExperimentDefinition(
@@ -689,11 +678,11 @@ class Experiment(ExperimentReference):
                 simulation_log_level=analysis["simulationLogLevel"],
                 initialize_from=self._get_initialize_from(base["modifiers"]),
             )  # type: ignore
-        modifiers = {
-            mod["name"]: get_operator_from_dict(mod)
-            for mod in base["modifiers"]["variables"]
-        }
-        definition = definition.with_modifiers(modifiers=modifiers)
+            modifiers = {
+                mod["name"]: get_operator_from_dict(mod)
+                for mod in base["modifiers"]["variables"]
+            }
+            definition = definition.with_modifiers(modifiers=modifiers)
         extensions = self._get_info()["experiment"].get("extensions")
         if extensions:
             sim_exts = []
@@ -736,18 +725,6 @@ class Experiment(ExperimentReference):
         return _build_custom_function(
             self._workspace_id, meta, self._sal
         ).with_parameters(**params)
-
-    def _get_expansion_algorithm(
-        self, algorithm: str, parameters: Dict[str, Any]
-    ) -> ExpansionAlgorithm:
-        if algorithm == "SOBOL":
-            return Sobol(samples=parameters["samples"])
-        elif algorithm == "LATINHYPERCUBE":
-            return LatinHypercube(
-                samples=parameters["samples"], seed=parameters.get("seed")
-            )
-        else:
-            return FullFactorial()
 
     @classmethod
     def from_reference(cls, reference: ExperimentReference) -> Experiment:

--- a/modelon/impact/client/entities/experiment.py
+++ b/modelon/impact/client/entities/experiment.py
@@ -6,6 +6,7 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from modelon.impact.client.entities._initialize_from import _resolve_initialize_from
 from modelon.impact.client.entities.asserts import assert_variable_in_result
 from modelon.impact.client.entities.case import Case
 from modelon.impact.client.entities.custom_function import (
@@ -32,6 +33,9 @@ from modelon.impact.client.experiment_definition.expansion import (
 )
 from modelon.impact.client.experiment_definition.extension import (
     SimpleExperimentExtension,
+)
+from modelon.impact.client.experiment_definition.model_based import (
+    _build_simple_modelica_experiment_definition,
 )
 from modelon.impact.client.experiment_definition.operators import get_operator_from_dict
 from modelon.impact.client.operations import experiment
@@ -630,17 +634,7 @@ class Experiment(ExperimentReference):
     def _get_initialize_from(
         self, modifiers: Dict[str, Any]
     ) -> Optional[Union[Case, Experiment, ExternalResult]]:
-        if "initializeFrom" in modifiers:
-            exp_id = modifiers["initializeFrom"]
-            return self._get_initialize_from_experiment(exp_id)
-        elif "initializeFromCase" in modifiers:
-            case_id = modifiers["initializeFromCase"]["caseId"]
-            exp_id = modifiers["initializeFromCase"]["experimentId"]
-            return self._get_initialize_from_case(exp_id, case_id)
-        elif "initializeFromExternalResult" in modifiers:
-            ext_result_id = modifiers["initializeFromExternalResult"]
-            return ExternalResult(result_id=ext_result_id, service=self._sal)
-        return None
+        return _resolve_initialize_from(self._workspace_id, self._sal, modifiers)
 
     def _get_extension_initialize_from(
         self, modifiers: Dict[str, Any]
@@ -677,11 +671,8 @@ class Experiment(ExperimentReference):
                 project_id="",
                 service=self._sal,
             )
-            definition = SimpleModelicaExperimentDefinition.from_experiment_base_dict(
-                model,
-                base,
-                custom_function,
-                initialize_from=self._get_initialize_from(base["modifiers"]),
+            definition = _build_simple_modelica_experiment_definition(
+                model, base, custom_function, self._workspace_id, self._sal
             )
             expansion = base.get("expansion", {})
             expansion = self._get_expansion_algorithm(

--- a/modelon/impact/client/entities/experiment.py
+++ b/modelon/impact/client/entities/experiment.py
@@ -674,19 +674,10 @@ class Experiment(ExperimentReference):
                 project_id="",
                 service=self._sal,
             )
-            modelica = base["model"]["modelica"]
-            definition = SimpleModelicaExperimentDefinition(
-                model=model,
-                custom_function=custom_function,
-                compiler_options=self.get_compiler_options(),
-                fmi_target=modelica["fmiTarget"],
-                fmi_version=modelica["fmiVersion"],
-                platform=modelica["platform"],
-                compiler_log_level=modelica["compilerLogLevel"],
-                runtime_options=self.get_runtime_options(),
-                solver_options=self.get_solver_options(),
-                simulation_options=self.get_simulation_options(),
-                simulation_log_level=analysis["simulationLogLevel"],
+            definition = SimpleModelicaExperimentDefinition.from_experiment_base_dict(
+                model,
+                base,
+                custom_function,
                 initialize_from=self._get_initialize_from(base["modifiers"]),
             )
             expansion = base.get("expansion", {})
@@ -744,18 +735,13 @@ class Experiment(ExperimentReference):
         return definition
 
     def _get_custom_function(self, analysis: Dict[str, Any]) -> CustomFunction:
-        custom_function_meta = self._sal.custom_function.custom_function_get(
+        meta = self._sal.custom_function.custom_function_get(
             self._workspace_id, self.custom_function
         )
-        custom_function_params = {
-            param["name"]: param["value"] for param in analysis.get("parameters", [])
-        }
-        return CustomFunction(
-            self._workspace_id,
-            custom_function_meta["name"],
-            custom_function_meta["parameters"],
-            self._sal,
-        ).with_parameters(**custom_function_params)
+        params = {p["name"]: p["value"] for p in analysis.get("parameters", [])}
+        return CustomFunction.from_response_dict(
+            self._workspace_id, meta, self._sal
+        ).with_parameters(**params)
 
     def _get_expansion_algorithm(
         self, algorithm: str, parameters: Dict[str, Any]

--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from modelon.impact.client.configuration import Experimental
-from modelon.impact.client.entities.custom_function import CustomFunction
+from modelon.impact.client.entities.custom_function import (
+    CustomFunction,
+    _build_custom_function,
+)
 from modelon.impact.client.entities.interfaces.model import ModelInterface
 from modelon.impact.client.entities.model_executable import ModelExecutable
 from modelon.impact.client.entities.project import Project
@@ -254,7 +257,7 @@ class Model(ModelInterface):
                 self._workspace_id, analysis["type"]
             )
             params = {p["name"]: p["value"] for p in analysis.get("parameters", [])}
-            custom_function = CustomFunction.from_response_dict(
+            custom_function = _build_custom_function(
                 self._workspace_id, cf_meta, self._sal
             ).with_parameters(**params)
             definition = SimpleModelicaExperimentDefinition.from_experiment_base_dict(

--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -249,43 +249,16 @@ class Model(ModelInterface):
         entries = []
         for item in resp["data"]["items"]:
             base = item["experiment"]["base"]
-            modelica = base["model"]["modelica"]
             analysis = base["analysis"]
-
-            custom_function_meta = self._sal.custom_function.custom_function_get(
+            cf_meta = self._sal.custom_function.custom_function_get(
                 self._workspace_id, analysis["type"]
             )
-            custom_function_params = {
-                param["name"]: param["value"]
-                for param in analysis.get("parameters", [])
-            }
-            custom_function = CustomFunction(
-                self._workspace_id,
-                custom_function_meta["name"],
-                custom_function_meta["parameters"],
-                self._sal,
-            ).with_parameters(**custom_function_params)
-
-            definition = SimpleModelicaExperimentDefinition(
-                model=self,
-                custom_function=custom_function,
-                compiler_options=CompilerOptions(
-                    modelica.get("compilerOptions", {}), custom_function.name
-                ),
-                fmi_target=modelica.get("fmiTarget", "me"),
-                fmi_version=modelica.get("fmiVersion", "2.0"),
-                platform=modelica.get("platform", "auto"),
-                compiler_log_level=modelica.get("compilerLogLevel", "warning"),
-                runtime_options=RuntimeOptions(
-                    modelica.get("runtimeOptions", {}), custom_function.name
-                ),
-                solver_options=SolverOptions(
-                    analysis.get("solverOptions", {}), custom_function.name
-                ),
-                simulation_options=SimulationOptions(
-                    analysis.get("simulationOptions", {}), custom_function.name
-                ),
-                simulation_log_level=analysis.get("simulationLogLevel", "WARNING"),
+            params = {p["name"]: p["value"] for p in analysis.get("parameters", [])}
+            custom_function = CustomFunction.from_response_dict(
+                self._workspace_id, cf_meta, self._sal
+            ).with_parameters(**params)
+            definition = SimpleModelicaExperimentDefinition.from_experiment_base_dict(
+                self, base, custom_function
             )
             meta = item["metadata"]
             entries.append(

--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -15,6 +15,7 @@ from modelon.impact.client.entities.model_executable import ModelExecutable
 from modelon.impact.client.entities.project import Project
 from modelon.impact.client.experiment_definition.model_based import (
     SimpleModelicaExperimentDefinition,
+    _build_simple_modelica_experiment_definition,
 )
 from modelon.impact.client.experiment_definition.modifiers import Enumeration
 from modelon.impact.client.operations.fmu_import import FMUImportOperation
@@ -260,8 +261,8 @@ class Model(ModelInterface):
             custom_function = _build_custom_function(
                 self._workspace_id, cf_meta, self._sal
             ).with_parameters(**params)
-            definition = SimpleModelicaExperimentDefinition.from_experiment_base_dict(
-                self, base, custom_function
+            definition = _build_simple_modelica_experiment_definition(
+                self, base, custom_function, self._workspace_id, self._sal
             )
             meta = item["metadata"]
             entries.append(

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -9,7 +9,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Union
 
 from modelon.impact.client.configuration import Experimental
-from modelon.impact.client.entities.custom_function import CustomFunction
+from modelon.impact.client.entities.custom_function import (
+    CustomFunction,
+    _build_custom_function,
+)
 from modelon.impact.client.entities.experiment import Experiment
 from modelon.impact.client.entities.external_result import ExternalResult
 from modelon.impact.client.entities.file_uri import ModelicaResourceURI
@@ -731,9 +734,7 @@ class Workspace(WorkspaceInterface):
         custom_function = self._sal.custom_function.custom_function_get(
             self._workspace_id, name
         )
-        return CustomFunction.from_response_dict(
-            self._workspace_id, custom_function, self._sal
-        )
+        return _build_custom_function(self._workspace_id, custom_function, self._sal)
 
     def get_custom_functions(self) -> List[CustomFunction]:
         """Returns a list of CustomFunctions class objects.
@@ -750,7 +751,7 @@ class Workspace(WorkspaceInterface):
             self._workspace_id
         )
         return [
-            CustomFunction.from_response_dict(self._workspace_id, cf, self._sal)
+            _build_custom_function(self._workspace_id, cf, self._sal)
             for cf in custom_functions["data"]["items"]
         ]
 

--- a/modelon/impact/client/entities/workspace.py
+++ b/modelon/impact/client/entities/workspace.py
@@ -731,11 +731,8 @@ class Workspace(WorkspaceInterface):
         custom_function = self._sal.custom_function.custom_function_get(
             self._workspace_id, name
         )
-        return CustomFunction(
-            self._workspace_id,
-            custom_function["name"],
-            custom_function["parameters"],
-            self._sal,
+        return CustomFunction.from_response_dict(
+            self._workspace_id, custom_function, self._sal
         )
 
     def get_custom_functions(self) -> List[CustomFunction]:
@@ -753,13 +750,8 @@ class Workspace(WorkspaceInterface):
             self._workspace_id
         )
         return [
-            CustomFunction(
-                self._workspace_id,
-                custom_function["name"],
-                custom_function["parameters"],
-                self._sal,
-            )
-            for custom_function in custom_functions["data"]["items"]
+            CustomFunction.from_response_dict(self._workspace_id, cf, self._sal)
+            for cf in custom_functions["data"]["items"]
         ]
 
     def delete(self) -> None:

--- a/modelon/impact/client/experiment_definition/expansion.py
+++ b/modelon/impact/client/experiment_definition/expansion.py
@@ -111,3 +111,15 @@ class Sobol(ExpansionAlgorithm):
 
     def get_parameters_as_dict(self) -> Optional[Dict[str, Any]]:
         return asdict(self)
+
+
+def expansion_from_dict(
+    algorithm: str, parameters: Dict[str, Any]
+) -> ExpansionAlgorithm:
+    if algorithm == "SOBOL":
+        return Sobol(samples=parameters["samples"])
+    elif algorithm == "LATINHYPERCUBE":
+        return LatinHypercube(
+            samples=parameters["samples"], seed=parameters.get("seed")
+        )
+    return FullFactorial()

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from modelon.impact.client.entities._initialize_from import _resolve_initialize_from
 from modelon.impact.client.entities.interfaces.case import CaseInterface
 from modelon.impact.client.entities.interfaces.experiment import ExperimentInterface
 from modelon.impact.client.entities.interfaces.external_result import (
@@ -47,6 +48,7 @@ if TYPE_CHECKING:
         SimulationOptions,
         SolverOptions,
     )
+    from modelon.impact.client.sal.service import Service
 
     CaseOrExperimentOrExternalResult = Union[Case, Experiment, ExternalResult]
     RuntimeOptionsOrDict = Union[RuntimeOptions, Dict[str, Any]]
@@ -55,6 +57,37 @@ if TYPE_CHECKING:
     CompilerOptionsOrDict = Union[CompilerOptions, Dict[str, Any]]
 
 logger = logging.getLogger(__name__)
+
+
+def _build_simple_modelica_experiment_definition(
+    model: "Model",
+    base: Dict[str, Any],
+    custom_function: "CustomFunction",
+    workspace_id: str,
+    sal: "Service",
+) -> "SimpleModelicaExperimentDefinition":
+    initialize_from = _resolve_initialize_from(
+        workspace_id, sal, base.get("modifiers", {})
+    )
+
+    modelica = base["model"]["modelica"]
+    analysis = base["analysis"]
+    definition = SimpleModelicaExperimentDefinition(
+        model=model,
+        custom_function=custom_function,
+        compiler_options=modelica.get("compilerOptions", {}),
+        fmi_target=modelica.get("fmiTarget", "me"),
+        fmi_version=modelica.get("fmiVersion", "2.0"),
+        platform=modelica.get("platform", "auto"),
+        compiler_log_level=modelica.get("compilerLogLevel", "warning"),
+        runtime_options=modelica.get("runtimeOptions", {}),
+        solver_options=analysis.get("solverOptions", {}),
+        simulation_options=analysis.get("simulationOptions", {}),
+        simulation_log_level=analysis.get("simulationLogLevel", "WARNING"),
+    )
+    if initialize_from is not None:
+        definition = definition.with_initialize_from(initialize_from)
+    return definition
 
 
 class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
@@ -156,31 +189,6 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
         self._variable_modifiers: Dict[str, Modifier] = {}
         self._extensions: List[SimpleExperimentExtension] = []
         self._expansion: ExpansionAlgorithm = FullFactorial()
-
-    @classmethod
-    def from_experiment_base_dict(
-        cls,
-        model: Model,
-        base: Dict[str, Any],
-        custom_function: CustomFunction,
-        initialize_from: Optional[CaseOrExperimentOrExternalResult] = None,
-    ) -> SimpleModelicaExperimentDefinition:
-        modelica = base["model"]["modelica"]
-        analysis = base["analysis"]
-        return cls(
-            model=model,
-            custom_function=custom_function,
-            compiler_options=modelica.get("compilerOptions", {}),
-            fmi_target=modelica.get("fmiTarget", "me"),
-            fmi_version=modelica.get("fmiVersion", "2.0"),
-            platform=modelica.get("platform", "auto"),
-            compiler_log_level=modelica.get("compilerLogLevel", "warning"),
-            runtime_options=modelica.get("runtimeOptions", {}),
-            solver_options=analysis.get("solverOptions", {}),
-            simulation_options=analysis.get("simulationOptions", {}),
-            simulation_log_level=analysis.get("simulationLogLevel", "WARNING"),
-            initialize_from=initialize_from,
-        )
 
     @property
     def modifiers(self) -> Dict[str, Any]:

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -157,6 +157,31 @@ class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):
         self._extensions: List[SimpleExperimentExtension] = []
         self._expansion: ExpansionAlgorithm = FullFactorial()
 
+    @classmethod
+    def from_experiment_base_dict(
+        cls,
+        model: Model,
+        base: Dict[str, Any],
+        custom_function: CustomFunction,
+        initialize_from: Optional[CaseOrExperimentOrExternalResult] = None,
+    ) -> SimpleModelicaExperimentDefinition:
+        modelica = base["model"]["modelica"]
+        analysis = base["analysis"]
+        return cls(
+            model=model,
+            custom_function=custom_function,
+            compiler_options=modelica.get("compilerOptions", {}),
+            fmi_target=modelica.get("fmiTarget", "me"),
+            fmi_version=modelica.get("fmiVersion", "2.0"),
+            platform=modelica.get("platform", "auto"),
+            compiler_log_level=modelica.get("compilerLogLevel", "warning"),
+            runtime_options=modelica.get("runtimeOptions", {}),
+            solver_options=analysis.get("solverOptions", {}),
+            simulation_options=analysis.get("simulationOptions", {}),
+            simulation_log_level=analysis.get("simulationLogLevel", "WARNING"),
+            initialize_from=initialize_from,
+        )
+
     @property
     def modifiers(self) -> Dict[str, Any]:
         """Returns the variable modifiers dict."""

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -72,7 +72,7 @@ def _build_simple_modelica_experiment_definition(
 
     modelica = base["model"]["modelica"]
     analysis = base["analysis"]
-    definition = SimpleModelicaExperimentDefinition(
+    return SimpleModelicaExperimentDefinition(
         model=model,
         custom_function=custom_function,
         compiler_options=modelica.get("compilerOptions", {}),
@@ -84,10 +84,8 @@ def _build_simple_modelica_experiment_definition(
         solver_options=analysis.get("solverOptions", {}),
         simulation_options=analysis.get("simulationOptions", {}),
         simulation_log_level=analysis.get("simulationLogLevel", "WARNING"),
+        initialize_from=initialize_from,
     )
-    if initialize_from is not None:
-        definition = definition.with_initialize_from(initialize_from)
-    return definition
 
 
 class SimpleModelicaExperimentDefinition(BaseExperimentDefinition):

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -18,6 +18,7 @@ from modelon.impact.client.experiment_definition.asserts import (
 from modelon.impact.client.experiment_definition.expansion import (
     ExpansionAlgorithm,
     FullFactorial,
+    expansion_from_dict,
 )
 from modelon.impact.client.experiment_definition.extension import (
     SimpleExperimentExtension,
@@ -30,6 +31,7 @@ from modelon.impact.client.experiment_definition.modifiers import (
     ensure_as_modifier,
     modifiers_to_dict,
 )
+from modelon.impact.client.experiment_definition.operators import get_operator_from_dict
 from modelon.impact.client.experiment_definition.util import (
     case_to_identifier_dict,
     custom_function_parameters_to_dict,
@@ -72,19 +74,31 @@ def _build_simple_modelica_experiment_definition(
 
     modelica = base["model"]["modelica"]
     analysis = base["analysis"]
-    return SimpleModelicaExperimentDefinition(
-        model=model,
-        custom_function=custom_function,
-        compiler_options=modelica.get("compilerOptions", {}),
-        fmi_target=modelica.get("fmiTarget", "me"),
-        fmi_version=modelica.get("fmiVersion", "2.0"),
-        platform=modelica.get("platform", "auto"),
-        compiler_log_level=modelica.get("compilerLogLevel", "warning"),
-        runtime_options=modelica.get("runtimeOptions", {}),
-        solver_options=analysis.get("solverOptions", {}),
-        simulation_options=analysis.get("simulationOptions", {}),
-        simulation_log_level=analysis.get("simulationLogLevel", "WARNING"),
-        initialize_from=initialize_from,
+    variable_modifiers = {
+        mod["name"]: get_operator_from_dict(mod)
+        for mod in base.get("modifiers", {}).get("variables", [])
+    }
+    expansion_dict = base.get("expansion", {})
+    expansion = expansion_from_dict(
+        expansion_dict.get("algorithm", ""), expansion_dict.get("parameters", {})
+    )
+    return (
+        SimpleModelicaExperimentDefinition(
+            model=model,
+            custom_function=custom_function,
+            compiler_options=modelica.get("compilerOptions", {}),
+            fmi_target=modelica.get("fmiTarget", "me"),
+            fmi_version=modelica.get("fmiVersion", "2.0"),
+            platform=modelica.get("platform", "auto"),
+            compiler_log_level=modelica.get("compilerLogLevel", "warning"),
+            runtime_options=modelica.get("runtimeOptions", {}),
+            solver_options=analysis.get("solverOptions", {}),
+            simulation_options=analysis.get("simulationOptions", {}),
+            simulation_log_level=analysis.get("simulationLogLevel", "WARNING"),
+            initialize_from=initialize_from,
+        )
+        .with_modifiers(variable_modifiers)
+        .with_expansion(expansion)
     )
 
 

--- a/modelon/impact/client/experiment_definition/operators.py
+++ b/modelon/impact/client/experiment_definition/operators.py
@@ -287,8 +287,8 @@ class Normal(Operator):
         return Normal(
             mean=data["mean"],
             variance=data["variance"],
-            start=data["start"],
-            end=data["end"],
+            start=data.get("start"),
+            end=data.get("end"),
         )
 
 


### PR DESCRIPTION
This MR refactors the code to have factory classmethods for building CustomFunction and SimpleModelicaExperimentDefinition from API response dicts as discussed in https://github.com/modelon-community/impact-client-python/pull/342#discussion_r3371476200