### PR TITLE
Add support for creating a default Experiment definition

### DIFF
--- a/modelon/impact/client/entities/_initialize_from.py
+++ b/modelon/impact/client/entities/_initialize_from.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from modelon.impact.client.entities.external_result import ExternalResult
@@ -9,14 +10,48 @@ if TYPE_CHECKING:
     from modelon.impact.client.entities.experiment import Experiment
     from modelon.impact.client.sal.service import Service
 
+logger = logging.getLogger(__name__)
+
+LATEST_EXPERIMENT = "latest"
+"""Symbolic 'initializeFrom' value denoting the most recently created experiment of the
+model."""
+
+
+def _get_latest_experiment(
+    workspace_id: str, sal: Service, class_path: Optional[str] = None
+) -> Optional[Experiment]:
+    from modelon.impact.client.entities.experiment import Experiment
+
+    experiments = sal.workspace.experiments_get(workspace_id, class_path=class_path)[
+        "data"
+    ]["items"]
+    if not experiments:
+        logger.warning(
+            "Could not resolve 'initializeFrom' value '%s': no experiments "
+            "exist for '%s' in workspace '%s'.",
+            LATEST_EXPERIMENT,
+            class_path,
+            workspace_id,
+        )
+        return None
+    latest = max(
+        experiments,
+        key=lambda item: item.get("meta_data", {}).get("created_epoch", 0),
+    )
+    return Experiment(workspace_id, latest["id"], sal, latest)
+
 
 def _resolve_initialize_from(
     workspace_id: str,
     sal: Service,
     modifiers: Dict[str, Any],
+    class_path: Optional[str] = None,
 ) -> Optional[Union[Case, Experiment, ExternalResult]]:
     if "initializeFrom" in modifiers:
         from modelon.impact.client.entities.experiment import Experiment
+
+        if modifiers["initializeFrom"] == LATEST_EXPERIMENT:
+            return _get_latest_experiment(workspace_id, sal, class_path)
 
         resp = sal.workspace.experiment_get(workspace_id, modifiers["initializeFrom"])
         return Experiment(workspace_id, resp["id"], sal, resp)

--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -30,6 +30,7 @@ from modelon.impact.client.options import (
     SimulationOptions,
     SolverOptions,
 )
+from modelon.impact.client.sal.exceptions import HTTPError
 
 if TYPE_CHECKING:
     from modelon.impact.client.entities.case import Case
@@ -283,10 +284,19 @@ class Model(ModelInterface):
         resp = self._sal.workspace.experiment_definitions_get(
             self._workspace_id, self._class_name, extends=extends
         )
-        return [
-            self._experiment_definition_entry_from_item(item)
-            for item in resp["data"]["items"]
-        ]
+        entries = []
+        for item in resp["data"]["items"]:
+            try:
+                entries.append(self._experiment_definition_entry_from_item(item))
+            except HTTPError as err:
+                logger.warning(
+                    "Skipping experiment definition '%s' (id: %s) as it could "
+                    "not be resolved: %s",
+                    item.get("metadata", {}).get("name"),
+                    item.get("id"),
+                    err,
+                )
+        return entries
 
     @Experimental
     def create_default_experiment_definition(

--- a/modelon/impact/client/entities/model.py
+++ b/modelon/impact/client/entities/model.py
@@ -246,6 +246,34 @@ class Model(ModelInterface):
             ModelExecutable.from_operation,
         )
 
