### PR TITLE
fix: keep modifiers when fetching experiment definitions for a model

### DIFF
--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -10,10 +10,20 @@ from modelon.impact.client.entities.custom_function import CustomFunction
 from modelon.impact.client.entities.interfaces.model import ModelInterface
 from modelon.impact.client.entities.model_executable import ModelExecutable
 from modelon.impact.client.entities.project import Project
+from modelon.impact.client.experiment_definition.expansion import (
+    ExpansionAlgorithm,
+    FullFactorial,
+    LatinHypercube,
+    Sobol,
+)
 from modelon.impact.client.experiment_definition.model_based import (
     SimpleModelicaExperimentDefinition,
 )
 from modelon.impact.client.experiment_definition.modifiers import Enumeration
+from modelon.impact.client.experiment_definition.operators import (
+    get_operator_from_dict,
+    get_operator_from_expression,
+)
 from modelon.impact.client.operations.fmu_import import FMUImportOperation
 from modelon.impact.client.operations.model_executable import (
     CachedModelExecutableOperation,
@@ -74,6 +84,41 @@ def to_domain_parameter_value(
         if param_data.get("dataType", "") == "ENUMERATION"
         else param_data["value"]
     )
+
+
+def _variable_modifiers_from_definition(
+    modifiers_data: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Returns the variable modifiers of a stored experiment definition.
+
+    Variables are given either as operator dictionaries (experiment schema,
+    e.g. ``{"kind": "value", ...}``) or as textual expressions
+    (``{"name": ..., "expression": ...}``).
+
+    """
+    modifiers: Dict[str, Any] = {}
+    for variable in modifiers_data.get("variables") or []:
+        if "kind" in variable:
+            modifiers[variable["name"]] = get_operator_from_dict(variable)
+        elif variable.get("expression") not in (None, ""):
+            modifiers[variable["name"]] = get_operator_from_expression(
+                str(variable["expression"])
+            )
+    return modifiers
+
+
+def _expansion_algorithm_from_definition(
+    expansion_data: Dict[str, Any]
+) -> ExpansionAlgorithm:
+    algorithm = expansion_data.get("algorithm")
+    parameters = expansion_data.get("parameters", {})
+    if algorithm == "SOBOL":
+        return Sobol(samples=parameters["samples"])
+    elif algorithm == "LATINHYPERCUBE":
+        return LatinHypercube(
+            samples=parameters["samples"], seed=parameters.get("seed")
+        )
+    return FullFactorial()
 
 
 def _assert_valid_compilation_options(
@@ -237,6 +282,34 @@ class Model(ModelInterface):
             ModelExecutable.from_operation,
         )
 
+    def _get_definition_initialize_from(
+        self, modifiers_data: Dict[str, Any]
+    ) -> Optional[CaseOrExperimentOrExternalResult]:
+        # Imported here to avoid circular imports:
+        from modelon.impact.client.entities.case import Case
+        from modelon.impact.client.entities.experiment import Experiment
+        from modelon.impact.client.entities.external_result import ExternalResult
+
+        experiment_id = modifiers_data.get("initializeFrom")
+        # "latest" is a sentinel used by the Impact UI for the latest result in
+        # the editor session and cannot be resolved to an experiment here.
+        if experiment_id and experiment_id != "latest":
+            resp = self._sal.workspace.experiment_get(self._workspace_id, experiment_id)
+            return Experiment(self._workspace_id, resp["id"], self._sal, resp)
+        case_reference = modifiers_data.get("initializeFromCase")
+        if case_reference:
+            experiment_id = case_reference["experimentId"]
+            case_data = self._sal.experiment.case_get(
+                self._workspace_id, experiment_id, case_reference["caseId"]
+            )
+            return Case(
+                case_data["id"], self._workspace_id, experiment_id, self._sal, case_data
+            )
+        external_result_id = modifiers_data.get("initializeFromExternalResult")
+        if external_result_id:
+            return ExternalResult(result_id=external_result_id, service=self._sal)
+        return None
+
     @Experimental
     def get_experiment_definitions(
         self,
@@ -251,6 +324,7 @@ class Model(ModelInterface):
             base = item["experiment"]["base"]
             modelica = base["model"]["modelica"]
             analysis = base["analysis"]
+            modifiers_data = base.get("modifiers", {})
 
             custom_function_meta = self._sal.custom_function.custom_function_get(
                 self._workspace_id, analysis["type"]
@@ -286,7 +360,16 @@ class Model(ModelInterface):
                     analysis.get("simulationOptions", {}), custom_function.name
                 ),
                 simulation_log_level=analysis.get("simulationLogLevel", "WARNING"),
+                initialize_from=self._get_definition_initialize_from(modifiers_data),
             )
+            variable_modifiers = _variable_modifiers_from_definition(modifiers_data)
+            if variable_modifiers:
+                definition = definition.with_modifiers(variable_modifiers)
+            expansion_data = base.get("expansion")
+            if expansion_data:
+                definition = definition.with_expansion(
+                    _expansion_algorithm_from_definition(expansion_data)
+                )
             meta = item["metadata"]
             entries.append(
                 ExperimentDefinitionEntry(

--- a/modelon/impact/client/experiment_definition/operators.py
+++ b/modelon/impact/client/experiment_definition/operators.py
@@ -1,6 +1,7 @@
 """This module contains operators for parametrizing batch runs."""
 from __future__ import annotations
 
+import re
 from abc import abstractmethod
 from dataclasses import dataclass
 from typing import Any, Optional, Union
@@ -109,6 +110,10 @@ class Choices(Operator):
 
             if used_data_type == DataType.REAL and value_type == DataType.INTEGER:
                 pass  # Integer can be assigned to real, do nothing
+            elif (
+                used_data_type == DataType.ENUMERATION and value_type == DataType.STRING
+            ):
+                pass  # Enumeration literals are given as strings, do nothing
             elif used_data_type != value_type:
                 if given_data_type:
                     raise ValueError(
@@ -313,3 +318,66 @@ def get_operator_from_dict(
         else:
             return data["value"]
     raise ValueError(f"Unsupported operator kind: {kind}!")
+
+
+_OPERATOR_EXPRESSION = re.compile(r"^(range|choices|uniform|normal|beta)\((.*)\)$")
+
+
+def _scalar_from_expression(
+    expression: str,
+) -> Union[Enumeration, int, float, bool, str]:
+    expression = expression.strip()
+    try:
+        return int(expression)
+    except ValueError:
+        pass
+    try:
+        return float(expression)
+    except ValueError:
+        pass
+    if expression in ("true", "false"):
+        return expression == "true"
+    if expression.startswith('"'):
+        return expression.replace('"', "")
+    if "loadResource" in expression:
+        return expression
+    if "." in expression:
+        return Enumeration(expression)
+    return expression
+
+
+def get_operator_from_expression(
+    expression: str,
+) -> Union[Range, Choices, Uniform, Beta, Normal, Enumeration, int, float, bool, str]:
+    """Returns a modifier value from a textual modifier expression as stored in
+    experiment definitions, e.g. ``"range(0.1, 0.5, 3)"`` or ``"1.5"``."""
+    expression = expression.strip()
+    match = _OPERATOR_EXPRESSION.match(expression)
+    if not match:
+        return _scalar_from_expression(expression)
+    kind, argument_blob = match.groups()
+    arguments = [arg.strip() for arg in argument_blob.split(",") if arg.strip()]
+    if kind == "range" and len(arguments) == 3:
+        return Range(float(arguments[0]), float(arguments[1]), int(arguments[2]))
+    if kind == "choices" and arguments:
+        values = [_scalar_from_expression(argument) for argument in arguments]
+        scalars: list[Scalar] = [
+            value.value if isinstance(value, Enumeration) else value for value in values
+        ]
+        if any(isinstance(value, Enumeration) for value in values):
+            return Choices(*scalars, data_type=DataType.ENUMERATION)
+        return Choices(*scalars)
+    if kind == "uniform" and len(arguments) == 2:
+        return Uniform(float(arguments[0]), float(arguments[1]))
+    if kind == "normal" and len(arguments) == 2:
+        return Normal(float(arguments[0]), float(arguments[1]))
+    if kind == "normal" and len(arguments) == 4:
+        return Normal(
+            float(arguments[0]),
+            float(arguments[1]),
+            float(arguments[2]),
+            float(arguments[3]),
+        )
+    if kind == "beta" and len(arguments) == 2:
+        return Beta(float(arguments[0]), float(arguments[1]))
+    raise ValueError(f"Unsupported modifier expression: {expression}!")

--- a/tests/impact/client/entities/test_model.py
+++ b/tests/impact/client/entities/test_model.py
@@ -141,3 +141,147 @@ class TestModel:
         model = package.import_fmu(fmu_path, expected_fmu_class_path).wait()
         assert isinstance(model, Model)
         assert model.name == expected_fmu_class_path
+
+
+def _experiment_definition_item(modifiers, definition_id="exp_def_1"):
+    return {
+        "id": definition_id,
+        "experiment": {
+            "base": {
+                "model": {"modelica": {"className": "Test.PID"}},
+                "modifiers": modifiers,
+                "analysis": {
+                    "type": "dynamic",
+                    "parameters": [],
+                    "simulationOptions": {"ncp": 500},
+                    "solverOptions": {},
+                    "simulationLogLevel": "WARNING",
+                },
+            },
+        },
+        "metadata": {
+            "name": "My definition",
+            "modelName": "Test.PID",
+            "projectId": IDs.PROJECT_ID_PRIMARY,
+            "created": "2026-06-08T12:00:00Z",
+            "lastModified": "2026-06-08T12:00:00Z",
+            "isDefault": True,
+            "isReadOnly": False,
+        },
+    }
+
+
+@pytest.mark.experimental
+class TestGetExperimentDefinitions:
+    def _get_entries(self, model, modifiers):
+        model.service.workspace.experiment_definitions_get.return_value = {
+            "data": {"items": [_experiment_definition_item(modifiers)]}
+        }
+        model.service.custom_function.custom_function_get.return_value = {
+            "name": "dynamic",
+            "parameters": [],
+        }
+        model.service.workspace.experiment_get.return_value = {
+            "id": IDs.EXPERIMENT_ID_PRIMARY
+        }
+        return model.entity.get_experiment_definitions()
+
+    def test_definition_keeps_expression_variable_modifiers(self, model):
+        entries = self._get_entries(
+            model,
+            {
+                "initializeFrom": "",
+                "variables": [
+                    {"name": "driveAngle", "expression": "1.65806278939461138713"},
+                    {"name": "PI.k", "expression": "range(10, 100, 3)"},
+                ],
+            },
+        )
+        definition_dict = entries[0].definition.to_dict()
+        modifiers = definition_dict["experiment"]["base"]["modifiers"]
+        assert modifiers["variables"] == [
+            {
+                "kind": "value",
+                "name": "driveAngle",
+                "value": pytest.approx(1.65806278939461138713),
+                "dataType": "REAL",
+            },
+            {
+                "kind": "range",
+                "name": "PI.k",
+                "start": 10.0,
+                "end": 100.0,
+                "steps": 3,
+            },
+        ]
+        assert "initializeFrom" not in modifiers
+        model.service.workspace.experiment_get.assert_not_called()
+
+    def test_definition_keeps_operator_dict_variable_modifiers(self, model):
+        entries = self._get_entries(
+            model,
+            {
+                "variables": [
+                    {
+                        "kind": "value",
+                        "name": "driveAngle",
+                        "value": 1.65806278939461138713,
+                        "dataType": "REAL",
+                    },
+                    {
+                        "kind": "range",
+                        "name": "PI.k",
+                        "start": 10.0,
+                        "end": 100.0,
+                        "steps": 3,
+                    },
+                ],
+            },
+        )
+        definition = entries[0].definition
+        assert set(definition.modifiers) == {"driveAngle", "PI.k"}
+        variables = definition.to_dict()["experiment"]["base"]["modifiers"]["variables"]
+        assert variables == [
+            {
+                "kind": "value",
+                "name": "driveAngle",
+                "value": pytest.approx(1.65806278939461138713),
+                "dataType": "REAL",
+            },
+            {
+                "kind": "range",
+                "name": "PI.k",
+                "start": 10.0,
+                "end": 100.0,
+                "steps": 3,
+            },
+        ]
+
+    def test_definition_keeps_initialize_from(self, model):
+        entries = self._get_entries(
+            model,
+            {"initializeFrom": IDs.EXPERIMENT_ID_PRIMARY, "variables": []},
+        )
+        definition = entries[0].definition
+        model.service.workspace.experiment_get.assert_called_once_with(
+            IDs.WORKSPACE_ID_PRIMARY, IDs.EXPERIMENT_ID_PRIMARY
+        )
+        definition_dict = definition.to_dict()
+        modifiers = definition_dict["experiment"]["base"]["modifiers"]
+        assert modifiers["initializeFrom"] == IDs.EXPERIMENT_ID_PRIMARY
+
+    def test_definition_skips_latest_initialize_from(self, model):
+        entries = self._get_entries(
+            model,
+            {"initializeFrom": "latest", "variables": []},
+        )
+        definition_dict = entries[0].definition.to_dict()
+        assert (
+            "initializeFrom" not in definition_dict["experiment"]["base"]["modifiers"]
+        )
+        model.service.workspace.experiment_get.assert_not_called()
+
+    def test_definition_without_modifiers(self, model):
+        entries = self._get_entries(model, {})
+        definition_dict = entries[0].definition.to_dict()
+        assert definition_dict["experiment"]["base"]["modifiers"] == {"variables": []}

--- a/tests/impact/client/test_experiment_definition.py
+++ b/tests/impact/client/test_experiment_definition.py
@@ -19,6 +19,9 @@ from modelon.impact.client import (
 )
 from modelon.impact.client.entities.result import Result
 from modelon.impact.client.experiment_definition.modifiers import DataType
+from modelon.impact.client.experiment_definition.operators import (
+    get_operator_from_expression,
+)
 from tests.impact.client.helpers import (
     IDs,
     create_case_entity,
@@ -1589,3 +1592,78 @@ class TestSimpleModelicaExperimentDefinition:
                 "dataType": "INTEGER",
             },
         ]
+
+
+class TestGetOperatorFromExpression:
+    @pytest.mark.parametrize(
+        "expression, expected",
+        [
+            ("1.65806278939461138713", 1.65806278939461138713),
+            ("2", 2),
+            ("true", True),
+            ("false", False),
+            ('"file.mat"', "file.mat"),
+        ],
+    )
+    def test_scalar_expression(self, expression, expected):
+        assert get_operator_from_expression(expression) == expected
+
+    def test_real_expression_is_float(self):
+        assert isinstance(get_operator_from_expression("1.5"), float)
+
+    def test_integer_expression_is_int(self):
+        assert isinstance(get_operator_from_expression("2"), int)
+
+    def test_enumeration_expression(self):
+        value = get_operator_from_expression("Modelica.Blocks.Types.Init.SteadyState")
+        assert isinstance(value, Enumeration)
+        assert value.value == "Modelica.Blocks.Types.Init.SteadyState"
+
+    def test_load_resource_expression_stays_string(self):
+        expression = 'loadResource("modelica://Lib/data.mat")'
+        assert get_operator_from_expression(expression) == expression
+
+    def test_range_expression(self):
+        value = get_operator_from_expression("range(0.1, 0.5, 3)")
+        assert value == Range(0.1, 0.5, 3)
+
+    def test_choices_expression(self):
+        value = get_operator_from_expression("choices(1, 2.5, 3)")
+        assert isinstance(value, Choices)
+        assert value.values == (1, 2.5, 3)
+
+    def test_choices_enumeration_expression(self):
+        value = get_operator_from_expression("choices(Lib.E.a, Lib.E.b)")
+        assert isinstance(value, Choices)
+        assert value.data_type == DataType.ENUMERATION
+        assert value.values == ("Lib.E.a", "Lib.E.b")
+
+    def test_uniform_expression(self):
+        assert get_operator_from_expression("uniform(0.1, 0.5)") == Uniform(0.1, 0.5)
+
+    def test_normal_expression(self):
+        assert get_operator_from_expression("normal(0.1, 0.5)") == Normal(0.1, 0.5)
+
+    def test_truncated_normal_expression(self):
+        value = get_operator_from_expression("normal(0.1, 0.5, 0.0, 1.0)")
+        assert value == Normal(0.1, 0.5, 0.0, 1.0)
+
+    def test_beta_expression(self):
+        assert get_operator_from_expression("beta(0.1, 0.5)") == Beta(0.1, 0.5)
+
+    def test_invalid_operator_expression_raises(self):
+        with pytest.raises(ValueError):
+            get_operator_from_expression("range(0.1, 0.5)")
+
+
+class TestChoicesEnumeration:
+    def test_choices_with_enumeration_data_type(self):
+        choices = Choices("Lib.E.a", "Lib.E.b", data_type=DataType.ENUMERATION)
+        assert choices.data_type == DataType.ENUMERATION
+
+    def test_choices_from_dict_with_enumeration_data_type(self):
+        choices = Choices.from_dict(
+            {"values": ["Lib.E.a", "Lib.E.b"], "dataType": "ENUMERATION"}
+        )
+        assert choices.data_type == DataType.ENUMERATION
+        assert choices.values == ("Lib.E.a", "Lib.E.b")


### PR DESCRIPTION
## Problem

`Model.get_experiment_definitions()` (added in #d4b80c7 / 4.13.0) reconstructs a `SimpleModelicaExperimentDefinition` from each stored definition item but never reads `base.modifiers`. As a result the returned `entry.definition` always has empty variable modifiers, no initialize-from result, and the default expansion algorithm — and `workspace.execute(entry.definition)` serializes `"modifiers": {"variables": []}`, silently running the experiment without any of its saved modifiers.

Example: a definition saved with

```json
"modifiers": {"initializeFrom": "", "variables": [{"name": "driveAngle", "expression": "1.65806278939461138713"}]}
```

executes with `driveAngle` at its model default instead of the saved value.

## Fix

`get_experiment_definitions` now restores the stored modifiers, mirroring what `Experiment.get_definition()` does for executed experiments:

- **Variable modifiers** are populated from `base.modifiers.variables`. Both shapes are supported:
  - experiment-schema operator dictionaries (`{"kind": "value"|"range"|..., ...}`), parsed with the existing `get_operator_from_dict`;
  - textual expressions (`{"name": ..., "expression": "1.65"|"range(0.1,0.5,3)"|...}`) as saved by the Impact UI, parsed with a new `get_operator_from_expression` helper that mirrors the UI's expression-to-modifier conversion (`modifierV2ToV3`).
- **Initialize-from** (`initializeFrom`, `initializeFromCase`, `initializeFromExternalResult`) is resolved to the corresponding entity. The empty string and the UI session sentinel `"latest"` are skipped since they cannot be resolved outside the editor.
- **Expansion algorithm** is restored from `base.expansion` when present.
- **`Choices` with enumeration values**: `Choices(*values, data_type=DataType.ENUMERATION)` previously raised `ValueError` because enumeration literals are plain strings. This also made `Choices.from_dict` (and therefore `Experiment.get_definition()`) fail for experiments using enumeration choices. String values are now accepted when the data type is ENUMERATION.

## Not covered

Saved definition `extensions` are still not reconstructed (out of scope for this fix; the entry-level reconstruction never handled them and the UI does not store them in definitions).

## Testing

- New unit tests for `get_experiment_definitions` covering both modifier shapes, initialize-from resolution, the `""`/`"latest"` guards, and definitions without modifiers (`tests/impact/client/entities/test_model.py`).
- New unit tests for `get_operator_from_expression` (scalars, enumerations, quoted strings, `loadResource`, all operator kinds) and for ENUMERATION `Choices` (`tests/impact/client/test_experiment_definition.py`).
- Full suite: 329 passed; the only failure (`test_get_client_url_default`) is a pre-existing environment-dependent test unrelated to this change.
- Lint (black, flake8, mypy, isort, docformatter, pylint spelling) is clean.