### PR TITLE
feat: add get_extends method to Model entity

### DIFF
--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -50,6 +50,11 @@ class ModelParameter:
 
 
 @dataclass
+class ExtendsClause:
+    class_name: str
+
+
+@dataclass
 class ExperimentDefinitionEntry:
     id: str
     name: str
@@ -511,6 +516,23 @@ class Model(ModelInterface):
         """
         modeling_sal = self._require_modeling_session("get_source")
         return modeling_sal().get_model_source(self._class_name)
+
+    @Experimental
+    def get_extends_clauses(self) -> List[ExtendsClause]:
+        """Returns the extends clauses for this model's class.
+
+        Example::
+
+            with workspace.new_modeling_session() as session:
+                model = session.get_model("LibA.Model")
+                extends = model.get_extends_clauses()
+
+        """
+        modeling_sal = self._require_modeling_session("get_extends_clauses")
+        return [
+            ExtendsClause(class_name=name)
+            for name in modeling_sal().get_extends_clauses(self._class_name)
+        ]
 
     @classmethod
     def from_operation(cls, operation: BaseOperation[Model], **kwargs: Any) -> Model:

--- a/modelon/impact/client/sal/modeling.py
+++ b/modelon/impact/client/sal/modeling.py
@@ -21,6 +21,9 @@ class ModelingService:
             "impact/getModelParameters", modelica_path
         )
 
+    def get_extends_clauses(self, class_path: str) -> List[str]:
+        return self._ws_client.get_json_response("impact/getExtends", class_path)
+
     def get_model_source(self, class_path: str) -> str:
         params = {"className": class_path}
         return self._ws_client.get_json_response("impact/getSource", params)


### PR DESCRIPTION
**Description**
This PR adds an API to get all the models a given class extends.

**How to test**
import os
os.environ["IMPACT_PYTHON_CLIENT_EXPERIMENTAL"] ="true"
from modelon.impact.client import Client, ProjectType

client = Client(url="https://impact.modelon.cloud/", interactive=True)
model_path = "Unnamed.ex1_1_1"
ws = client.get_workspace("opo")
with ws.new_modeling_session() as session:
    model = session.get_model(model_path)
    print(model.get_extends())
