### PR TITLE
fix: send params objects to subscribeToWorkspace and getExtends

### DIFF
--- a/modelon/impact/client/sal/modeling.py
+++ b/modelon/impact/client/sal/modeling.py
@@ -22,7 +22,8 @@ class ModelingService:
         )
 
     def get_extends_clauses(self, class_path: str) -> List[str]:
-        return self._ws_client.get_json_response("impact/getExtends", class_path)
+        params = {"classPath": class_path}
+        return self._ws_client.get_json_response("impact/getExtends", params)
 
     def get_experiment_annotations(self, class_path: str) -> Dict[str, str]:
         params = {"className": class_path}

--- a/modelon/impact/client/sal/service.py
+++ b/modelon/impact/client/sal/service.py
@@ -89,7 +89,7 @@ class Service:
     def start_modeling_session(self, workspace_id: str) -> ModelingService:
         ws_client = SyncWebSocketClient(self._base_ws_uri, self._api_key)
         response = ws_client.get_json_response(
-            "impact/subscribeToWorkspace", workspace_id
+            "impact/subscribeToWorkspace", {"workspaceId": workspace_id}
         )
         if isinstance(response, dict) and not response.get("created"):
             raise FailedToStartModelingServer(


### PR DESCRIPTION
The server now takes a record instead of a bare string on these two RPCs, so the payload changes from "params": "abc" to "params": {"field": "abc"}, and a blank id is rejected at the boundary.

subscribeToWorkspace is the handshake in start_modeling_session, so without this every modeling session fails at its first call, not just the extends path. getExtends reaches users through Model.get_extends_clauses.