+    def _experiment_definition_entry_from_item(
+        self, item: Dict[str, Any]
+    ) -> ExperimentDefinitionEntry:
+        base = item["experiment"]["base"]
+        analysis = base["analysis"]
+        cf_meta = self._sal.custom_function.custom_function_get(
+            self._workspace_id, analysis["type"]
+        )
+        params = {p["name"]: p["value"] for p in analysis.get("parameters", [])}
+        custom_function = _build_custom_function(
+            self._workspace_id, cf_meta, self._sal
+        ).with_parameters(**params)
+        definition = _build_simple_modelica_experiment_definition(
+            self, base, custom_function, self._workspace_id, self._sal
+        )
+        meta = item["metadata"]
+        return ExperimentDefinitionEntry(
+            id=item["id"],
+            name=meta["name"],
+            model_name=meta["modelName"],
+            project_id=meta["projectId"],
+            created=meta["created"],
+            last_modified=meta["lastModified"],
+            is_default=meta["isDefault"],
+            is_read_only=meta["isReadOnly"],
+            definition=definition,
+        )
+
     @Experimental
     def get_experiment_definitions(
         self,
@@ -255,35 +283,61 @@ class Model(ModelInterface):
         resp = self._sal.workspace.experiment_definitions_get(
             self._workspace_id, self._class_name, extends=extends
         )
-        entries = []
-        for item in resp["data"]["items"]:
-            base = item["experiment"]["base"]
-            analysis = base["analysis"]
-            cf_meta = self._sal.custom_function.custom_function_get(
-                self._workspace_id, analysis["type"]
-            )
-            params = {p["name"]: p["value"] for p in analysis.get("parameters", [])}
-            custom_function = _build_custom_function(
-                self._workspace_id, cf_meta, self._sal
-            ).with_parameters(**params)
-            definition = _build_simple_modelica_experiment_definition(
-                self, base, custom_function, self._workspace_id, self._sal
-            )
-            meta = item["metadata"]
-            entries.append(
-                ExperimentDefinitionEntry(
-                    id=item["id"],
-                    name=meta["name"],
-                    model_name=meta["modelName"],
-                    project_id=meta["projectId"],
-                    created=meta["created"],
-                    last_modified=meta["lastModified"],
-                    is_default=meta["isDefault"],
-                    is_read_only=meta["isReadOnly"],
-                    definition=definition,
+        return [
+            self._experiment_definition_entry_from_item(item)
+            for item in resp["data"]["items"]
+        ]
+
+    @Experimental
+    def create_default_experiment_definition(
+        self,
+        custom_function: CustomFunction,
+        name: Optional[str] = None,
+        is_default: bool = False,
+    ) -> ExperimentDefinitionEntry:
+        """Creates and persists a default experiment definition for this model.
+
+        The definition is pre-populated with default parameter and option values
+        resolved from the custom function's signature, with the model's Modelica
+        experiment annotations (e.g. StartTime, StopTime, Tolerance) overriding
+        those defaults where applicable.
+
+        Args:
+            custom_function: The custom function to build the definition for.
+            name: Name for the new experiment definition. Default: None, which
+                means a placeholder name is used.
+            is_default: Whether to mark this experiment definition as the
+                default for the model. Default: False.
+
+        Example::
+
+            with workspace.new_modeling_session() as session:
+                model = session.get_model("LibA.Model")
+                dynamic = workspace.get_custom_function("dynamic")
+                entry = model.create_default_experiment_definition(
+                    dynamic, name="My experiment"
                 )
-            )
-        return entries
+                experiment = workspace.execute(entry.definition).wait()
+
+        """
+        modeling_sal = self._require_modeling_session(
+            "create_default_experiment_definition"
+        )
+        annotations = modeling_sal().get_experiment_annotations(self._class_name)
+        template = self._sal.workspace.experiment_definition_template_get(
+            self._workspace_id,
+            self._class_name,
+            custom_function_type=custom_function.name,
+            experiment_annotations=annotations,
+        )
+        resp = self._sal.project.experiment_definition_create(
+            self._project_id,
+            self._class_name,
+            name=name or template["data"]["metadata"]["name"],
+            experiment=template["data"]["experiment"],
+            is_default=is_default,
+        )
+        return self._experiment_definition_entry_from_item(resp["data"])
 
     def new_experiment_definition(
         self,

--- a/modelon/impact/client/experiment_definition/model_based.py
+++ b/modelon/impact/client/experiment_definition/model_based.py
@@ -69,7 +69,7 @@ def _build_simple_modelica_experiment_definition(
     sal: "Service",
 ) -> "SimpleModelicaExperimentDefinition":
     initialize_from = _resolve_initialize_from(
-        workspace_id, sal, base.get("modifiers", {})
+        workspace_id, sal, base.get("modifiers", {}), class_path=model.name
     )
 
     modelica = base["model"]["modelica"]

--- a/modelon/impact/client/sal/project.py
+++ b/modelon/impact/client/sal/project.py
@@ -45,6 +45,26 @@ class ProjectService:
         url = (self._base_uri / f"api/projects/{project_id}").resolve()
         self._http_client.put_json(url, body=project_data)
 
+    def experiment_definition_create(
+        self,
+        project_id: str,
+        model_path: str,
+        name: str,
+        experiment: Dict[str, Any],
+        is_default: bool = False,
+    ) -> Dict[str, Any]:
+        url = (
+            self._base_uri / f"api/projects/{project_id}/models/{model_path}/"
+            "experiment-definitions"
+        ).resolve()
+        body = {
+            "data": {
+                "metadata": {"name": name, "isDefault": is_default},
+                "experiment": experiment,
+            }
+        }
+        return self._http_client.post_json(url, body=body)
+
     def project_options_get(
         self, project_id: str, workspace_id: str, custom_function: str
     ) -> Dict[str, Any]:

--- a/modelon/impact/client/sal/workspace.py
+++ b/modelon/impact/client/sal/workspace.py
@@ -370,6 +370,26 @@ class WorkspaceService:
             url, headers={"Accept": self._experiment_schema}, params=params
         )
 
+    def experiment_definition_template_get(
+        self,
+        workspace_id: str,
+        model_name: str,
+        custom_function_type: Optional[str] = None,
+        experiment_annotations: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = (
+            self._base_uri / f"api/workspaces/{workspace_id}/models/{model_name}/"
+            "experiment-definition-template"
+        ).resolve()
+        custom_function = {"type": custom_function_type} if custom_function_type else {}
+        body = {
+            "data": {
+                "customFunction": custom_function,
+                "experimentAnnotations": experiment_annotations or {},
+            }
+        }
+        return self._http_client.post_json(url, body=body)
+
     def update_workspace(
         self, workspace_id: str, data: Dict[str, Any]
     ) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

This PR adds two new experimental methods to the `Model` entity and improves `initializeFrom` resolution:

- **`Model.create_default_experiment_definition()`** — creates and persists a default experiment definition for a model, pre-populated from the custom function's defaults with the model's experiment annotations overriding them where applicable. Backed by new service-layer calls for fetching an experiment definition template and creating a definition in a project.
- **Resolve `'latest'` as an `initializeFrom` value** — when an experiment definition uses `initializeFrom: "latest"`, it now resolves to the model's most recently created experiment, logging a warning and returning `None` if no experiments exist.

Additionally, `get_experiment_definitions()` now skips (with a warning) entries that fail to resolve due to HTTP errors instead of failing the whole call.

## Changes

- `modelon/impact/client/entities/model.py` — new  `create_default_experiment_definition()` methods; shared helper for building `ExperimentDefinitionEntry` items; graceful handling of unresolvable definitions.
- `modelon/impact/client/entities/_initialize_from.py` — support for the symbolic `"latest"` value, resolved to the most recently created experiment for the model's class path.
- `modelon/impact/client/sal/workspace.py` — new endpoint call to fetch an experiment definition template.
- `modelon/impact/client/sal/project.py` — new endpoint call to create an experiment definition in a project.

Both new `Model` methods are marked `@Experimental` and require an active modeling session.
